### PR TITLE
Promote staging to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -44,6 +44,7 @@ jobs:
       VITE_REPORT_BUG_URL: ${{ vars.VITE_REPORT_BUG_URL || 'https://github.com/inshell-art/inshell.art/issues/new?template=sepolia-bug.md' }}
       VITE_GITHUB_URL: ${{ vars.VITE_GITHUB_URL || 'https://github.com/inshell-art/' }}
       VITE_DEBUG_PANEL: ${{ vars.VITE_DEBUG_PANEL || 'off' }}
+      VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ github.event.inputs.branch == 'main' && vars.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
       VITE_THOUGHT_URL: ${{ github.event.inputs.branch == 'staging' && 'https://thought.preview.inshell.art/' || vars.VITE_THOUGHT_URL || 'https://thought.inshell.art/' }}
       VITE_GALLERY_URL: ${{ github.event.inputs.branch == 'staging' && 'https://gallery.preview.inshell.art/' || vars.VITE_GALLERY_URL || vars.VITE_THOUGHT_GALLERY_URL || 'https://gallery.inshell.art/' }}
       VITE_THOUGHT_GALLERY_URL: ${{ github.event.inputs.branch == 'staging' && 'https://gallery.preview.inshell.art/' || vars.VITE_GALLERY_URL || vars.VITE_THOUGHT_GALLERY_URL || 'https://gallery.inshell.art/' }}
@@ -107,6 +108,7 @@ jobs:
       VITE_PUBLIC_LAUNCH_MODE: ${{ vars.VITE_PUBLIC_LAUNCH_MODE || 'sepolia_invite' }}
       VITE_REPORT_BUG_URL: ${{ vars.VITE_REPORT_BUG_URL || 'https://github.com/inshell-art/inshell.art/issues/new?template=sepolia-bug.md' }}
       VITE_GITHUB_URL: ${{ vars.VITE_GITHUB_URL || 'https://github.com/inshell-art/' }}
+      VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ github.event.inputs.branch == 'main' && vars.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "test:fast": "jest --runTestsByPath tests/num.test.ts tests/pulseCurve.test.ts",
     "test:presepolia": "jest --runTestsByPath tests/App.test.tsx tests/pathTokens.test.ts tests/AuctionCanvas.test.tsx tests/middlewareFunction.test.ts",
-    "test:unit": "jest --runTestsByPath tests/App.test.tsx tests/AuctionCanvas.test.tsx tests/AuctionCanvasPulseFixtures.test.tsx tests/AuctionCanvasLook.test.tsx tests/HeaderWalletCTA.test.tsx tests/Movements.test.tsx tests/bidsService.test.ts tests/coreService.test.ts tests/ethereumClient.test.ts tests/middlewareFunction.test.ts tests/num.test.ts tests/pathTokens.test.ts tests/pulseCurve.test.ts tests/thoughtPreviewFunction.test.ts",
+    "test:unit": "jest --runTestsByPath tests/App.test.tsx tests/AuctionCanvas.test.tsx tests/AuctionCanvasPulseFixtures.test.tsx tests/AuctionCanvasLook.test.tsx tests/HeaderWalletCTA.test.tsx tests/Movements.test.tsx tests/bidsService.test.ts tests/cloudflareWebAnalytics.test.ts tests/coreService.test.ts tests/ethereumClient.test.ts tests/middlewareFunction.test.ts tests/num.test.ts tests/pathTokens.test.ts tests/pulseCurve.test.ts tests/thoughtPreviewFunction.test.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "preview": "vite preview --host 127.0.0.1 --port 4173 --strictPort"

--- a/apps/home/src/main.tsx
+++ b/apps/home/src/main.tsx
@@ -7,9 +7,11 @@ import "@fontsource/source-code-pro/200.css";
 import "@fontsource/source-code-pro/300.css";
 import "@fontsource/source-code-pro/400.css";
 import "@fontsource/source-code-pro/600.css";
+import { maybeInstallCloudflareWebAnalytics } from "@inshell/shared";
 import { WalletProvider } from "@inshell/wallet";
 
 (globalThis as any).__VITE_ENV__ = import.meta.env;
+maybeInstallCloudflareWebAnalytics({ env: import.meta.env });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/home/tests/cloudflareWebAnalytics.test.ts
+++ b/apps/home/tests/cloudflareWebAnalytics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import {
+  CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID,
+  maybeInstallCloudflareWebAnalytics,
+} from "@inshell/shared";
+
+const env = {
+  VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: "test-rum-token",
+};
+
+describe("Cloudflare Web Analytics install policy", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    delete (globalThis as any).__VITE_ENV__;
+  });
+
+  test("installs the beacon on production Inshell hosts", () => {
+    expect(
+      maybeInstallCloudflareWebAnalytics({
+        document,
+        env,
+        hostname: "inshell.art",
+      }),
+    ).toBe(true);
+
+    const script = document.getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID);
+    expect(script).not.toBeNull();
+    expect(script?.getAttribute("src")).toBe("https://static.cloudflareinsights.com/beacon.min.js");
+    expect(script?.getAttribute("data-cf-beacon")).toBe(
+      JSON.stringify({ token: env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN }),
+    );
+  });
+
+  test("does not install on preview, ops, pages.dev, or local hosts", () => {
+    const blockedHosts = [
+      "preview.inshell.art",
+      "thought.preview.inshell.art",
+      "gallery.preview.inshell.art",
+      "ops.inshell.art",
+      "staging.inshell-art.pages.dev",
+      "127.0.0.1",
+      "localhost",
+    ];
+
+    for (const hostname of blockedHosts) {
+      document.head.innerHTML = "";
+      expect(maybeInstallCloudflareWebAnalytics({ document, env, hostname })).toBe(false);
+      expect(document.getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID)).toBeNull();
+    }
+  });
+
+  test("does not install without a token or duplicate an installed beacon", () => {
+    expect(
+      maybeInstallCloudflareWebAnalytics({ document, env: {}, hostname: "inshell.art" }),
+    ).toBe(false);
+    expect(
+      maybeInstallCloudflareWebAnalytics({ document, env, hostname: "thought.inshell.art" }),
+    ).toBe(true);
+    expect(
+      maybeInstallCloudflareWebAnalytics({ document, env, hostname: "thought.inshell.art" }),
+    ).toBe(false);
+    expect(document.querySelectorAll(`#${CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID}`)).toHaveLength(1);
+  });
+});

