### PR TITLE
Promote analytics beacon endpoint fix

### DIFF
--- a/apps/home/tests/cloudflareWebAnalytics.test.ts
+++ b/apps/home/tests/cloudflareWebAnalytics.test.ts
@@ -8,6 +8,11 @@ const env = {
   VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN: "test-rum-token",
 };
 
+const expectedBeaconConfig = JSON.stringify({
+  token: env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN,
+  send: { to: "/cdn-cgi/rum" },
+});
+
 describe("Cloudflare Web Analytics install policy", () => {
   beforeEach(() => {
     document.head.innerHTML = "";
@@ -27,9 +32,7 @@ describe("Cloudflare Web Analytics install policy", () => {
     const script = document.getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID);
     expect(script).not.toBeNull();
     expect(script?.getAttribute("src")).toBe("https://static.cloudflareinsights.com/beacon.min.js");
-    expect(script?.getAttribute("data-cf-beacon")).toBe(
-      JSON.stringify({ token: env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN }),
-    );
+    expect(script?.getAttribute("data-cf-beacon")).toBe(expectedBeaconConfig);
   });
 
   test("does not install on preview, ops, pages.dev, or local hosts", () => {
@@ -74,6 +77,6 @@ describe("Cloudflare Web Analytics install policy", () => {
       document
         .getElementById(CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID)
         ?.getAttribute("data-cf-beacon"),
-    ).toBe(JSON.stringify({ token: env.VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN }));
+    ).toBe(expectedBeaconConfig);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -466,7 +466,10 @@ export function maybeInstallCloudflareWebAnalytics(
   script.id = CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID;
   script.defer = true;
   script.src = "https://static.cloudflareinsights.com/beacon.min.js";
-  script.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  script.setAttribute(
+    "data-cf-beacon",
+    JSON.stringify({ token, send: { to: "/cdn-cgi/rum" } }),
+  );
   documentRef.head.appendChild(script);
   return true;
 }


### PR DESCRIPTION
Promotes the staging fix that sends Cloudflare Web Analytics beacons through the same-origin /cdn-cgi/rum collector.\n\nChecks already run on staging before opening this PR:\n- pnpm --filter @inshell/home test -- --runTestsByPath tests/cloudflareWebAnalytics.test.ts\n- pnpm run type-check\n- pnpm run build:home\n- pnpm run build:thought\n- git diff --check\n- gitleaks detect --no-git --redact