### PR TITLE
Promote D1 chain read model refresh

### DIFF
--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -24,6 +24,7 @@ import {
 } from "@inshell/utils";
 import type { AuctionSnapshot } from "@/types/types";
 import type { NormalizedBid } from "@/services/auction/bidsService";
+import { requestPulseAuctionRefresh } from "@/services/chainIndexer";
 import { clearPathTokenInventoryCache } from "@/services/pathTokens";
 import { useAuctionCore } from "@/hooks/useAuctionCore";
 import {
@@ -4386,6 +4387,10 @@ export default function AuctionCanvas({
     setCurrentAskQuoteDec(null);
     postMintNowTipPendingRef.current = true;
     postMintNowTipBaseCurveKeyRef.current = initialAskTipCurveKeyRef.current;
+    void requestPulseAuctionRefresh(hash).then(() => {
+      void pullBidsOnce();
+      void refreshCore();
+    });
     void pullBidsOnce();
     void refreshCore();
     window.setTimeout(() => void pullBidsOnce(), 2_000);

--- a/apps/home/src/services/chainIndexer.ts
+++ b/apps/home/src/services/chainIndexer.ts
@@ -1,0 +1,18 @@
+const DEFAULT_INDEXER_REFRESH_API_URL = "/api/indexer/refresh";
+
+export async function requestPulseAuctionRefresh(txHash: string) {
+  if (!/^0x[a-fA-F0-9]{64}$/.test(txHash)) return false;
+  try {
+    const response = await fetch(DEFAULT_INDEXER_REFRESH_API_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        target: "pulse-auction",
+        tx: txHash,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
 import {
+  clearChainCacheForTest,
   createStats,
   createChainCacheDiagnostics,
   getLogsChunked,
@@ -11,7 +12,9 @@ import {
   writeSnapshot,
   type IndexedSnapshot,
 } from "../../../functions/api/chain-cache";
+import { onRequestPost as onIndexerRefreshPost } from "../../../functions/api/indexer/refresh";
 import { onRequestGet as onPathTokensGet } from "../../../functions/api/path-tokens";
+import { onRequestGet as onPulseAuctionGet } from "../../../functions/api/pulse-auction";
 import { onRequestGet as onThoughtImageGet } from "../../../functions/api/thought-image";
 import { onRequestGet as onThoughtProvenanceGet } from "../../../functions/api/thought-provenance";
 import { onRequestGet as onThoughtSpecGet } from "../../../functions/api/thought-spec";
@@ -25,6 +28,9 @@ const OWNER = "0x1111222233334444555566667777888899990000";
 const PATH_NFT = "0x84915746a1f06850CF41a3E90C60c2DcA3fa116D";
 const TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const PULSE_SALE_TOPIC =
+  "0xa789468a0212cbe853fbdd6011d2ee7d85144ebc1d67c7dd82f087a970d9593d";
+const PULSE_AUCTION = "0x1071e99928Bdf020794a5E3e5B9c920450Ac9b39";
 const ZERO_TOPIC =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -69,6 +75,44 @@ function rpcError(status: number, message: string) {
     ok: false,
     status,
     json: async () => ({ jsonrpc: "2.0", id: 1, error: { message } }),
+  };
+}
+
+function createD1Mock(seed: Record<string, unknown> = {}) {
+  const rows = new Map<string, string>(
+    Object.entries(seed).map(([key, value]) => [key, JSON.stringify(value)]),
+  );
+  const exec = jest.fn(async () => undefined);
+  const prepare = jest.fn((query: string) => {
+    let bound: unknown[] = [];
+    const statement = {
+      bind: (...values: unknown[]) => {
+        bound = values;
+        return statement;
+      },
+      first: jest.fn(async () => {
+        if (/select\s+snapshot_json/i.test(query)) {
+          const key = String(bound[0] ?? "");
+          const snapshot_json = rows.get(key);
+          return snapshot_json ? { snapshot_json } : null;
+        }
+        return null;
+      }),
+      run: jest.fn(async () => {
+        if (/insert\s+into\s+chain_snapshots/i.test(query)) {
+          rows.set(String(bound[0] ?? ""), String(bound[1] ?? ""));
+        }
+        return {};
+      }),
+    };
+    return statement;
+  });
+  return {
+    rows,
+    db: {
+      exec,
+      prepare,
+    },
   };
 }
 
@@ -126,14 +170,23 @@ class TestResponse {
 
 class TestRequest {
   url: string;
+  headers: TestHeaders;
+  private readonly bodyText: string;
 
-  constructor(url: string) {
+  constructor(url: string, init?: { headers?: Record<string, string>; body?: string }) {
     this.url = String(url);
+    this.headers = new TestHeaders(init?.headers);
+    this.bodyText = init?.body ?? "";
+  }
+
+  async json(): Promise<unknown> {
+    return JSON.parse(this.bodyText);
   }
 }
 
 describe("chain cache Pages functions", () => {
   afterEach(() => {
+    clearChainCacheForTest();
     globalThis.fetch = originalFetch;
     globalThis.Request = originalRequest;
     globalThis.Response = originalResponse;
@@ -270,6 +323,88 @@ describe("chain cache Pages functions", () => {
     expect(diagnostics.source).toBe("live");
   });
 
+  test("reads D1 snapshots before KV snapshots", async () => {
+    const d1Snapshot: IndexedSnapshot<{ id: string }> = {
+      version: 1,
+      cachedAt: Date.now() - 120_000,
+      chainId: 11155111,
+      contract: PATH_NFT,
+      fromBlock: 1,
+      lastScannedBlock: 99,
+      items: [{ id: "d1" }],
+    };
+    const d1 = createD1Mock({ "d1-test": d1Snapshot });
+    const kvGet = jest.fn(async () => {
+      throw new Error("KV should not be read when D1 has the snapshot");
+    });
+    const diagnostics = createChainCacheDiagnostics("d1-test");
+
+    const snapshot = await readSnapshot<{ id: string }>(
+      {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_CHAIN_DATA_KV: {
+          get: kvGet,
+          put: jest.fn(),
+        },
+      },
+      "d1-test",
+      diagnostics,
+    );
+
+    expect(snapshot?.items).toEqual([{ id: "d1" }]);
+    expect(kvGet).not.toHaveBeenCalled();
+    expect(diagnostics.source).toBe("d1");
+    expect(diagnostics.dbRead).toBe(1);
+    expect(diagnostics.kvRead).toBe(0);
+  });
+
+  test("serves pulse auction D1 read model without live RPC", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const d1Snapshot: IndexedSnapshot<{
+      key: string;
+      atMs: number;
+      amount: { raw: { low: string; high: string }; dec: string };
+    }> = {
+      version: 1,
+      cachedAt: Date.now() - 120_000,
+      chainId: 11155111,
+      contract: PULSE_AUCTION,
+      fromBlock: 10854123,
+      lastScannedBlock: 10870000,
+      items: [
+        {
+          key: "tx:cached",
+          atMs: 1_780_000_000_000,
+          amount: { raw: { low: "1", high: "0" }, dec: "1" },
+        },
+      ],
+    };
+    const d1 = createD1Mock({ "pulse-auction:v1:sepolia": d1Snapshot });
+    const fetchMock = jest.fn(async () => {
+      throw new Error("live RPC should not be called for a D1 read model hit");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onPulseAuctionGet({
+      request: new Request("https://preview.inshell.art/api/pulse-auction"),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        CHAIN_CACHE_DIAGNOSTICS: "1",
+      },
+    });
+    const payload = (await response.json()) as { bids?: Array<{ key: string }> };
+
+    expect(response.status).toBe(200);
+    expect(payload.bids?.map((bid) => bid.key)).toEqual(["tx:cached"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.headers.get("x-chain-cache-source")).toBe("d1");
+    expect(response.headers.get("x-db-read")).toBe("1");
+    expect(response.headers.get("x-live-rpc-calls")).toBe("0");
+  });
+
   test("skips KV writes when snapshot content is unchanged and recent", async () => {
     const put = jest.fn(async () => undefined);
     const waited: Promise<unknown>[] = [];
@@ -312,6 +447,119 @@ describe("chain cache Pages functions", () => {
 
     expect(put).not.toHaveBeenCalled();
     expect(diagnostics.kvWrite).toBe(0);
+  });
+
+  test("writes changed snapshots to D1 read model", async () => {
+    const d1 = createD1Mock();
+    const waited: Promise<unknown>[] = [];
+    const previous: IndexedSnapshot<{ id: string }> = {
+      version: 1,
+      cachedAt: Date.now(),
+      chainId: 11155111,
+      contract: PATH_NFT,
+      fromBlock: 1,
+      lastScannedBlock: 10,
+      items: [{ id: "1" }],
+    };
+    const next: IndexedSnapshot<{ id: string }> = {
+      ...previous,
+      cachedAt: Date.now() + 1000,
+      lastScannedBlock: 20,
+    };
+    const diagnostics = createChainCacheDiagnostics("d1-write-test");
+
+    await writeSnapshot(
+      {
+        request: { url: "https://preview.inshell.art/api/path-tokens" } as Request,
+        env: { INSHELL_CHAIN_DATA_DB: d1.db },
+        waitUntil: (promise) => {
+          waited.push(promise);
+        },
+      },
+      "d1-write-test",
+      next,
+      0,
+      diagnostics,
+      previous,
+    );
+    await Promise.all(waited);
+    const stored = JSON.parse(d1.rows.get("d1-write-test") ?? "{}") as IndexedSnapshot<{ id: string }>;
+
+    expect(stored.lastScannedBlock).toBe(20);
+    expect(diagnostics.dbWrite).toBe(1);
+  });
+
+  test("public tx refresh updates the pulse auction read model", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const txHash = `0x${"abc".padStart(64, "0")}`;
+    const d1 = createD1Mock({
+      "pulse-auction:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PULSE_AUCTION,
+        fromBlock: 10854123,
+        lastScannedBlock: 10860000,
+        items: [],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method?: string;
+      };
+      if (body.method === "eth_getTransactionReceipt") {
+        return rpcResponse({
+          transactionHash: txHash,
+          to: PULSE_AUCTION,
+          blockNumber: "0xa5a7ec",
+          status: "0x1",
+        });
+      }
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse("0xa5a7ef");
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcResponse([
+          {
+            address: PULSE_AUCTION,
+            blockNumber: "0xa5a7ec",
+            data: `0x${word(12n)}${word(1_780_000_000n)}${word(1_779_000_000n)}${word(3n)}`,
+            logIndex: "0x2",
+            topics: [PULSE_SALE_TOPIC, addressTopic(OWNER), tokenTopic(1n)],
+            transactionHash: txHash,
+          },
+        ]);
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerRefreshPost({
+      request: new Request("https://preview.inshell.art/api/indexer/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ target: "pulse-auction", tx: txHash }),
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        CHAIN_CACHE_DIAGNOSTICS: "1",
+      },
+    });
+    const payload = (await response.json()) as { ok?: boolean; results?: Array<{ items: number }> };
+    const stored = JSON.parse(d1.rows.get("pulse-auction:v1:sepolia") ?? "{}") as {
+      items?: Array<{ txHash?: string; amount?: { dec?: string } }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.results?.[0]?.items).toBe(1);
+    expect(stored.items?.[0]?.txHash).toBe(txHash);
+    expect(stored.items?.[0]?.amount?.dec).toBe("12");
+    expect(response.headers.get("x-live-rpc-calls")).toBe("3");
   });
 
   test("writes KV when snapshot content changes", async () => {

--- a/functions/api/chain-cache.ts
+++ b/functions/api/chain-cache.ts
@@ -3,6 +3,17 @@ type KVNamespaceLike = {
   put: (key: string, value: string, options?: { expirationTtl?: number }) => Promise<void>;
 };
 
+type D1PreparedStatementLike = {
+  bind: (...values: unknown[]) => D1PreparedStatementLike;
+  first: <T = unknown>() => Promise<T | null>;
+  run: () => Promise<unknown>;
+};
+
+type D1DatabaseLike = {
+  exec?: (query: string) => Promise<unknown>;
+  prepare: (query: string) => D1PreparedStatementLike;
+};
+
 export type ChainCacheEnv = {
   PRIVATE_FALLBACK_RPC_UPSTREAM?: string;
   PUBLIC_FALLBACK_RPC_UPSTREAM?: string;
@@ -25,6 +36,8 @@ export type ChainCacheEnv = {
   MSG_HUB_RPC_USAGE_ENDPOINT?: string;
   MSG_HUB_RPC_USAGE_TOKEN?: string;
   INSHELL_CHAIN_DATA_KV?: KVNamespaceLike;
+  INSHELL_CHAIN_DATA_DB?: D1DatabaseLike;
+  INSHELL_INDEXER_REFRESH_TOKEN?: string;
   CHAIN_CACHE_DIAGNOSTICS?: string;
 };
 
@@ -65,13 +78,15 @@ type EdgeCachedValue<T> = {
   value: T;
 };
 
-type ChainCacheSource = "memory" | "edge" | "kv" | "live";
+type ChainCacheSource = "memory" | "edge" | "d1" | "kv" | "live";
 
 export type ChainCacheDiagnostics = {
   source: ChainCacheSource;
   key: string;
   kvRead: 0 | 1;
   kvWrite: 0 | 1;
+  dbRead: 0 | 1;
+  dbWrite: 0 | 1;
   liveRpcCalls: number;
   snapshotBlock?: number;
 };
@@ -91,6 +106,7 @@ const EDGE_CACHE_PREFIX = "https://inshell.local/chain-cache/";
 const RESPONSE_CACHE_PREFIX = "https://inshell.local/chain-response/";
 const KV_SNAPSHOT_TTL_SECONDS = 30 * 24 * 60 * 60;
 const KV_WRITE_MIN_INTERVAL_SECONDS = 10 * 60;
+const D1_SNAPSHOT_TABLE = "chain_snapshots";
 
 export const SEPOLIA_CHAIN_ID = 11155111;
 export const PATH_NFT_ADDRESS = "0x84915746a1f06850CF41a3E90C60c2DcA3fa116D";
@@ -143,6 +159,13 @@ export type ChainLog = {
   logIndex?: string;
   removed?: boolean;
   topics: string[];
+  transactionHash?: string;
+};
+
+export type TransactionReceiptLike = {
+  blockNumber?: string;
+  status?: string;
+  to?: string;
   transactionHash?: string;
 };
 
@@ -449,6 +472,21 @@ export async function getLogsChunked(
   return out;
 }
 
+export async function getTransactionReceipt(
+  env: ChainCacheEnv,
+  service: "path" | "thought",
+  stats: RpcStats,
+  txHash: string,
+) {
+  return rpcCall<TransactionReceiptLike | null>(
+    env,
+    service,
+    stats,
+    "eth_getTransactionReceipt",
+    [txHash],
+  );
+}
+
 export async function readSnapshot<T>(
   env: ChainCacheEnv,
   key: string,
@@ -471,6 +509,16 @@ export async function readSnapshot<T>(
       diagnostics.snapshotBlock = snapshotBlock(edge);
     }
     return edge;
+  }
+
+  const fromD1 = await readD1Snapshot<T>(env, key, diagnostics);
+  if (fromD1) {
+    memoryCache.set(key, { cachedAt: Date.now(), value: fromD1 });
+    if (diagnostics) {
+      diagnostics.source = "d1";
+      diagnostics.snapshotBlock = snapshotBlock(fromD1);
+    }
+    return fromD1;
   }
 
   try {
@@ -502,6 +550,10 @@ export async function writeSnapshot<T>(
   if (diagnostics) diagnostics.snapshotBlock = snapshot.lastScannedBlock;
 
   const tasks: Array<Promise<unknown>> = [writeEdgeCache(key, snapshot, edgeTtlSeconds)];
+  if (ctx.env.INSHELL_CHAIN_DATA_DB && shouldWriteD1Snapshot(previous ?? null, snapshot)) {
+    if (diagnostics) diagnostics.dbWrite = 1;
+    tasks.push(writeD1Snapshot(ctx.env, key, snapshot));
+  }
   const shouldPersist = shouldWriteKvSnapshot(previous ?? null, snapshot);
   if (shouldPersist && ctx.env.INSHELL_CHAIN_DATA_KV) {
     if (diagnostics) diagnostics.kvWrite = 1;
@@ -522,8 +574,14 @@ export function createChainCacheDiagnostics(key: string): ChainCacheDiagnostics 
     key,
     kvRead: 0,
     kvWrite: 0,
+    dbRead: 0,
+    dbWrite: 0,
     liveRpcCalls: 0,
   };
+}
+
+export function readModelEnabled(env: ChainCacheEnv) {
+  return Boolean(env.INSHELL_CHAIN_DATA_DB);
 }
 
 export async function readResponseCache(
@@ -574,6 +632,8 @@ export function withChainCacheDiagnostics(
   out.headers.set("x-chain-cache-key", diagnostics.key);
   out.headers.set("x-kv-read", String(diagnostics.kvRead));
   out.headers.set("x-kv-write", String(diagnostics.kvWrite));
+  out.headers.set("x-db-read", String(diagnostics.dbRead));
+  out.headers.set("x-db-write", String(diagnostics.dbWrite));
   out.headers.set("x-live-rpc-calls", String(liveRpcCalls));
   if (typeof block === "number") {
     out.headers.set("x-cache-snapshot-block", String(block));
@@ -690,6 +750,10 @@ export function topicToBigInt(topic: string | undefined) {
 export function hexToNumber(value: string | undefined) {
   if (!value) return 0;
   return Number(BigInt(value));
+}
+
+export function isTxHash(value: string | null | undefined) {
+  return typeof value === "string" && /^0x[a-fA-F0-9]{64}$/.test(value);
 }
 
 export function lower(value: string | undefined) {
@@ -828,6 +892,11 @@ function hexToBytes(hex: string) {
 }
 
 const memoryCache = new Map<string, EdgeCachedValue<unknown>>();
+const ensuredD1Tables = new WeakSet<object>();
+
+export function clearChainCacheForTest() {
+  memoryCache.clear();
+}
 
 async function readEdgeCache<T>(key: string): Promise<T | null> {
   const cache = (globalThis as any).caches?.default;
@@ -873,6 +942,80 @@ function snapshotBlock(value: unknown) {
   return typeof block === "number" && Number.isFinite(block) ? block : undefined;
 }
 
+async function ensureD1SnapshotTable(db: D1DatabaseLike) {
+  if (!db.exec || ensuredD1Tables.has(db as object)) return;
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (
+      key TEXT PRIMARY KEY,
+      snapshot_json TEXT NOT NULL,
+      cached_at INTEGER NOT NULL,
+      last_scanned_block INTEGER NOT NULL,
+      content_hash TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  ensuredD1Tables.add(db as object);
+}
+
+async function readD1Snapshot<T>(
+  env: ChainCacheEnv,
+  key: string,
+  diagnostics?: ChainCacheDiagnostics,
+): Promise<IndexedSnapshot<T> | null> {
+  const db = env.INSHELL_CHAIN_DATA_DB;
+  if (!db) return null;
+  try {
+    await ensureD1SnapshotTable(db);
+    if (diagnostics) diagnostics.dbRead = 1;
+    const row = await db
+      .prepare(`SELECT snapshot_json FROM ${D1_SNAPSHOT_TABLE} WHERE key = ?1`)
+      .bind(key)
+      .first<{ snapshot_json?: string }>();
+    const raw = row?.snapshot_json;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") return parsed as IndexedSnapshot<T>;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function writeD1Snapshot<T>(
+  env: ChainCacheEnv,
+  key: string,
+  snapshot: IndexedSnapshot<T>,
+) {
+  const db = env.INSHELL_CHAIN_DATA_DB;
+  if (!db) return;
+  try {
+    await ensureD1SnapshotTable(db);
+    await db
+      .prepare(`
+        INSERT INTO ${D1_SNAPSHOT_TABLE}
+          (key, snapshot_json, cached_at, last_scanned_block, content_hash, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(key) DO UPDATE SET
+          snapshot_json = excluded.snapshot_json,
+          cached_at = excluded.cached_at,
+          last_scanned_block = excluded.last_scanned_block,
+          content_hash = excluded.content_hash,
+          updated_at = excluded.updated_at
+      `)
+      .bind(
+        key,
+        JSON.stringify(snapshot),
+        snapshot.cachedAt,
+        snapshot.lastScannedBlock,
+        snapshotContent(snapshot),
+        Date.now(),
+      )
+      .run();
+  } catch {
+    // D1 is a read-model optimization; edge/KV/live fallback still serve the route.
+  }
+}
+
 function shouldWriteKvSnapshot<T>(
   previous: IndexedSnapshot<T> | null,
   snapshot: IndexedSnapshot<T>,
@@ -880,6 +1023,15 @@ function shouldWriteKvSnapshot<T>(
   if (!previous) return true;
   if (snapshotContent(previous) !== snapshotContent(snapshot)) return true;
   return Date.now() - previous.cachedAt >= KV_WRITE_MIN_INTERVAL_SECONDS * 1000;
+}
+
+function shouldWriteD1Snapshot<T>(
+  previous: IndexedSnapshot<T> | null,
+  snapshot: IndexedSnapshot<T>,
+) {
+  if (!previous) return true;
+  if (previous.lastScannedBlock !== snapshot.lastScannedBlock) return true;
+  return snapshotContent(previous) !== snapshotContent(snapshot);
 }
 
 function snapshotContent<T>(snapshot: IndexedSnapshot<T>) {

--- a/functions/api/indexer/refresh.ts
+++ b/functions/api/indexer/refresh.ts
@@ -1,0 +1,155 @@
+import {
+  createChainCacheDiagnostics,
+  createStats,
+  emitUsage,
+  isTxHash,
+  json,
+  onOptions,
+  withChainCacheDiagnostics,
+  type ChainCacheDiagnostics,
+  type IndexedSnapshot,
+  type PagesContextLike,
+} from "../chain-cache";
+import { refreshPathTokens } from "../path-tokens";
+import { refreshPulseAuction, refreshPulseAuctionForTx } from "../pulse-auction";
+import { refreshThoughtGallery } from "../thought-gallery";
+
+type RefreshTarget = "pulse-auction" | "path-tokens" | "thought-gallery" | "all";
+
+type RefreshResult = {
+  target: Exclude<RefreshTarget, "all">;
+  cachedAt: number;
+  lastScannedBlock: number;
+  items: number;
+  source: string;
+};
+
+export const onRequestOptions = onOptions;
+
+export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
+  const url = new globalThis.URL(ctx.request.url);
+  const body = await readJsonBody(ctx.request);
+  const target = readString(body.target) || url.searchParams.get("target") || "all";
+  const txHash = readString(body.tx) || url.searchParams.get("tx") || "";
+  const normalizedTarget = normalizeTarget(target);
+  if (!normalizedTarget) {
+    return json(400, { error: "invalid refresh target" });
+  }
+
+  const targetedPublicRefresh =
+    normalizedTarget === "pulse-auction" && isTxHash(txHash);
+  if (!targetedPublicRefresh && !isAuthorized(ctx)) {
+    return json(401, { error: "indexer refresh token required" });
+  }
+
+  const results: RefreshResult[] = [];
+  const diagnostics: ChainCacheDiagnostics[] = [];
+  const statsList: ReturnType<typeof createStats>[] = [];
+  const snapshots: IndexedSnapshot<unknown>[] = [];
+  try {
+    if (normalizedTarget === "pulse-auction" || normalizedTarget === "all") {
+      const currentDiagnostics = createChainCacheDiagnostics("pulse-auction:v1:sepolia");
+      const stats = createStats("path", "indexer-refresh:pulse-auction", ctx.env);
+      const snapshot = targetedPublicRefresh
+        ? await refreshPulseAuctionForTx(ctx, stats, currentDiagnostics, txHash)
+        : await refreshPulseAuction(ctx, stats, currentDiagnostics);
+      emitUsage(ctx, stats);
+      diagnostics.push(currentDiagnostics);
+      statsList.push(stats);
+      snapshots.push(snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("pulse-auction", snapshot, currentDiagnostics));
+    }
+
+    if (normalizedTarget === "path-tokens" || normalizedTarget === "all") {
+      const currentDiagnostics = createChainCacheDiagnostics("path-tokens:v1:sepolia");
+      const stats = createStats("path", "indexer-refresh:path-tokens", ctx.env);
+      const snapshot = await refreshPathTokens(ctx, stats, currentDiagnostics);
+      emitUsage(ctx, stats);
+      diagnostics.push(currentDiagnostics);
+      statsList.push(stats);
+      snapshots.push(snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("path-tokens", snapshot, currentDiagnostics));
+    }
+
+    if (normalizedTarget === "thought-gallery" || normalizedTarget === "all") {
+      const currentDiagnostics = createChainCacheDiagnostics("thought-gallery:v1:sepolia");
+      const stats = createStats("thought", "indexer-refresh:thought-gallery", ctx.env);
+      const snapshot = await refreshThoughtGallery(ctx, stats, currentDiagnostics);
+      emitUsage(ctx, stats);
+      diagnostics.push(currentDiagnostics);
+      statsList.push(stats);
+      snapshots.push(snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("thought-gallery", snapshot, currentDiagnostics));
+    }
+  } catch {
+    for (const stats of statsList) emitUsage(ctx, stats);
+    return json(500, { error: "indexer refresh failed" });
+  }
+
+  const response = json(200, {
+    ok: true,
+    target: normalizedTarget,
+    tx: txHash || undefined,
+    results,
+  });
+  const firstDiagnostics = diagnostics[0];
+  if (!firstDiagnostics) return response;
+  return withChainCacheDiagnostics(
+    ctx,
+    response,
+    firstDiagnostics,
+    statsList[0],
+    snapshots[0],
+  );
+}
+
+function normalizeTarget(value: string): RefreshTarget | null {
+  if (
+    value === "pulse-auction" ||
+    value === "path-tokens" ||
+    value === "thought-gallery" ||
+    value === "all"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function isAuthorized(ctx: PagesContextLike) {
+  const expected = ctx.env.INSHELL_INDEXER_REFRESH_TOKEN?.trim();
+  if (!expected) return false;
+  const auth = ctx.request.headers.get("authorization") ?? "";
+  const bearer = auth.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  const header = ctx.request.headers.get("x-inshell-indexer-token")?.trim();
+  return bearer === expected || header === expected;
+}
+
+async function readJsonBody(request: Request): Promise<Record<string, unknown>> {
+  if (!request.headers.get("content-type")?.includes("application/json")) return {};
+  try {
+    const parsed = await request.json();
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resultFor<T>(
+  target: Exclude<RefreshTarget, "all">,
+  snapshot: IndexedSnapshot<T>,
+  diagnostics: ChainCacheDiagnostics,
+): RefreshResult {
+  return {
+    target,
+    cachedAt: snapshot.cachedAt,
+    lastScannedBlock: snapshot.lastScannedBlock,
+    items: snapshot.items.length,
+    source: diagnostics.source,
+  };
+}

--- a/functions/api/path-tokens.ts
+++ b/functions/api/path-tokens.ts
@@ -17,6 +17,7 @@ import {
   ownerOfData,
   parseMetadata,
   pruneReorgWindow,
+  readModelEnabled,
   readSnapshot,
   readResponseCache,
   refreshFromBlock,
@@ -51,22 +52,18 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
     return withChainCacheDiagnostics(ctx, cached, diagnostics);
   }
 
+  const previous = await readSnapshot<PathTokenApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (previous && readModelEnabled(ctx.env)) {
+    const response = responseFromSnapshot(previous);
+    writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, previous.lastScannedBlock);
+    return withChainCacheDiagnostics(ctx, response, diagnostics, undefined, previous);
+  }
+
   const stats = createStats("path", "path-tokens", ctx.env);
   try {
-    const snapshot = await loadPathTokens(ctx.env, ctx, stats, diagnostics);
+    const snapshot = await loadPathTokens(ctx.env, ctx, stats, diagnostics, previous);
     emitUsage(ctx, stats);
-    const response = json(
-      200,
-      {
-        cachedAt: snapshot.cachedAt,
-        chainId: snapshot.chainId,
-        contract: snapshot.contract,
-        fromBlock: snapshot.fromBlock,
-        lastScannedBlock: snapshot.lastScannedBlock,
-        items: snapshot.items,
-      },
-      RESPONSE_CACHE_SECONDS,
-    );
+    const response = responseFromSnapshot(snapshot);
     writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, snapshot.lastScannedBlock);
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
   } catch {
@@ -82,9 +79,14 @@ async function loadPathTokens(
   ctx: PagesContextLike,
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
+  previousOverride?: IndexedSnapshot<PathTokenApiItem> | null,
+  force = false,
 ): Promise<IndexedSnapshot<PathTokenApiItem>> {
-  const previous = await readSnapshot<PathTokenApiItem>(env, SNAPSHOT_KEY, diagnostics);
-  if (previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+  const previous =
+    previousOverride === undefined
+      ? await readSnapshot<PathTokenApiItem>(env, SNAPSHOT_KEY, diagnostics)
+      : previousOverride;
+  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
     return previous;
   }
 
@@ -159,6 +161,37 @@ async function loadPathTokens(
   };
   await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
   return snapshot;
+}
+
+export async function refreshPathTokens(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+) {
+  const snapshot = await loadPathTokens(ctx.env, ctx, stats, diagnostics, undefined, true);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
+function responseFromSnapshot(snapshot: IndexedSnapshot<PathTokenApiItem>) {
+  return json(
+    200,
+    {
+      cachedAt: snapshot.cachedAt,
+      chainId: snapshot.chainId,
+      contract: snapshot.contract,
+      fromBlock: snapshot.fromBlock,
+      lastScannedBlock: snapshot.lastScannedBlock,
+      items: snapshot.items,
+    },
+    RESPONSE_CACHE_SECONDS,
+  );
 }
 
 function normalizeAddressResult(result: string) {

--- a/functions/api/pulse-auction.ts
+++ b/functions/api/pulse-auction.ts
@@ -7,10 +7,13 @@ import {
   emitUsage,
   getBlockNumber,
   getLogsChunked,
+  getTransactionReceipt,
   hexToNumber,
+  isTxHash,
   json,
   onOptions,
   pruneReorgWindow,
+  readModelEnabled,
   readSnapshot,
   readResponseCache,
   refreshFromBlock,
@@ -44,22 +47,18 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
     return withChainCacheDiagnostics(ctx, cached, diagnostics);
   }
 
+  const previous = await readSnapshot<PulseBidApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (previous && readModelEnabled(ctx.env)) {
+    const response = responseFromSnapshot(previous);
+    writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, previous.lastScannedBlock);
+    return withChainCacheDiagnostics(ctx, response, diagnostics, undefined, previous);
+  }
+
   const stats = createStats("path", "pulse-auction", ctx.env);
   try {
-    const snapshot = await loadPulseAuction(ctx.env, ctx, stats, diagnostics);
+    const snapshot = await loadPulseAuction(ctx.env, ctx, stats, diagnostics, previous);
     emitUsage(ctx, stats);
-    const response = json(
-      200,
-      {
-        cachedAt: snapshot.cachedAt,
-        chainId: snapshot.chainId,
-        contract: snapshot.contract,
-        fromBlock: snapshot.fromBlock,
-        lastScannedBlock: snapshot.lastScannedBlock,
-        bids: snapshot.items,
-      },
-      RESPONSE_CACHE_SECONDS,
-    );
+    const response = responseFromSnapshot(snapshot);
     writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, snapshot.lastScannedBlock);
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
   } catch {
@@ -75,9 +74,14 @@ async function loadPulseAuction(
   ctx: PagesContextLike,
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
+  previousOverride?: IndexedSnapshot<PulseBidApiItem> | null,
+  force = false,
 ): Promise<IndexedSnapshot<PulseBidApiItem>> {
-  const previous = await readSnapshot<PulseBidApiItem>(env, SNAPSHOT_KEY, diagnostics);
-  if (previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+  const previous =
+    previousOverride === undefined
+      ? await readSnapshot<PulseBidApiItem>(env, SNAPSHOT_KEY, diagnostics)
+      : previousOverride;
+  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
     return previous;
   }
 
@@ -90,6 +94,86 @@ async function loadPulseAuction(
     topics: [PULSE_SALE_TOPIC],
   });
 
+  const snapshot = mergePulseSnapshot(previous, logs, refreshStart, latestBlock);
+  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
+  return snapshot;
+}
+
+export async function refreshPulseAuction(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+) {
+  const snapshot = await loadPulseAuction(ctx.env, ctx, stats, diagnostics, undefined, true);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
+export async function refreshPulseAuctionForTx(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  txHash: string,
+) {
+  if (!isTxHash(txHash)) throw new Error("invalid transaction hash");
+  const normalizedTxHash = txHash.toLowerCase();
+  const previous = await readSnapshot<PulseBidApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (previous?.items.some((item) => item.txHash?.toLowerCase() === normalizedTxHash)) {
+    return previous;
+  }
+
+  const receipt = await getTransactionReceipt(ctx.env, "path", stats, txHash);
+  if ((receipt?.to ?? "").toLowerCase() !== PULSE_AUCTION_ADDRESS.toLowerCase()) {
+    throw new Error("transaction is not a pulse auction transaction");
+  }
+  if (receipt.status && receipt.status !== "0x1") {
+    throw new Error("transaction did not succeed");
+  }
+  const txBlock = hexToNumber(receipt?.blockNumber);
+  if (!Number.isFinite(txBlock) || txBlock <= 0) {
+    throw new Error("transaction receipt unavailable");
+  }
+
+  const latestBlock = await getBlockNumber(ctx.env, "path", stats);
+  const refreshStart = Math.max(PULSE_AUCTION_DEPLOY_BLOCK, txBlock - 3);
+  const refreshEnd = Math.min(latestBlock, txBlock + 3);
+  const logs = await getLogsChunked(ctx.env, "path", stats, {
+    address: PULSE_AUCTION_ADDRESS,
+    fromBlock: refreshStart,
+    toBlock: refreshEnd,
+    topics: [PULSE_SALE_TOPIC],
+  });
+
+  const previousLastScanned = previous?.lastScannedBlock ?? refreshEnd;
+  const continuousRefresh =
+    !previous || refreshStart <= previous.lastScannedBlock + 1;
+  const nextLastScanned = continuousRefresh
+    ? Math.max(previousLastScanned, refreshEnd)
+    : previousLastScanned;
+  const snapshot = mergePulseSnapshot(previous, logs, refreshStart, nextLastScanned);
+  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
+function mergePulseSnapshot(
+  previous: IndexedSnapshot<PulseBidApiItem> | null | undefined,
+  logs: ChainLog[],
+  refreshStart: number,
+  lastScannedBlock: number,
+) {
   const bids = new Map<string, PulseBidApiItem>();
   for (const item of pruneReorgWindow(previous?.items ?? [], refreshStart)) {
     bids.set(item.key, item);
@@ -106,11 +190,25 @@ async function loadPulseAuction(
     chainId: 11155111,
     contract: PULSE_AUCTION_ADDRESS,
     fromBlock: PULSE_AUCTION_DEPLOY_BLOCK,
-    lastScannedBlock: latestBlock,
+    lastScannedBlock,
     items: [...bids.values()].sort((left, right) => left.atMs - right.atMs),
   };
-  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
   return snapshot;
+}
+
+function responseFromSnapshot(snapshot: IndexedSnapshot<PulseBidApiItem>) {
+  return json(
+    200,
+    {
+      cachedAt: snapshot.cachedAt,
+      chainId: snapshot.chainId,
+      contract: snapshot.contract,
+      fromBlock: snapshot.fromBlock,
+      lastScannedBlock: snapshot.lastScannedBlock,
+      bids: snapshot.items,
+    },
+    RESPONSE_CACHE_SECONDS,
+  );
 }
 
 function decodeSaleLog(log: ChainLog): PulseBidApiItem | null {

--- a/functions/api/thought-gallery.ts
+++ b/functions/api/thought-gallery.ts
@@ -20,6 +20,7 @@ import {
   provenanceData,
   pruneReorgWindow,
   rawTextData,
+  readModelEnabled,
   readSnapshot,
   readResponseCache,
   refreshFromBlock,
@@ -53,22 +54,18 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
     return withChainCacheDiagnostics(ctx, cached, diagnostics);
   }
 
+  const previous = await readSnapshot<ThoughtGalleryApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (previous && readModelEnabled(ctx.env)) {
+    const response = responseFromSnapshot(previous);
+    writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, previous.lastScannedBlock);
+    return withChainCacheDiagnostics(ctx, response, diagnostics, undefined, previous);
+  }
+
   const stats = createStats("thought", "thought-gallery", ctx.env);
   try {
-    const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics);
+    const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, previous);
     emitUsage(ctx, stats);
-    const response = json(
-      200,
-      {
-        cachedAt: snapshot.cachedAt,
-        chainId: snapshot.chainId,
-        contract: snapshot.contract,
-        fromBlock: snapshot.fromBlock,
-        lastScannedBlock: snapshot.lastScannedBlock,
-        thoughts: snapshot.items,
-      },
-      RESPONSE_CACHE_SECONDS,
-    );
+    const response = responseFromSnapshot(snapshot);
     writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, snapshot.lastScannedBlock);
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
   } catch {
@@ -84,9 +81,14 @@ async function loadThoughtGallery(
   ctx: PagesContextLike,
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
+  previousOverride?: IndexedSnapshot<ThoughtGalleryApiItem> | null,
+  force = false,
 ): Promise<IndexedSnapshot<ThoughtGalleryApiItem>> {
-  const previous = await readSnapshot<ThoughtGalleryApiItem>(env, SNAPSHOT_KEY, diagnostics);
-  if (previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+  const previous =
+    previousOverride === undefined
+      ? await readSnapshot<ThoughtGalleryApiItem>(env, SNAPSHOT_KEY, diagnostics)
+      : previousOverride;
+  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
     return previous;
   }
 
@@ -121,6 +123,37 @@ async function loadThoughtGallery(
   };
   await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
   return snapshot;
+}
+
+export async function refreshThoughtGallery(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+) {
+  const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, undefined, true);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
+function responseFromSnapshot(snapshot: IndexedSnapshot<ThoughtGalleryApiItem>) {
+  return json(
+    200,
+    {
+      cachedAt: snapshot.cachedAt,
+      chainId: snapshot.chainId,
+      contract: snapshot.contract,
+      fromBlock: snapshot.fromBlock,
+      lastScannedBlock: snapshot.lastScannedBlock,
+      thoughts: snapshot.items,
+    },
+    RESPONSE_CACHE_SECONDS,
+  );
 }
 
 async function readThoughtFromLog(


### PR DESCRIPTION
Promotes staging to main for the D1-backed chain read model refresh path.\n\nChanges:\n- add D1 chain snapshot read model support before KV/live fallback\n- add protected /api/indexer/refresh for OPS scheduled refreshes\n- add tx-scoped pulse auction refresh after PATH mint\n- add diagnostics and regression coverage for D1/cache behavior\n\nValidation already run on staging:\n- GitHub test: pass\n- CodeQL: pass\n- deploy-pages staging: pass