### PR TITLE
Hotfix PATH RPC fallback for prod curves

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
 import {
+  createStats,
   createChainCacheDiagnostics,
+  getLogsChunked,
   json,
   readResponseCache,
   readSnapshot,
@@ -57,7 +59,16 @@ function encodeAddressResult(address: string) {
 function rpcResponse(result: unknown) {
   return {
     ok: true,
+    status: 200,
     json: async () => ({ jsonrpc: "2.0", id: 1, result }),
+  };
+}
+
+function rpcError(status: number, message: string) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ jsonrpc: "2.0", id: 1, error: { message } }),
   };
 }
 
@@ -189,6 +200,54 @@ describe("chain cache Pages functions", () => {
       "https://target-path-rpc.example/sepolia",
       expect.objectContaining({ method: "POST" })
     );
+  });
+
+  test("falls back when primary PATH RPC rejects eth_getLogs block ranges", async () => {
+    const fetchMock = jest.fn(async (url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method?: string;
+      };
+      if (body.method !== "eth_getLogs") throw new Error(`unexpected RPC method ${body.method}`);
+      if (url === "https://target-path-rpc.example/sepolia") {
+        return rpcError(
+          400,
+          "Under the Free tier plan, you can make eth_getLogs requests with up to a 10 block range.",
+        );
+      }
+      if (url === "https://public-fallback-rpc.example/sepolia") {
+        return rpcResponse([
+          {
+            address: PATH_NFT,
+            blockNumber: "0xa5a7ec",
+            data: "0x",
+            logIndex: "0x0",
+            topics: [TRANSFER_TOPIC, ZERO_TOPIC, addressTopic(OWNER), tokenTopic(1n)],
+            transactionHash: `0x${"1".padStart(64, "0")}`,
+          },
+        ]);
+      }
+      throw new Error(`unexpected RPC upstream ${String(url)}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const env = {
+      PATH_PRIMARY_RPC_UPSTREAM: "https://target-path-rpc.example/sepolia",
+      PUBLIC_FALLBACK_RPC_UPSTREAM: "https://public-fallback-rpc.example/sepolia",
+    };
+    const stats = createStats("path", "pulse-auction", env);
+
+    const logs = await getLogsChunked(env, "path", stats, {
+      address: PATH_NFT,
+      fromBlock: 100,
+      toBlock: 5099,
+      topics: [TRANSFER_TOPIC],
+    });
+
+    expect(logs).toHaveLength(1);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://target-path-rpc.example/sepolia",
+      "https://public-fallback-rpc.example/sepolia",
+    ]);
+    expect(stats.calls).toBe(2);
   });
 
   test("does not fail open when KV is quota limited", async () => {

--- a/functions/api/chain-cache.ts
+++ b/functions/api/chain-cache.ts
@@ -345,6 +345,18 @@ function estimateCu(method: string) {
   return 10;
 }
 
+function shouldTryNextRpcUpstream(method: string, status: number, message: string) {
+  if (status === 429 || status >= 500) return true;
+  if (method !== "eth_getLogs" || status !== 400) return false;
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("block range") ||
+    normalized.includes("free tier") ||
+    normalized.includes("range should work") ||
+    normalized.includes("too many blocks")
+  );
+}
+
 export async function rpcCall<T>(
   env: ChainCacheEnv,
   service: "path" | "thought",
@@ -387,7 +399,7 @@ export async function rpcCall<T>(
           ? (parsed?.error as any).message
           : `RPC request failed with ${response.status}`;
       lastError = new Error(message);
-      if (!(response.status === 429 || response.status >= 500 || !parsed)) {
+      if (!(shouldTryNextRpcUpstream(method, response.status, message) || !parsed)) {
         break;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- Refresh PATH log reads to continue to the next configured RPC upstream when the primary provider rejects eth_getLogs block ranges.
- Add a regression test for an Alchemy free-tier block-range 400 falling back to the public RPC.

## Production context
- Production Pages RPC env was refreshed and redeployed before this PR; raw RPC gateway probes now return 200.
- /api/pulse-auction still needs this code patch because the PATH primary provider rejects 5,000-block eth_getLogs chunks.

## Checks run locally
- pnpm --filter @inshell/home test -- --runTestsByPath tests/chainCacheFunction.test.ts
- pnpm run type-check
- pnpm --filter @inshell/home test:unit
- pnpm run lint
- git diff --check
- gitleaks detect --no-git --redact
