### PR TITLE
Promote analytics token fix

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -85,6 +85,11 @@ jobs:
         run: pnpm run test:presepolia
       - name: Build home
         run: pnpm run build:home
+      - name: Verify production analytics bundle
+        if: ${{ github.event.inputs.branch == 'main' }}
+        run: |
+          grep -R -q "static.cloudflareinsights.com/beacon.min.js" dist/home
+          grep -R -F -q "$VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN" dist/home
       - name: Deploy home to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -152,6 +157,11 @@ jobs:
         run: pnpm --filter @inshell/thought type-check
       - name: Build THOUGHT
         run: pnpm --filter @inshell/thought build
+      - name: Verify production analytics bundle
+        if: ${{ github.event.inputs.branch == 'main' }}
+        run: |
+          grep -R -q "static.cloudflareinsights.com/beacon.min.js" dist/thought
+          grep -R -F -q "$VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN" dist/thought
       - name: Deploy THOUGHT to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/home/src/main.tsx
+++ b/apps/home/src/main.tsx
@@ -10,8 +10,13 @@ import "@fontsource/source-code-pro/600.css";
 import { maybeInstallCloudflareWebAnalytics } from "@inshell/shared";
 import { WalletProvider } from "@inshell/wallet";
 
-(globalThis as any).__VITE_ENV__ = import.meta.env;
-maybeInstallCloudflareWebAnalytics({ env: import.meta.env });
+const runtimeEnv = {
+  ...import.meta.env,
+  VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: import.meta.env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN,
+};
+
+(globalThis as any).__VITE_ENV__ = runtimeEnv;
+maybeInstallCloudflareWebAnalytics({ env: runtimeEnv });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -98,8 +98,13 @@ import {
 } from "./thought-preview-policy";
 import { createSingleRequestJsonRpcProvider } from "./rpc-provider";
 
-(globalThis as any).__VITE_ENV__ = import.meta.env;
-maybeInstallCloudflareWebAnalytics({ env: import.meta.env });
+const runtimeEnv = {
+  ...import.meta.env,
+  VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: import.meta.env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN,
+};
+
+(globalThis as any).__VITE_ENV__ = runtimeEnv;
+maybeInstallCloudflareWebAnalytics({ env: runtimeEnv });
 
 type ColorFontFile = {
   colors: Array<{


### PR DESCRIPTION
Promotes the staging analytics-token fix to production.\n\nChanges:\n- Force Vite to retain VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN in both home and THOUGHT runtime env bundles.\n- Add main-deploy guards that fail if the Cloudflare Web Analytics beacon or exact token is absent from home or THOUGHT build output.\n\nValidation already run on staging:\n- home unit test suite\n- thought type-check\n- production-style dummy-token build/grep guard\n- git diff --check\n- gitleaks detect --no-git --redact\n- GitHub build and gitleaks checks passed on staging\n