### PR TITLE
Promote staging to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -74,6 +74,9 @@ jobs:
           test -n "$VITE_WALLET_CHAIN_RPC_URL"
           test -n "$VITE_THOUGHT_URL"
           test -n "$VITE_GALLERY_URL"
+          if [ "${{ github.event.inputs.branch }}" = "main" ]; then
+            test -n "$VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN"
+          fi
       - name: Validate deployment gates
         run: pnpm run check:deployment
       - name: Lint home
@@ -138,6 +141,9 @@ jobs:
           test -n "$VITE_PATH_MINT_URL"
           test -n "$VITE_THOUGHT_DETAIL_BASE_URL"
           test -n "$VITE_GALLERY_URL"
+          if [ "${{ github.event.inputs.branch }}" = "main" ]; then
+            test -n "$VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN"
+          fi
       - name: Validate deployment gates
         run: pnpm run check:deployment
       - name: Test THOUGHT runtime payloads

--- a/apps/home/tests/cloudflareWebAnalytics.test.ts
+++ b/apps/home/tests/cloudflareWebAnalytics.test.ts
@@ -12,6 +12,7 @@ describe("Cloudflare Web Analytics install policy", () => {
   beforeEach(() => {
     document.head.innerHTML = "";
     delete (globalThis as any).__VITE_ENV__;
+    delete (globalThis as any).__INSHELL_VITE_ENV__;
   });
 
   test("installs the beacon on production Inshell hosts", () => {
@@ -60,5 +61,19 @@ describe("Cloudflare Web Analytics install policy", () => {
       maybeInstallCloudflareWebAnalytics({ document, env, hostname: "thought.inshell.art" }),
     ).toBe(false);
     expect(document.querySelectorAll(`#${CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID}`)).toHaveLength(1);
+  });
+
+  test("installs from the build-time Vite env object", () => {
+    (globalThis as any).__INSHELL_VITE_ENV__ = env;
+
+    expect(
+      maybeInstallCloudflareWebAnalytics({ document, hostname: "gallery.inshell.art" }),
+    ).toBe(true);
+
+    expect(
+      document
+        .getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID)
+        ?.getAttribute("data-cf-beacon"),
+    ).toBe(JSON.stringify({ token: env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN }));
   });
 });

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -98,6 +98,7 @@ import {
 } from "./thought-preview-policy";
 import { createSingleRequestJsonRpcProvider } from "./rpc-provider";
 
+(globalThis as any).__VITE_ENV__ = import.meta.env;
 maybeInstallCloudflareWebAnalytics({ env: import.meta.env });
 
 type ColorFontFile = {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -434,8 +434,9 @@ function isCloudflareWebAnalyticsHostAllowed(hostname: string): boolean {
 
 function getSharedEnvValue(name: string, env?: Readonly<Record<string, unknown>>): unknown {
   const globalEnv: Record<string, unknown> | undefined = (globalThis as any).__VITE_ENV__;
+  const buildEnv: Record<string, unknown> | undefined = (globalThis as any).__INSHELL_VITE_ENV__;
   const procEnv: Record<string, unknown> | undefined = (globalThis as any)?.process?.env;
-  return env?.[name] ?? globalEnv?.[name] ?? procEnv?.[name];
+  return env?.[name] ?? globalEnv?.[name] ?? buildEnv?.[name] ?? procEnv?.[name];
 }
 
 function readSharedEnvString(


### PR DESCRIPTION
## Summary\n- Fix shared Cloudflare Web Analytics env lookup so THOUGHT/gallery builds can install the beacon when the public token is provided.\n- Align THOUGHT startup with home by exposing Vite env on globalThis before analytics install.\n- Add a regression test for build-time env token lookup.\n- Fail main deploy config checks when the analytics token is missing.\n\n## Checks\n- pnpm --filter @inshell/home test:unit -- --runTestsByPath tests/cloudflareWebAnalytics.test.ts\n- pnpm --filter @inshell/thought type-check\n- git diff --check\n- gitleaks detect --no-git --redact\n- VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN=local-dummy-rum-token pnpm --filter @inshell/home build\n- VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN=local-dummy-rum-token pnpm --filter @inshell/thought build\n- GitHub staging test workflow: passed\n- GitHub staging CodeQL workflow: passed\n- GitHub deploy-pages target=all branch=staging: passed\n\nNote: analytics remains intentionally disabled on staging by workflow config. The production proof is the dummy-token build plus the new main deploy guard.