### PR TITLE
Import surface shell core for THOUGHT CLI

### DIFF
--- a/apps/thought/package.json
+++ b/apps/thought/package.json
@@ -19,6 +19,7 @@
     "ethers": "^6.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "surface-shell": "github:inshell-art/surface-shell#0.1.0",
     "vite": "^7.3.2"
   },
   "devDependencies": {

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -37,13 +37,6 @@ import {
   shouldShowPreviewWatermark,
   type PublicLaunchMode,
 } from "@inshell/shared";
-import {
-  parseSurfaceInput,
-  redactSurfaceInput,
-  shouldRecordSurfaceInput,
-  type SurfaceRedactionRule,
-} from "@inshell/surface-shell-core";
-
 import thoughtInstructions from "../THOUGHT.md?raw";
 import thoughtInstructionsUrl from "../THOUGHT.md?url";
 import colorFontRaw from "../colorFontJSON/colorfont.byToolv2.json?raw";
@@ -55,6 +48,12 @@ import {
   validateColorFontDataShape,
   type ColorFontDoc,
 } from "./color-font-doc";
+import {
+  createThoughtSurfaceShellAdapter,
+  redactThoughtShellInput,
+  shouldRecordThoughtShellInput,
+} from "./surfaceShell/thoughtDispatcherAdapter";
+import type { ThoughtShellState } from "./surfaceShell/thoughtShellState";
 import {
   appendThoughtWork,
   getLatestWork,
@@ -8569,26 +8568,8 @@ const appendCliEntry = (
   return entry;
 };
 
-const THOUGHT_CLI_SECRET_REDACTION_RULES: SurfaceRedactionRule[] = [
-  {
-    id: "direct-key",
-    tokens: ["key"],
-    allowRestValues: ["clear", "help"],
-  },
-  {
-    id: "config-key",
-    tokens: ["config", "key"],
-    allowRestValues: ["clear", "help"],
-  },
-  {
-    id: "config-direct-key",
-    tokens: ["config", "direct", "key"],
-    allowRestValues: ["clear", "help"],
-  },
-];
-
 const displayCliCommand = (command: string) => {
-  return redactSurfaceInput(command, THOUGHT_CLI_SECRET_REDACTION_RULES);
+  return redactThoughtShellInput(command);
 };
 
 const isMyBrainShellActive = () =>
@@ -8596,8 +8577,33 @@ const isMyBrainShellActive = () =>
 
 const currentCliShellPrompt = () => (isMyBrainShellActive() ? "my-brain>" : "thought>");
 
+const getThoughtSurfaceShellState = (): ThoughtShellState => ({
+  prompt: sessionState.prompt,
+  route: sessionState.mode,
+  routeConfigured: sessionState.routeConfigured,
+  provider: sessionState.mode === "direct" ? sessionState.direct.provider : ROUTE_COPY[sessionState.mode].provider,
+  model: getCurrentModelValue(),
+  apiKeyConfigured: sessionState.mode === "direct"
+    ? Boolean(getDirectApiKey())
+    : Boolean(sessionState.connect.apiKey.trim()),
+  localEndpoint: sessionState.local.endpoint,
+  localAvailable: sessionState.local.available,
+  openRouterLinked: Boolean(sessionState.connect.apiKey.trim()),
+  previewMode: readPreviewMode(),
+  previewProvider: cliPreviewProviderState(),
+  walletConnected: Boolean(walletState.address),
+  walletChainReady: walletState.chainId === THOUGHT_CHAIN_ID,
+  pathSelected: mintFlowData.pathId !== null,
+  pathAuthorized: mintFlowState === "authorized" || mintFlowState === "minting" || mintFlowState === "minted",
+  candidateReady: runState === "candidate_ready",
+  workReady: runState === "output_ready" || Boolean(currentOutputText),
+  myBrainWaiting: isMyBrainShellActive(),
+});
+
+const thoughtSurfaceShell = createThoughtSurfaceShellAdapter(getThoughtSurfaceShellState);
+
 const shouldRecordCliCommand = (command: string) => {
-  return shouldRecordSurfaceInput(command, THOUGHT_CLI_SECRET_REDACTION_RULES);
+  return shouldRecordThoughtShellInput(command);
 };
 
 const readStoredCliCommandHistory = () => {
@@ -12211,14 +12217,14 @@ const executeCliCommand = async (rawCommand: string) => {
   syncCliPanel();
 
   try {
-    const parsedCommand = parseSurfaceInput(command, { mode: "command-first" });
+    const parsedCommand = thoughtSurfaceShell.resolve(command);
     const rest = parsedCommand.rest;
-    const [second = ""] = rest.split(/\s+/, 1);
-    const lowerHead = parsedCommand.commandKey;
+    const [second = ""] = parsedCommand.args;
+    const lowerHead = parsedCommand.legacyHead;
     const lowerRest = rest.toLowerCase();
     cliSuggestionContext = "auto";
 
-    if (command === "?" || command === "--help" || lowerHead === "help") {
+    if (lowerHead === "help") {
       appendCliOutput(cliHelpLines(lowerRest));
       cliSuggestionContext = "help";
     } else if (lowerHead === "commands") {

--- a/apps/thought/src/surfaceShell/thoughtCommandTree.ts
+++ b/apps/thought/src/surfaceShell/thoughtCommandTree.ts
@@ -1,0 +1,407 @@
+import type { SurfaceCommandNode } from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+import type { ThoughtShellState } from "./thoughtShellState";
+import {
+  sideEffectContractRead,
+  sideEffectContractWrite,
+  sideEffectExternalModel,
+  sideEffectLocalWrite,
+  sideEffectNetwork,
+  sideEffectNone,
+  sideEffectRead,
+  sideEffectWallet,
+} from "./thoughtSideEffects";
+
+type ThoughtCommandNode = SurfaceCommandNode<ThoughtShellState>;
+
+const leaf = (
+  path: string[],
+  title: string,
+  options: Partial<ThoughtCommandNode> = {},
+): ThoughtCommandNode => ({
+  id: path.join("."),
+  path,
+  title,
+  sideEffect: sideEffectNone,
+  ...options,
+});
+
+const branch = (
+  path: string[],
+  title: string,
+  children: ThoughtCommandNode[],
+  options: Partial<ThoughtCommandNode> = {},
+): ThoughtCommandNode => ({
+  id: path.join("."),
+  path,
+  title,
+  children,
+  ...options,
+});
+
+const configLocal = branch(
+  ["config", "local"],
+  "local model route",
+  [
+    leaf(["config", "local", "detect"], "detect local Ollama", {
+      sideEffect: sideEffectNetwork("detect local Ollama endpoint"),
+    }),
+    leaf(["config", "local", "retry"], "retry local detection", {
+      sideEffect: sideEffectNetwork("retry local Ollama detection"),
+    }),
+    leaf(["config", "local", "endpoint"], "set local endpoint", {
+      sideEffect: sideEffectLocalWrite("store local model endpoint"),
+    }),
+    branch(
+      ["config", "local", "model"],
+      "local model",
+      [
+        leaf(["config", "local", "model", "list"], "list local models", {
+          sideEffect: sideEffectNetwork("list local models"),
+        }),
+      ],
+      {
+        sideEffect: sideEffectLocalWrite("select local model"),
+      },
+    ),
+  ],
+);
+
+const configConnect = branch(
+  ["config", "connect"],
+  "OpenRouter Connect route",
+  [
+    leaf(["config", "connect", "authorize"], "authorize OpenRouter Connect", {
+      sideEffect: sideEffectNetwork("open external OpenRouter authorization"),
+    }),
+    leaf(["config", "connect", "openrouter"], "authorize OpenRouter Connect", {
+      canonicalPath: ["config", "connect", "authorize"],
+      sideEffect: sideEffectNetwork("open external OpenRouter authorization"),
+    }),
+    leaf(["config", "connect", "disconnect"], "disconnect OpenRouter Connect", {
+      sideEffect: sideEffectLocalWrite("remove OpenRouter Connect session"),
+    }),
+    branch(
+      ["config", "connect", "model"],
+      "OpenRouter Connect model",
+      [
+        leaf(["config", "connect", "model", "list"], "list OpenRouter models", {
+          sideEffect: sideEffectNetwork("list OpenRouter models"),
+        }),
+      ],
+      {
+        sideEffect: sideEffectLocalWrite("select OpenRouter Connect model"),
+      },
+    ),
+  ],
+  {
+    aliases: ["connect"],
+  },
+);
+
+const configDirect = branch(
+  ["config", "direct"],
+  "direct API route",
+  [
+    branch(
+      ["config", "direct", "provider"],
+      "direct provider",
+      [leaf(["config", "direct", "provider", "list"], "list direct providers")],
+      {
+        sideEffect: sideEffectLocalWrite("select direct provider"),
+      },
+    ),
+    branch(
+      ["config", "direct", "key"],
+      "direct API key",
+      [leaf(["config", "direct", "key", "clear"], "clear direct API key")],
+      {
+        sideEffect: sideEffectLocalWrite("store direct API key locally"),
+      },
+    ),
+    branch(
+      ["config", "direct", "model"],
+      "direct model",
+      [
+        leaf(["config", "direct", "model", "list"], "list direct models", {
+          sideEffect: sideEffectNetwork("list direct provider models"),
+        }),
+      ],
+      {
+        sideEffect: sideEffectLocalWrite("select direct model"),
+      },
+    ),
+  ],
+);
+
+export const thoughtCommandTree: ThoughtCommandNode[] = [
+  leaf(["help"], "show help", {
+    aliases: ["?", "--help"],
+  }),
+  leaf(["commands"], "list commands"),
+  leaf(["current"], "show current state"),
+  leaf(["status"], "show current state", {
+    canonicalPath: ["current"],
+  }),
+  leaf(["clear"], "clear transcript", {
+    sideEffect: sideEffectLocalWrite("clear CLI transcript"),
+  }),
+  leaf(["reset"], "reset current work", {
+    sideEffect: sideEffectLocalWrite("clear current work state"),
+  }),
+  leaf(["gallery"], "open gallery", {
+    sideEffect: sideEffectRead("navigate to gallery"),
+  }),
+  branch(
+    ["config"],
+    "configure THOUGHT",
+    [
+      branch(
+        ["config", "route"],
+        "model route",
+        [
+          leaf(["config", "route", "local"], "use local route"),
+          leaf(["config", "route", "connect"], "use OpenRouter Connect route"),
+          leaf(["config", "route", "direct"], "use direct API route"),
+          leaf(["config", "route", "my-brain"], "use my-brain route", {
+            aliases: ["mybrain"],
+          }),
+        ],
+        {
+          sideEffect: sideEffectLocalWrite("select model route"),
+        },
+      ),
+      branch(
+        ["config", "preview"],
+        "preview policy",
+        [
+          leaf(["config", "preview", "auto"], "use auto preview"),
+          leaf(["config", "preview", "wallet"], "use wallet preview"),
+          leaf(["config", "preview", "off"], "disable preview"),
+        ],
+        {
+          sideEffect: sideEffectLocalWrite("set preview mode"),
+        },
+      ),
+      configLocal,
+      configConnect,
+      configDirect,
+      leaf(["config", "my-brain"], "use my-brain route", {
+        aliases: ["mybrain"],
+        renderHelp: () => ({
+          kind: "guidance",
+          title: "my-brain route",
+          body: "you become the model for one THOUGHT round.",
+          sections: [
+            {
+              title: "use",
+              lines: ["config my-brain", "prompt <text>", "run", "return <text>", "cancel"],
+            },
+          ],
+        }),
+        sideEffect: sideEffectLocalWrite("select my-brain route"),
+      }),
+    ],
+  ),
+  leaf(["mode"], "select model route", {
+    canonicalPath: ["config", "route"],
+    sideEffect: sideEffectLocalWrite("select model route"),
+  }),
+  leaf(["my-brain"], "use my-brain route", {
+    aliases: ["mybrain"],
+    canonicalPath: ["config", "my-brain"],
+    sideEffect: sideEffectLocalWrite("select my-brain route"),
+  }),
+  leaf(["connect"], "authorize OpenRouter Connect", {
+    canonicalPath: ["config", "connect", "authorize"],
+    sideEffect: sideEffectNetwork("open external OpenRouter authorization"),
+  }),
+  leaf(["disconnect"], "disconnect OpenRouter Connect", {
+    canonicalPath: ["config", "connect", "disconnect"],
+    sideEffect: sideEffectLocalWrite("remove OpenRouter Connect session"),
+  }),
+  leaf(["provider"], "select direct provider", {
+    canonicalPath: ["config", "direct", "provider"],
+    sideEffect: sideEffectLocalWrite("select direct provider"),
+  }),
+  leaf(["key"], "set direct API key", {
+    canonicalPath: ["config", "direct", "key"],
+    sideEffect: sideEffectLocalWrite("store direct API key locally"),
+  }),
+  leaf(["models"], "list models", {
+    canonicalPath: ["config", "direct", "model", "list"],
+    sideEffect: sideEffectNetwork("list models"),
+  }),
+  leaf(["model"], "select model", {
+    canonicalPath: ["config", "direct", "model"],
+    sideEffect: sideEffectLocalWrite("select model"),
+  }),
+  branch(
+    ["prompt"],
+    "prompt",
+    [leaf(["prompt", "clear"], "clear prompt")],
+    {
+      sideEffect: sideEffectLocalWrite("store prompt"),
+    },
+  ),
+  branch(
+    ["spec"],
+    "THOUGHT spec",
+    [leaf(["spec", "text"], "show THOUGHT spec text"), leaf(["spec", "show"], "show THOUGHT spec"), leaf(["spec", "cat"], "show THOUGHT spec")],
+  ),
+  branch(
+    ["THOUGHT.md"],
+    "THOUGHT.md",
+    [
+      leaf(["THOUGHT.md", "text"], "show THOUGHT.md text"),
+      leaf(["THOUGHT.md", "show"], "show THOUGHT.md"),
+      leaf(["THOUGHT.md", "cat"], "show THOUGHT.md"),
+    ],
+  ),
+  branch(
+    ["color-font"],
+    "color-font",
+    [
+      leaf(["color-font", "raw"], "show raw color-font"),
+      leaf(["color-font", "text"], "show color-font text"),
+      leaf(["color-font", "show"], "show color-font"),
+    ],
+    {
+      aliases: ["font"],
+      sideEffect: sideEffectRead("open color-font source"),
+    },
+  ),
+  leaf(["run"], "run one model round", {
+    sideEffect: sideEffectExternalModel("send prompt and THOUGHT.md to selected model"),
+  }),
+  leaf(["rerun"], "rerun one model round", {
+    canonicalPath: ["run"],
+    sideEffect: sideEffectExternalModel("send prompt and THOUGHT.md to selected model"),
+  }),
+  branch(
+    ["retry"],
+    "retry",
+    [
+      leaf(["retry", "run"], "retry run", {
+        canonicalPath: ["run"],
+        sideEffect: sideEffectExternalModel("retry model run"),
+      }),
+    ],
+  ),
+  branch(
+    ["preview"],
+    "contract preview",
+    [
+      leaf(["preview", "retry"], "retry contract preview", {
+        sideEffect: sideEffectContractRead("read contract preview"),
+      }),
+    ],
+    {
+      sideEffect: sideEffectContractRead("read contract preview"),
+    },
+  ),
+  leaf(["return"], "return my-brain text"),
+  leaf(["cancel"], "cancel my-brain wait"),
+  branch(
+    ["work"],
+    "work history",
+    [
+      leaf(["work", "current"], "show current work"),
+      leaf(["work", "list"], "list works"),
+      leaf(["work", "clear"], "clear current work"),
+      leaf(["work", "previous"], "previous work"),
+      leaf(["work", "prev"], "previous work", { canonicalPath: ["work", "previous"] }),
+      leaf(["work", "next"], "next work"),
+      leaf(["work", "latest"], "latest work"),
+      leaf(["work", "last"], "latest work", { canonicalPath: ["work", "latest"] }),
+    ],
+    {
+      aliases: ["output"],
+      sideEffect: sideEffectLocalWrite("read or update work history"),
+    },
+  ),
+  branch(
+    ["works"],
+    "works",
+    [leaf(["works", "clear"], "clear works history", { sideEffect: sideEffectLocalWrite("clear work history") })],
+    {
+      canonicalPath: ["work"],
+    },
+  ),
+  branch(
+    ["thought"],
+    "thought works",
+    [leaf(["thought", "list"], "list minted THOUGHTs", { sideEffect: sideEffectContractRead("read THOUGHT tokens") })],
+    {
+      sideEffect: sideEffectContractRead("read THOUGHT tokens"),
+    },
+  ),
+  branch(
+    ["wallet"],
+    "wallet",
+    [
+      leaf(["wallet", "connect"], "connect wallet", { sideEffect: sideEffectWallet("connect wallet") }),
+      leaf(["wallet", "disconnect"], "disconnect wallet", {
+        sideEffect: sideEffectLocalWrite("disconnect wallet session"),
+      }),
+      leaf(["wallet", "switch"], "switch wallet network", {
+        sideEffect: sideEffectWallet("switch wallet network"),
+      }),
+    ],
+  ),
+  leaf(["mint"], "mint THOUGHT", {
+    sideEffect: sideEffectContractWrite("mint THOUGHT"),
+  }),
+  leaf(["mint-path"], "open $PATH mint", {
+    sideEffect: sideEffectRead("navigate to $PATH mint"),
+  }),
+  branch(
+    ["path"],
+    "$PATH",
+    [
+      leaf(["path", "list"], "list wallet $PATHs", {
+        sideEffect: sideEffectContractRead("read wallet $PATHs"),
+      }),
+    ],
+    {
+      sideEffect: sideEffectContractRead("read $PATH"),
+    },
+  ),
+  leaf(["authorize"], "authorize $PATH", {
+    sideEffect: sideEffectWallet("sign $PATH authorization"),
+  }),
+  leaf(["confirm"], "confirm THOUGHT mint", {
+    sideEffect: sideEffectContractWrite("mint THOUGHT"),
+  }),
+  branch(
+    ["provenance"],
+    "provenance",
+    [leaf(["provenance", "--json"], "open provenance JSON")],
+    {
+      sideEffect: sideEffectRead("read current provenance"),
+    },
+  ),
+  branch(
+    ["view"],
+    "view",
+    [
+      leaf(["view", "tx"], "open transaction", {
+        sideEffect: sideEffectRead("open transaction explorer"),
+      }),
+      leaf(["view", "THOUGHT"], "open THOUGHT detail", {
+        sideEffect: sideEffectRead("open THOUGHT detail"),
+      }),
+    ],
+  ),
+  leaf(["verify"], "verify contracts", {
+    sideEffect: sideEffectRead("open verification page"),
+  }),
+];
+
+export const thoughtBranchHelpCommands = [
+  "config",
+  "config direct",
+  "config local",
+  "config connect",
+  "config my-brain",
+];

--- a/apps/thought/src/surfaceShell/thoughtCompletions.ts
+++ b/apps/thought/src/surfaceShell/thoughtCompletions.ts
@@ -1,0 +1,17 @@
+import {
+  getCommandCompletions,
+  type SurfaceCompletion,
+} from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+import { thoughtCommandTree } from "./thoughtCommandTree";
+
+export const getThoughtShellCompletions = (input: string): SurfaceCompletion[] =>
+  getCommandCompletions(input, {
+    includeAliases: true,
+    config: {
+      mode: "command-first",
+      commandPrefix: null,
+      root: thoughtCommandTree,
+      caseInsensitiveCommands: true,
+    },
+  });

--- a/apps/thought/src/surfaceShell/thoughtDispatcherAdapter.ts
+++ b/apps/thought/src/surfaceShell/thoughtDispatcherAdapter.ts
@@ -1,0 +1,140 @@
+import {
+  createSurfaceShell,
+  parseInput,
+  type SurfaceParseResult,
+  type SurfaceShell,
+} from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+import { getThoughtShellCompletions } from "./thoughtCompletions";
+import { thoughtCommandTree } from "./thoughtCommandTree";
+import { redactThoughtShellInput, shouldRecordThoughtShellInput, THOUGHT_SHELL_REDACTION_RULES } from "./thoughtRedaction";
+import { surfaceReturnToCliLines, thoughtMyBrainWaitingLines, thoughtUnknownCommandLines } from "./thoughtShellReturns";
+import { defaultThoughtShellState, type ThoughtShellState } from "./thoughtShellState";
+
+export type ThoughtShellParsedCommand = {
+  raw: string;
+  trimmed: string;
+  isBlank: boolean;
+  kind: SurfaceParseResult["kind"];
+  commandText: string;
+  commandPath: string[];
+  canonicalPath: string[];
+  legacyHead: string;
+  rest: string;
+  args: string[];
+};
+
+export type ThoughtSurfaceShellAdapter = {
+  parse(input: string): SurfaceParseResult;
+  resolve(input: string): ThoughtShellParsedCommand;
+  getBranchHelpLines(input: string): Promise<string[]>;
+  getCompletions(input: string): string[];
+  isAllowedWhileMyBrainWaiting(parsed: ThoughtShellParsedCommand): boolean;
+  redactForEcho(input: string): string;
+  shouldRecord(input: string): boolean;
+};
+
+const createCoreShell = (getState: () => ThoughtShellState): SurfaceShell<ThoughtShellState> =>
+  createSurfaceShell<ThoughtShellState>({
+    shellId: "thought-cli",
+    displayName: "THOUGHT CLI",
+    mode: "command-first",
+    commandPrefix: null,
+    getPrompt: ({ state }) => (state.myBrainWaiting ? "my-brain>" : "thought>"),
+    caseInsensitiveCommands: true,
+    argumentMode: "raw-remainder",
+    historyLimit: 80,
+    transcriptLimit: 80,
+    inFlightBehavior: "ignore",
+    root: thoughtCommandTree,
+    redactionRules: THOUGHT_SHELL_REDACTION_RULES,
+    getState,
+  });
+
+const normalizeLegacyHead = (head: string) => {
+  const lowerHead = head.toLowerCase();
+  if (lowerHead === "?" || lowerHead === "--help") {
+    return "help";
+  }
+  if (lowerHead === "mybrain") {
+    return "my-brain";
+  }
+  if (lowerHead === "font") {
+    return "color-font";
+  }
+  if (lowerHead === "output") {
+    return "work";
+  }
+  return lowerHead;
+};
+
+const splitLegacyInput = (trimmed: string) => {
+  const match = trimmed.match(/^(\S+)(?:\s+([\s\S]*))?$/);
+  const rawHead = match?.[1] ?? "";
+  const rest = match?.[2]?.trim() ?? "";
+  return {
+    legacyHead: normalizeLegacyHead(rawHead),
+    rest,
+    args: rest ? rest.split(/\s+/) : [],
+  };
+};
+
+export const parseThoughtShellInput = (input: string): ThoughtShellParsedCommand => {
+  const parsed = parseInput(input, {
+    mode: "command-first",
+    commandPrefix: null,
+    root: thoughtCommandTree,
+    caseInsensitiveCommands: true,
+  });
+  const trimmed = input.trim();
+  const legacy = splitLegacyInput(trimmed);
+  const commandPath = parsed.kind === "command" || parsed.kind === "unknown" ? parsed.commandPath : [];
+
+  return {
+    raw: input,
+    trimmed,
+    isBlank: parsed.kind === "blank",
+    kind: parsed.kind,
+    commandText: parsed.kind === "command" || parsed.kind === "unknown" ? parsed.commandText : "",
+    commandPath,
+    canonicalPath: commandPath,
+    legacyHead: legacy.legacyHead,
+    rest: legacy.rest,
+    args: legacy.args,
+  };
+};
+
+export const createThoughtSurfaceShellAdapter = (
+  getState: () => ThoughtShellState = defaultThoughtShellState,
+): ThoughtSurfaceShellAdapter => {
+  const coreShell = createCoreShell(getState);
+
+  return {
+    parse(input) {
+      return coreShell.parse(input);
+    },
+    resolve(input) {
+      return parseThoughtShellInput(input);
+    },
+    async getBranchHelpLines(input) {
+      return surfaceReturnToCliLines(await coreShell.dispatch(input));
+    },
+    getCompletions(input) {
+      return getThoughtShellCompletions(input).map((completion) => completion.value);
+    },
+    isAllowedWhileMyBrainWaiting(parsed) {
+      if (!getState().myBrainWaiting) {
+        return true;
+      }
+      return parsed.legacyHead === "return" || parsed.legacyHead === "cancel";
+    },
+    redactForEcho(input) {
+      return redactThoughtShellInput(input);
+    },
+    shouldRecord(input) {
+      return shouldRecordThoughtShellInput(input);
+    },
+  };
+};
+
+export { redactThoughtShellInput, shouldRecordThoughtShellInput, thoughtMyBrainWaitingLines, thoughtUnknownCommandLines };

--- a/apps/thought/src/surfaceShell/thoughtGoldenTranscripts.test.ts
+++ b/apps/thought/src/surfaceShell/thoughtGoldenTranscripts.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+
+import {
+  createThoughtSurfaceShellAdapter,
+  parseThoughtShellInput,
+  redactThoughtShellInput,
+  shouldRecordThoughtShellInput,
+} from "./thoughtDispatcherAdapter";
+import { defaultThoughtShellState, type ThoughtShellState } from "./thoughtShellState";
+
+export const runThoughtShellAdapterTests = async () => {
+  const state: ThoughtShellState = {
+    ...defaultThoughtShellState(),
+    route: "connect",
+    routeConfigured: true,
+    model: "openrouter/free",
+  };
+  const adapter = createThoughtSurfaceShellAdapter(() => state);
+
+  const pathList = parseThoughtShellInput("  PATH   list  ");
+  assert.equal(pathList.legacyHead, "path");
+  assert.equal(pathList.rest, "list");
+  assert.deepEqual(pathList.args, ["list"]);
+  assert.deepEqual(pathList.canonicalPath, ["path", "list"]);
+
+  const help = parseThoughtShellInput("?");
+  assert.equal(help.legacyHead, "help");
+  assert.deepEqual(help.canonicalPath, ["help"]);
+
+  const colorFont = parseThoughtShellInput("font raw");
+  assert.equal(colorFont.legacyHead, "color-font");
+  assert.equal(colorFont.rest, "raw");
+  assert.deepEqual(colorFont.canonicalPath, ["color-font", "raw"]);
+
+  const thoughtView = parseThoughtShellInput("view THOUGHT 9");
+  assert.equal(thoughtView.legacyHead, "view");
+  assert.equal(thoughtView.rest, "THOUGHT 9");
+  assert.deepEqual(thoughtView.canonicalPath, ["view", "THOUGHT"]);
+
+  assert.equal(redactThoughtShellInput("config direct key sk-private"), "config direct key ********");
+  assert.equal(shouldRecordThoughtShellInput("config direct key sk-private"), false);
+  assert.equal(shouldRecordThoughtShellInput("config direct key clear"), true);
+
+  const directHelp = await adapter.getBranchHelpLines("config direct");
+  assert(
+    directHelp.some((line) => line.includes("config direct key")),
+    "config direct branch help should include key guidance",
+  );
+  assert(
+    directHelp.some((line) => line.includes("config direct model")),
+    "config direct branch help should include model guidance",
+  );
+
+  state.myBrainWaiting = true;
+  assert.equal(adapter.isAllowedWhileMyBrainWaiting(adapter.resolve("run")), false);
+  assert.equal(adapter.isAllowedWhileMyBrainWaiting(adapter.resolve("return YES")), true);
+  assert.equal(adapter.isAllowedWhileMyBrainWaiting(adapter.resolve("cancel")), true);
+
+  const completions = adapter.getCompletions("config ");
+  assert(completions.includes("config direct"));
+  assert(completions.includes("config local"));
+};

--- a/apps/thought/src/surfaceShell/thoughtRedaction.ts
+++ b/apps/thought/src/surfaceShell/thoughtRedaction.ts
@@ -1,0 +1,74 @@
+import {
+  applyRedaction,
+  type SurfaceRedactionRule,
+} from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+const SECRET_MASK = "********";
+
+type SecretCommandRule = {
+  id: string;
+  prefix: string[];
+};
+
+const SECRET_COMMAND_RULES: SecretCommandRule[] = [
+  { id: "key", prefix: ["key"] },
+  { id: "config-key", prefix: ["config", "key"] },
+  { id: "config-direct-key", prefix: ["config", "direct", "key"] },
+];
+
+export const THOUGHT_SHELL_REDACTION_RULES: SurfaceRedactionRule[] = SECRET_COMMAND_RULES.map((rule) => ({
+  id: rule.id,
+  description: "Mask THOUGHT CLI API key commands before echo/history/transcript storage.",
+  pattern: new RegExp(`^(${rule.prefix.join("\\s+")})\\s+(.+)$`, "i"),
+  replacement: `$1 ${SECRET_MASK}`,
+  suppressHistory: true,
+  suppressTranscript: true,
+  phases: ["echo", "history", "transcript", "event"],
+}));
+
+const normalizeSecretRest = (rest: string) => rest.trim().toLowerCase();
+
+const isAllowedSecretRest = (rest: string) => {
+  const normalized = normalizeSecretRest(rest);
+  return normalized === "" || normalized === "clear" || normalized === "help";
+};
+
+const matchSecretCommand = (input: string) => {
+  const trimmed = input.trim();
+  const tokens = trimmed.split(/\s+/);
+
+  for (const rule of SECRET_COMMAND_RULES) {
+    const prefixMatches = rule.prefix.every((segment, index) => tokens[index]?.toLowerCase() === segment);
+    if (!prefixMatches) {
+      continue;
+    }
+
+    const restTokens = tokens.slice(rule.prefix.length);
+    if (restTokens.length === 0) {
+      return null;
+    }
+
+    const prefix = tokens.slice(0, rule.prefix.length).join(" ");
+    const rest = restTokens.join(" ");
+    return {
+      prefix,
+      rest,
+    };
+  }
+
+  return null;
+};
+
+export const redactThoughtShellInput = (input: string) => {
+  const secret = matchSecretCommand(input);
+  if (!secret || isAllowedSecretRest(secret.rest)) {
+    return applyRedaction(input, THOUGHT_SHELL_REDACTION_RULES, "echo").text;
+  }
+
+  return `${secret.prefix} ${SECRET_MASK}`;
+};
+
+export const shouldRecordThoughtShellInput = (input: string) => {
+  const secret = matchSecretCommand(input);
+  return !secret || isAllowedSecretRest(secret.rest);
+};

--- a/apps/thought/src/surfaceShell/thoughtShellReturns.ts
+++ b/apps/thought/src/surfaceShell/thoughtShellReturns.ts
@@ -1,0 +1,11 @@
+import { renderText, type SurfaceReturn } from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+export const surfaceReturnToCliLines = (result: SurfaceReturn) => renderText(result).split("\n");
+
+export const thoughtUnknownCommandLines = () => ["unknown command.", "use: help"];
+
+export const thoughtMyBrainWaitingLines = () => [
+  "my-brain is waiting for return.",
+  "use: return <text>",
+  "use: cancel",
+];

--- a/apps/thought/src/surfaceShell/thoughtShellState.ts
+++ b/apps/thought/src/surfaceShell/thoughtShellState.ts
@@ -1,0 +1,43 @@
+export type ThoughtShellRoute = "connect" | "direct" | "local" | "my-brain";
+
+export type ThoughtShellState = {
+  prompt: string;
+  route: ThoughtShellRoute;
+  routeConfigured: boolean;
+  provider: string;
+  model: string;
+  apiKeyConfigured: boolean;
+  localEndpoint: string;
+  localAvailable: boolean | null;
+  openRouterLinked: boolean;
+  previewMode: string;
+  previewProvider: string;
+  walletConnected: boolean;
+  walletChainReady: boolean;
+  pathSelected: boolean;
+  pathAuthorized: boolean;
+  candidateReady: boolean;
+  workReady: boolean;
+  myBrainWaiting: boolean;
+};
+
+export const defaultThoughtShellState = (): ThoughtShellState => ({
+  prompt: "",
+  route: "connect",
+  routeConfigured: false,
+  provider: "openrouter",
+  model: "",
+  apiKeyConfigured: false,
+  localEndpoint: "",
+  localAvailable: null,
+  openRouterLinked: false,
+  previewMode: "auto",
+  previewProvider: "auto",
+  walletConnected: false,
+  walletChainReady: false,
+  pathSelected: false,
+  pathAuthorized: false,
+  candidateReady: false,
+  workReady: false,
+  myBrainWaiting: false,
+});

--- a/apps/thought/src/surfaceShell/thoughtSideEffects.ts
+++ b/apps/thought/src/surfaceShell/thoughtSideEffects.ts
@@ -1,0 +1,50 @@
+import type { SurfaceSideEffectGate } from "surface-shell/packages/surface-shell-core/src/index.ts";
+
+export const sideEffectNone: SurfaceSideEffectGate = {
+  kind: "none",
+  requiresExplicitCommand: false,
+};
+
+export const sideEffectRead = (label: string): SurfaceSideEffectGate => ({
+  kind: "read",
+  label,
+  requiresExplicitCommand: true,
+});
+
+export const sideEffectNetwork = (label: string): SurfaceSideEffectGate => ({
+  kind: "network",
+  label,
+  requiresExplicitCommand: true,
+});
+
+export const sideEffectExternalModel = (label: string): SurfaceSideEffectGate => ({
+  kind: "external-model",
+  label,
+  requiresExplicitCommand: true,
+});
+
+export const sideEffectWallet = (label: string): SurfaceSideEffectGate => ({
+  kind: "wallet",
+  label,
+  requiresExplicitCommand: true,
+  requiresConfirmation: true,
+});
+
+export const sideEffectContractRead = (label: string): SurfaceSideEffectGate => ({
+  kind: "contract-read",
+  label,
+  requiresExplicitCommand: true,
+});
+
+export const sideEffectContractWrite = (label: string): SurfaceSideEffectGate => ({
+  kind: "contract-write",
+  label,
+  requiresExplicitCommand: true,
+  requiresConfirmation: true,
+});
+
+export const sideEffectLocalWrite = (label: string): SurfaceSideEffectGate => ({
+  kind: "write",
+  label,
+  requiresExplicitCommand: true,
+});

--- a/apps/thought/tsconfig.json
+++ b/apps/thought/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "../../node_modules/.tmp/tsconfig.thought.tsbuildinfo",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "types": ["vite/client", "node"],
     "jsx": "react-jsx",
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      surface-shell:
+        specifier: github:inshell-art/surface-shell#0.1.0
+        version: https://codeload.github.com/inshell-art/surface-shell/tar.gz/fbb3039416b3e01a24545aa4e9dada3399762550
       vite:
         specifier: 7.3.2
         version: 7.3.2(@types/node@24.2.0)(tsx@4.20.3)(yaml@2.8.4)
@@ -5128,6 +5131,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  surface-shell@https://codeload.github.com/inshell-art/surface-shell/tar.gz/fbb3039416b3e01a24545aa4e9dada3399762550:
+    resolution: {tarball: https://codeload.github.com/inshell-art/surface-shell/tar.gz/fbb3039416b3e01a24545aa4e9dada3399762550}
+    version: 0.1.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -12163,6 +12170,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  surface-shell@https://codeload.github.com/inshell-art/surface-shell/tar.gz/fbb3039416b3e01a24545aa4e9dada3399762550: {}
 
   symbol-tree@3.2.4: {}
 

--- a/scripts/test-thought-runtime.ts
+++ b/scripts/test-thought-runtime.ts
@@ -18,6 +18,7 @@ import {
   JSON_RPC_NO_BATCH_OPTIONS,
   createSingleRequestJsonRpcProvider,
 } from "../apps/thought/src/rpc-provider";
+import { runThoughtShellAdapterTests } from "../apps/thought/src/surfaceShell/thoughtGoldenTranscripts.test";
 import {
   createMemoryStorageAdapter,
   createSurfaceShell,
@@ -154,6 +155,7 @@ assert.equal(
 );
 assert.equal(shouldRecordSurfaceInput("config direct key sk-private", secretRules), false);
 assert.equal(shouldRecordSurfaceInput("config direct key clear", secretRules), true);
+await runThoughtShellAdapterTests();
 
 const storage = createMemoryStorageAdapter();
 const shell = createSurfaceShell<{ value: string }>({


### PR DESCRIPTION
## Summary
- Import Surface Shell core from the GitHub 0.1.0 tag for THOUGHT CLI parsing/redaction structure.
- Add THOUGHT-specific adapter, command tree, redaction, completions, and golden runtime coverage.
- Preserve existing THOUGHT CLI command behavior while routing command parsing through the adapter.

## Checks
- pnpm run check
- pnpm --filter @inshell/thought build
- gitleaks detect --no-git --redact
- staging GitHub test passed
- staging CodeQL passed