### PR TITLE
Promote staging PATH RPC cleanup

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
       CLOUDFLARE_PAGES_PROJECT_HOME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_HOME || 'inshell-art' }}
       VITE_DEPLOY_ENV: ${{ github.event.inputs.branch == 'staging' && 'preview' || 'production' }}
       VITE_NETWORK: ${{ vars.VITE_NETWORK || 'sepolia' }}
-      VITE_ETH_RPC: ${{ github.event.inputs.branch == 'staging' && '/api/path-rpc' || vars.VITE_ETH_RPC || '/api/path-rpc' }}
+      VITE_PATH_RPC_URL: ${{ github.event.inputs.branch == 'staging' && '/api/path-rpc' || vars.VITE_PATH_RPC_URL || vars.VITE_ETH_RPC || '/api/path-rpc' }}
       VITE_WALLET_CHAIN_RPC_URL: ${{ vars.VITE_WALLET_CHAIN_RPC_URL || 'https://ethereum-sepolia-rpc.publicnode.com' }}
       VITE_WALLETCONNECT_PROJECT_ID: ${{ vars.VITE_WALLETCONNECT_PROJECT_ID }}
       VITE_PUBLIC_LAUNCH_MODE: ${{ vars.VITE_PUBLIC_LAUNCH_MODE || 'sepolia_invite' }}
@@ -70,7 +70,7 @@ jobs:
           test -n "$CLOUDFLARE_PAGES_PROJECT_HOME"
           test -n "$CLOUDFLARE_API_TOKEN"
           test -n "$CLOUDFLARE_ACCOUNT_ID"
-          test -n "$VITE_ETH_RPC"
+          test -n "$VITE_PATH_RPC_URL"
           test -n "$VITE_WALLET_CHAIN_RPC_URL"
           test -n "$VITE_THOUGHT_URL"
           test -n "$VITE_GALLERY_URL"
@@ -103,7 +103,7 @@ jobs:
       CLOUDFLARE_PAGES_PROJECT_THOUGHT: ${{ vars.CLOUDFLARE_PAGES_PROJECT_THOUGHT || 'thought-inshell-art' }}
       VITE_DEPLOY_ENV: ${{ github.event.inputs.branch == 'staging' && 'preview' || 'production' }}
       VITE_NETWORK: ${{ vars.VITE_NETWORK || 'sepolia' }}
-      VITE_ETH_RPC: ${{ github.event.inputs.branch == 'staging' && '/api/path-rpc' || vars.VITE_ETH_RPC || '/api/path-rpc' }}
+      VITE_PATH_RPC_URL: ${{ github.event.inputs.branch == 'staging' && '/api/path-rpc' || vars.VITE_PATH_RPC_URL || vars.VITE_ETH_RPC || '/api/path-rpc' }}
       VITE_THOUGHT_RPC_URL: ${{ github.event.inputs.branch == 'staging' && '/api/thought-rpc' || vars.VITE_THOUGHT_RPC_URL || '/api/thought-rpc' }}
       VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED: ${{ vars.VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED || 'true' }}
       VITE_THOUGHT_PREVIEW_ENDPOINT_URL: ${{ github.event.inputs.branch == 'staging' && '/api/thought-preview' || vars.VITE_THOUGHT_PREVIEW_ENDPOINT_URL || '/api/thought-preview' }}
@@ -138,7 +138,7 @@ jobs:
           test -n "$CLOUDFLARE_PAGES_PROJECT_THOUGHT"
           test -n "$CLOUDFLARE_API_TOKEN"
           test -n "$CLOUDFLARE_ACCOUNT_ID"