--- a/apps/thought/index.html
+++ b/apps/thought/index.html
@@ -16,9 +16,6 @@
   <meta name="twitter:image" content="https://thought.inshell.art/og.png" />
   <meta name="theme-color" content="#008080" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Cloudflare Web Analytics -->
-  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "96bbc929b53e4b4f9fdef977ffd14d22"}'></script>
-  <!-- End Cloudflare Web Analytics -->
   <script>
     (() => {
       const params = new URLSearchParams(window.location.search);

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -33,6 +33,7 @@ import {
   buildReportBugLink,
   buildContractStatusSections,
   findContractStatusRow,
+  maybeInstallCloudflareWebAnalytics,
   resolveWalletChainRpcUrls,
   shouldShowPreviewWatermark,
   type PublicLaunchMode,
@@ -96,6 +97,8 @@ import {
   type PreviewStatus,
 } from "./thought-preview-policy";
 import { createSingleRequestJsonRpcProvider } from "./rpc-provider";
+
+maybeInstallCloudflareWebAnalytics({ env: import.meta.env });
 
 type ColorFontFile = {
   colors: Array<{

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,12 @@ export type WalletChainRpcOptions = {
   localFallbackRpcUrl?: string | null;
 };
 
+export type CloudflareWebAnalyticsOptions = {
+  env?: Readonly<Record<string, unknown>>;
+  hostname?: string | null;
+  document?: globalThis.Document | null;
+};
+
 export const SURFACE_TERMINOLOGY = {
   ecosystem: "Inshell",
   pathDapp: "$PATH",
@@ -403,6 +409,29 @@ export function findContractStatusRow(
   return sections.find((section) => section.id === sectionId)?.rows.find((row) => row.id === rowId);
 }
 
+export const CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID = "inshell-cloudflare-web-analytics";
+
+export const CLOUDFLARE_WEB_ANALYTICS_ALLOWED_HOSTS = [
+  "inshell.art",
+  "thought.inshell.art",
+  "gallery.inshell.art",
+] as const;
+
+function normalizeHostname(value: string | null | undefined): string {
+  return value?.trim().toLowerCase().replace(/\.$/, "") ?? "";
+}
+
+function getCurrentHostname(): string {
+  if (typeof window === "undefined") return "";
+  return normalizeHostname(window.location.hostname);
+}
+
+function isCloudflareWebAnalyticsHostAllowed(hostname: string): boolean {
+  return CLOUDFLARE_WEB_ANALYTICS_ALLOWED_HOSTS.includes(
+    hostname as (typeof CLOUDFLARE_WEB_ANALYTICS_ALLOWED_HOSTS)[number],
+  );
+}
+
 function getSharedEnvValue(name: string, env?: Readonly<Record<string, unknown>>): unknown {
   const globalEnv: Record<string, unknown> | undefined = (globalThis as any).__VITE_ENV__;
   const procEnv: Record<string, unknown> | undefined = (globalThis as any)?.process?.env;
@@ -415,6 +444,30 @@ function readSharedEnvString(
 ): string | null {
   const value = getSharedEnvValue(name, options?.env);
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function maybeInstallCloudflareWebAnalytics(
+  options: CloudflareWebAnalyticsOptions = {},
+): boolean {
+  const documentRef =
+    options.document ?? (typeof document === "undefined" ? null : document);
+  if (!documentRef) return false;
+
+  const hostname = normalizeHostname(options.hostname ?? getCurrentHostname());
+  if (!isCloudflareWebAnalyticsHostAllowed(hostname)) return false;
+
+  const token = readSharedEnvString("VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN", options);
+  if (!token) return false;
+
+  if (documentRef.getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID)) return false;
+
+  const script = documentRef.createElement("script");
+  script.id = CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID;
+  script.defer = true;
+  script.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  script.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  documentRef.head.appendChild(script);
+  return true;
 }
 
 function normalizeDeploymentEnv(raw: string | null | undefined): DeploymentEnv | null {


### PR DESCRIPTION
Promotes the validated staging changes to production.\n\nChanges:\n- Disable Cloudflare auto-injected Web Analytics and move analytics injection under repo control.\n- Inject Cloudflare Web Analytics only on exact production hosts with the public beacon token.\n- Keep preview/local/pages.dev builds analytics-free.\n- Add unit coverage for analytics host gating.\n\nValidation already run on staging:\n- pnpm --filter @inshell/home test -- --runTestsByPath tests/cloudflareWebAnalytics.test.ts\n- pnpm --filter @inshell/home test:unit\n- pnpm run lint\n- pnpm run build:home\n- pnpm run build:thought\n- pnpm run check:deployment\n- pnpm run test:thought-runtime\n- git diff --check\n- gitleaks detect --no-git --redact\n- GitHub staging test and CodeQL passed\n