-          test -n "$VITE_ETH_RPC"
+          test -n "$VITE_PATH_RPC_URL"
           test -n "$VITE_THOUGHT_RPC_URL"
           test -n "$VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED"
           test -n "$VITE_THOUGHT_PREVIEW_ENDPOINT_URL"

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -4,10 +4,10 @@
   "version": "2.0.0",
   "type": "module",
   "scripts": {
-    "dev": "VITE_NETWORK=sepolia VITE_PUBLIC_LAUNCH_MODE=sepolia_invite VITE_ETH_RPC=/api/path-rpc VITE_THOUGHT_URL=http://127.0.0.1:5174/ VITE_GALLERY_URL=http://127.0.0.1:5174/gallery vite --host 127.0.0.1 --port 5173 --strictPort",
+    "dev": "VITE_NETWORK=sepolia VITE_PUBLIC_LAUNCH_MODE=sepolia_invite VITE_PATH_RPC_URL=/api/path-rpc VITE_THOUGHT_URL=http://127.0.0.1:5174/ VITE_GALLERY_URL=http://127.0.0.1:5174/gallery vite --host 127.0.0.1 --port 5173 --strictPort",
     "dev:devnet": "vite --mode devnet --host 127.0.0.1 --port 5173 --strictPort",
     "build": "vite build",
-    "build:prod": "VITE_NETWORK=sepolia VITE_ETH_RPC=/api/path-rpc vite build --mode prod",
+    "build:prod": "VITE_NETWORK=sepolia VITE_PATH_RPC_URL=/api/path-rpc vite build --mode prod",
     "test": "jest",
     "test:fast": "jest --runTestsByPath tests/num.test.ts tests/pulseCurve.test.ts",
     "test:presepolia": "jest --runTestsByPath tests/App.test.tsx tests/pathTokens.test.ts tests/AuctionCanvas.test.tsx tests/middlewareFunction.test.ts",

--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -657,7 +657,8 @@ function resolveChainLabel(chainIdHex: string): string {
 
 function resolveAddChainParams(chainIdHex: string) {
   const normalized = chainIdHex.toLowerCase();
-  const rpcUrl = getEnvValue("VITE_ETH_RPC");
+  const rpcUrl =
+    getEnvValue("VITE_PATH_RPC_URL") ?? getEnvValue("VITE_ETH_RPC");
   const walletRpcUrl = getEnvValue("VITE_WALLET_CHAIN_RPC_URL");
   const rpcUrls = resolveWalletChainRpcUrls({
     chainId: parseChainId(normalized),
@@ -847,7 +848,7 @@ function useProtocolReleaseGuard(params: {
           const actualChainId = await getChainId(prov);
           if (actualChainId !== BigInt(releaseChainId)) {
             throw new Error(
-              `PATH release chain mismatch: expected ${releaseChainId}, RPC returned ${actualChainId.toString()}. Check VITE_ETH_RPC and VITE_NETWORK.`
+              `PATH release chain mismatch: expected ${releaseChainId}, RPC returned ${actualChainId.toString()}. Check VITE_PATH_RPC_URL and VITE_NETWORK.`
             );
           }
         }
@@ -855,7 +856,7 @@ function useProtocolReleaseGuard(params: {
         const code = await getCode(prov, address);
         if (!code || code === "0x") {
           throw new Error(
-            `No PulseAuction code at ${address} on the current RPC. Check VITE_ETH_RPC, VITE_NETWORK, and the imported PATH FE release.`
+            `No PulseAuction code at ${address} on the current RPC. Check VITE_PATH_RPC_URL, VITE_NETWORK, and the imported PATH FE release.`
           );
         }
 

--- a/apps/home/tests/AuctionCanvas.test.tsx
+++ b/apps/home/tests/AuctionCanvas.test.tsx
@@ -185,7 +185,7 @@ describe("AuctionCanvas", () => {
       VITE_PATH_ALLOW_DIRECT_AUCTION: "1",
       VITE_PAYMENT_TOKEN: TEST_PAYMENT_TOKEN,
       VITE_PAYMENT_TOKEN_SYMBOL: "ETH",
-      VITE_ETH_RPC: "https://ethereum-sepolia-rpc.publicnode.com",
+      VITE_PATH_RPC_URL: "https://ethereum-sepolia-rpc.publicnode.com",
     };
     mockCallContract.mockReset();
     mockGetBalance.mockReset();
@@ -333,7 +333,7 @@ describe("AuctionCanvas", () => {
       ...(globalThis as any).__VITE_ENV__,
       VITE_NETWORK: "devnet",
       VITE_EXPECTED_CHAIN_ID: "0x7a69",
-      VITE_ETH_RPC: "http://127.0.0.1:8546",
+      VITE_PATH_RPC_URL: "http://127.0.0.1:8546",
       VITE_WALLET_CHAIN_RPC_URL: "",
     };
     mockAuctionCore(mockUseAuctionCore, {
@@ -1991,7 +1991,7 @@ describe("AuctionCanvas", () => {
   test("switch CTA does not register the read-only dapp RPC with wallets", async () => {
     (globalThis as any).__VITE_ENV__ = {
       ...(globalThis as any).__VITE_ENV__,
-      VITE_ETH_RPC: "/api/eth-rpc",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
       VITE_WALLET_CHAIN_RPC_URL: "",
     };
     const request = jest
@@ -2026,7 +2026,7 @@ describe("AuctionCanvas", () => {
   test("switch CTA uses explicit wallet chain RPC when configured", async () => {
     (globalThis as any).__VITE_ENV__ = {
       ...(globalThis as any).__VITE_ENV__,
-      VITE_ETH_RPC: "/api/eth-rpc",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
       VITE_WALLET_CHAIN_RPC_URL: "https://wallet-rpc.example/sepolia",
     };
     const request = jest
@@ -2061,7 +2061,7 @@ describe("AuctionCanvas", () => {
   test("refreshes Sepolia wallet RPC before mint writes", async () => {
     (globalThis as any).__VITE_ENV__ = {
       ...(globalThis as any).__VITE_ENV__,
-      VITE_ETH_RPC: "/api/eth-rpc",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
       VITE_WALLET_CHAIN_RPC_URL: "",
     };
     const request = jest.fn().mockResolvedValue(null);
@@ -2098,7 +2098,7 @@ describe("AuctionCanvas", () => {
       VITE_PATH_ALLOW_DIRECT_AUCTION: "1",
       VITE_PAYMENT_TOKEN: TEST_PAYMENT_TOKEN,
       VITE_PAYMENT_TOKEN_SYMBOL: "ETH",
-      VITE_ETH_RPC: "http://127.0.0.1:8546",
+      VITE_PATH_RPC_URL: "http://127.0.0.1:8546",
       VITE_WALLET_CHAIN_RPC_URL: "",
       VITE_PUBLIC_LAUNCH_MODE: "local",
     };
@@ -2545,7 +2545,7 @@ describe("AuctionCanvas", () => {
       ...(globalThis as any).__VITE_ENV__,
       VITE_NETWORK: "devnet",
       VITE_EXPECTED_CHAIN_ID: "0x7a69",
-      VITE_ETH_RPC: "http://127.0.0.1:8546",
+      VITE_PATH_RPC_URL: "http://127.0.0.1:8546",
       VITE_WALLET_CHAIN_RPC_URL: "",
       VITE_PAYTOKEN: ZERO_ADDRESS,
       VITE_PUBLIC_LAUNCH_MODE: "local",
@@ -2639,7 +2639,7 @@ describe("AuctionCanvas", () => {
       ...(globalThis as any).__VITE_ENV__,
       VITE_NETWORK: "sepolia",
       VITE_EXPECTED_CHAIN_ID: "0xaa36a7",
-      VITE_ETH_RPC: "http://127.0.0.1:8546",
+      VITE_PATH_RPC_URL: "http://127.0.0.1:8546",
       VITE_PAYTOKEN: ZERO_ADDRESS,
       VITE_PAYMENT_TOKEN: ZERO_ADDRESS,
       VITE_PAYMENT_TOKEN_SYMBOL: "ETH",
@@ -2969,7 +2969,7 @@ describe("AuctionCanvas", () => {
     });
     (globalThis as any).__VITE_ENV__ = {
       ...(globalThis as any).__VITE_ENV__,
-      VITE_ETH_RPC: "/api/path-rpc",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
       VITE_WALLET_CHAIN_RPC_URL: "",
       VITE_PUBLIC_LAUNCH_MODE: "sepolia_invite",
       VITE_REPORT_BUG_URL: "https://github.com/inshell-art/inshell.art/issues/new",

--- a/apps/home/tests/ethereumClient.test.ts
+++ b/apps/home/tests/ethereumClient.test.ts
@@ -19,20 +19,29 @@ describe("Ethereum client production RPC guard", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("uses explicit VITE_ETH_RPC when configured", () => {
+  test("uses explicit VITE_PATH_RPC_URL when configured", () => {
     (globalThis as any).__VITE_ENV__ = {
       VITE_NETWORK: "sepolia",
-      VITE_ETH_RPC: "https://rpc.example/sepolia",
+      VITE_PATH_RPC_URL: "https://path-rpc.example/sepolia",
     };
 
-    expect(providerRpcUrl()).toBe("https://rpc.example/sepolia");
+    expect(providerRpcUrl()).toBe("https://path-rpc.example/sepolia");
+  });
+
+  test("keeps legacy VITE_ETH_RPC as a migration fallback", () => {
+    (globalThis as any).__VITE_ENV__ = {
+      VITE_NETWORK: "sepolia",
+      VITE_ETH_RPC: "https://legacy-rpc.example/sepolia",
+    };
+
+    expect(providerRpcUrl()).toBe("https://legacy-rpc.example/sepolia");
   });
 
   test("allows same-origin RPC proxy URL for production deployments", () => {
     (globalThis as any).__VITE_ENV__ = {
       VITE_NETWORK: "sepolia",
       VITE_PUBLIC_LAUNCH_MODE: "sepolia_invite",
-      VITE_ETH_RPC: "/api/path-rpc",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
     };
 
     expect(providerRpcUrl()).toBe("/api/path-rpc");

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -812,6 +812,17 @@ const resolveThoughtRpcUrl = () => {
   }
 };
 const THOUGHT_RPC_URL = resolveThoughtRpcUrl();
+const resolvePathRpcUrl = () => {
+  const configuredPathRpcUrl = readConfiguredUrl("VITE_PATH_RPC_URL") || readConfiguredUrl("VITE_ETH_RPC");
+  if (configuredPathRpcUrl) {
+    return resolveBrowserRpcUrl(configuredPathRpcUrl);
+  }
+  if (LOCAL_BROWSER_HOSTS.has(window.location.hostname)) {
+    return THOUGHT_RPC_URL;
+  }
+  return resolveBrowserRpcUrl("/api/path-rpc");
+};
+const PATH_RPC_URL = resolvePathRpcUrl();
 const THOUGHT_PREVIEW_ENDPOINT_ENABLED =
   typeof import.meta.env.VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED === "string" &&
   import.meta.env.VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED.trim().toLowerCase() === "true";
@@ -1606,6 +1617,7 @@ let thoughtDetailColorFontUrl = "";
 let thoughtDetailProvenanceJsonUrl = "";
 let colorFontPageRawUrl = "";
 let readProvider: JsonRpcProvider | null = null;
+let pathReadProvider: JsonRpcProvider | null = null;
 let readThoughtNFT: Contract | null = null;
 let readColorFontV1: Contract | null = null;
 let readThoughtSpecRegistry: Contract | null = null;
@@ -2034,6 +2046,18 @@ const getReadProvider = () => {
   return readProvider;
 };
 
+const getPathReadProvider = () => {
+  if (!PATH_RPC_URL) {
+    return null;
+  }
+
+  if (!pathReadProvider) {
+    pathReadProvider = createSingleRequestJsonRpcProvider(PATH_RPC_URL, THOUGHT_CHAIN_ID);
+  }
+
+  return pathReadProvider;
+};
+
 const getReadThoughtNFT = () => {
   const provider = getReadProvider();
   if (!provider || !THOUGHT_NFT_ADDRESS) {
@@ -2078,7 +2102,7 @@ const getReadThoughtSpecRegistry = () => {
 };
 
 const getReadPathNft = () => {
-  const provider = getReadProvider();
+  const provider = getPathReadProvider();
   if (!provider || !PATH_NFT_ADDRESS) {
     return null;
   }
@@ -11471,7 +11495,7 @@ const listCliPaths = async () => {
       return;
     }
 
-    const provider = getReadProvider();
+    const provider = getPathReadProvider();
     const pathNft = getReadPathNft();
     if (!provider || !pathNft || !PATH_NFT_ADDRESS || !THOUGHT_NFT_ADDRESS) {
       appendCliOutput([

--- a/packages/ethereum/src/client.ts
+++ b/packages/ethereum/src/client.ts
@@ -256,7 +256,9 @@ function requiresConfiguredRpc(): boolean {
 }
 
 export function getDefaultProvider(): ProviderInterface {
-  const configuredRpcUrl = getEnv("VITE_ETH_RPC") as string | undefined;
+  const configuredRpcUrl =
+    (getEnv("VITE_PATH_RPC_URL") as string | undefined) ||
+    (getEnv("VITE_ETH_RPC") as string | undefined);
   if (configuredRpcUrl?.trim()) {
     return new JsonRpcProvider(configuredRpcUrl.trim());
   }
@@ -269,7 +271,7 @@ export function getDefaultProvider(): ProviderInterface {
   if (!requiresConfiguredRpc() && isLocalBrowserHost()) {
     return new JsonRpcProvider("http://127.0.0.1:8546");
   }
-  throw new Error("VITE_ETH_RPC is required outside local development.");
+  throw new Error("VITE_PATH_RPC_URL is required outside local development.");
 }
 
 function encodeCall(entrypoint: string, calldata: readonly unknown[] = []): {

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -66,10 +66,10 @@ if (!ADDR_FILE && !ADDR_URL) {
           resolve(`apps/thought/.env.${net}.local`),
         ];
 
-// RPC (private), always as ETH_RPC consumed uniformly
+    // PATH read RPC for browser-side PATH/Pulse surfaces.
     const lines: string[] = [];
     lines.push(`VITE_NETWORK=${net}`);
-    lines.push(`VITE_ETH_RPC=${RPC}`);
+    lines.push(`VITE_PATH_RPC_URL=${RPC}`);
     if (DEPLOY_BLOCK && String(DEPLOY_BLOCK).trim()) {
       lines.push(`VITE_PULSE_AUCTION_DEPLOY_BLOCK=${DEPLOY_BLOCK}`);
     } else if (net !== "devnet") {

--- a/scripts/validate-inshell-contracts.mjs
+++ b/scripts/validate-inshell-contracts.mjs
@@ -188,6 +188,7 @@ function findRpcCandidate() {
     "THOUGHT_RPC_UPSTREAM",
     "ETH_RPC_UPSTREAM",
     "RPC_UPSTREAM_FALLBACK",
+    "VITE_PATH_RPC_URL",
     "VITE_THOUGHT_RPC_URL",
     "VITE_ETH_RPC",
   ];

--- a/scripts/validate-production-surface.ts
+++ b/scripts/validate-production-surface.ts
@@ -25,7 +25,7 @@ const DEPLOY_WORKFLOW_SNIPPETS = [
   "CLOUDFLARE_ACCOUNT_ID",
   "CLOUDFLARE_PAGES_PROJECT_HOME",
   "CLOUDFLARE_PAGES_PROJECT_THOUGHT",
-  "VITE_ETH_RPC",
+  "VITE_PATH_RPC_URL",
   "VITE_THOUGHT_RPC_URL",
   "VITE_THOUGHT_PREVIEW_ENDPOINT_ENABLED",
   "VITE_THOUGHT_PREVIEW_ENDPOINT_URL",
@@ -370,7 +370,7 @@ function checkEthereumRpcGuard() {
   const text = read("packages/ethereum/src/client.ts");
   for (const snippet of [
     "requiresConfiguredRpc",
-    "VITE_ETH_RPC is required outside local development.",
+    "VITE_PATH_RPC_URL is required outside local development.",
     "isLocalBrowserHost",
   ]) {
     if (!text.includes(snippet)) {


### PR DESCRIPTION
## Summary
- Route THOUGHT PATH inventory reads through the PATH RPC endpoint.
- Rename browser-facing PATH/Pulse RPC config to VITE_PATH_RPC_URL with legacy VITE_ETH_RPC fallback.
- Keep server-side private RPC upstream names unchanged.

## Checks
- staging test workflow passed before promotion PR
- staging CodeQL workflow passed before promotion PR
- local gitleaks detect --no-git --redact passed
