### PR TITLE
Promote indexed home auction reads

### DIFF
--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -1816,6 +1816,49 @@ function fixtureToState(
   return { config, bids, nowSec };
 }
 
+function releaseConfigToAuctionConfig(
+  release: ReturnType<typeof getProtocolRelease> | undefined,
+  decimals: number
+): AuctionSnapshot["config"] | null {
+  const cfg = release?.config;
+  if (!cfg) return null;
+  const openTimeSec = Number(cfg.open_time);
+  if (!Number.isFinite(openTimeSec) || openTimeSec <= 0) return null;
+
+  const toU256FromWei = (value: string | number | bigint | undefined) => {
+    if (value == null) return null;
+    try {
+      return toU256Num({
+        low: rescaleWeiToDecimals(BigInt(value), decimals).toString(),
+        high: "0",
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  const genesisPrice = toU256FromWei(cfg.genesis_price);
+  const genesisFloor = toU256FromWei(cfg.genesis_floor);
+  const k = toU256FromWei(cfg.k);
+  let pts: string | null = null;
+  try {
+    if (cfg.pts != null) {
+      pts = rescaleWeiToDecimals(BigInt(cfg.pts), decimals).toString();
+    }
+  } catch {
+    pts = null;
+  }
+
+  if (!genesisPrice || !genesisFloor || !k || !pts) return null;
+  return {
+    openTimeSec,
+    genesisPrice,
+    genesisFloor,
+    k,
+    pts,
+  };
+}
+
 function formatDuration(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) return "—";
   const rounded = Math.max(0, Math.round(seconds));
@@ -2233,6 +2276,10 @@ export default function AuctionCanvas({
   const bidsFromBlock = useMemo(() => resolveBidsFromBlock(), []);
   const protocolRelease = useMemo(() => getProtocolRelease(), []);
   const allowDirectAuction = useMemo(() => directAuctionOverrideAllowed(), []);
+  const cachedAuctionConfig = useMemo(
+    () => releaseConfigToAuctionConfig(protocolRelease, decimals),
+    [protocolRelease, decimals]
+  );
   const pathMintIntent = useMemo(() => readPathMintIntent(), []);
   const releaseMissing = !fixtureState && !allowDirectAuction && !protocolRelease;
   const network = useMemo(() => {
@@ -2251,23 +2298,30 @@ export default function AuctionCanvas({
   const protocolGuard = useProtocolReleaseGuard({
     address: auctionAddress,
     provider,
-    enabled: !fixtureState && !releaseMissing && Boolean(auctionAddress),
+    enabled:
+      allowDirectAuction &&
+      !fixtureState &&
+      !releaseMissing &&
+      Boolean(auctionAddress),
   });
   const liveAuctionEnabled =
-    !fixtureState && Boolean(auctionAddress) && protocolGuard.ready;
+    !fixtureState &&
+    Boolean(auctionAddress) &&
+    (allowDirectAuction ? protocolGuard.ready : Boolean(cachedAuctionConfig));
   const {
     data: coreData,
     loading: coreLoadingHook,
     error: coreErrorHook,
-    refresh: refreshCore = async () => undefined,
+    refresh: refreshCoreHook = async () => undefined,
   } = useAuctionCore({
     address: auctionAddress,
     provider,
     refreshMs,
-    enabled: liveAuctionEnabled,
+    enabled: allowDirectAuction && liveAuctionEnabled,
   });
   const bidHistoryEnabled =
-    liveAuctionEnabled && Boolean(coreData?.config);
+    liveAuctionEnabled &&
+    (allowDirectAuction ? Boolean(coreData?.config) : Boolean(cachedAuctionConfig));
   const {
     bids: bidsHook,
     loading: bidsLoading,
@@ -2292,20 +2346,46 @@ export default function AuctionCanvas({
     () => resolvePaymentSymbol(paymentToken),
     [paymentToken]
   );
+  const cachedCoreData = useMemo<AuctionSnapshot | null>(() => {
+    if (fixtureState || allowDirectAuction || !cachedAuctionConfig) return null;
+    return {
+      active: true,
+      price: cachedAuctionConfig.genesisPrice,
+      config: cachedAuctionConfig,
+      state: null,
+    };
+  }, [allowDirectAuction, cachedAuctionConfig, fixtureState]);
   const core = useMemo(
-    () => (fixtureState ? { config: fixtureState.config } : coreData),
-    [fixtureState, coreData]
+    () =>
+      fixtureState
+        ? { config: fixtureState.config }
+        : allowDirectAuction
+        ? coreData
+        : cachedCoreData,
+    [allowDirectAuction, cachedCoreData, fixtureState, coreData]
   );
   const coreImpliesActive = Boolean(
-    coreData?.active ||
-      coreData?.state?.active ||
-      ((coreData?.state?.epochIndex ?? 0) > 0)
+    allowDirectAuction
+      ? coreData?.active ||
+          coreData?.state?.active ||
+          ((coreData?.state?.epochIndex ?? 0) > 0)
+      : cachedCoreData?.active
   );
   const bidsLoadingVisible = fixtureState ? false : bidHistoryEnabled && bidsLoading;
   const coreLoading = fixtureState
     ? false
-    : protocolGuard.loading || coreLoadingHook;
-  const coreError = fixtureState ? null : protocolGuard.error ?? coreErrorHook;
+    : allowDirectAuction
+    ? protocolGuard.loading || coreLoadingHook
+    : false;
+  const coreError = fixtureState
+    ? null
+    : allowDirectAuction
+    ? protocolGuard.error ?? coreErrorHook
+    : null;
+  const refreshCore = useCallback(
+    () => (allowDirectAuction ? refreshCoreHook() : Promise.resolve(undefined)),
+    [allowDirectAuction, refreshCoreHook]
+  );
   const [coreErrorVisible, setCoreErrorVisible] = useState<unknown>(null);
   const [missingDeployBlockVisible, setMissingDeployBlockVisible] =
     useState(false);
@@ -3131,6 +3211,8 @@ export default function AuctionCanvas({
   }, [pendingMint, queueToast]);
 
   const mimicLocalTime = network === "devnet" || protocolRelease?.network === "devnet";
+  const useBrowserAuctionClock =
+    mimicLocalTime || (!allowDirectAuction && !fixtureState);
 
   // Devnet uses browser time to make local Anvil rehearsals usable even when
   // idle blocks are not mined. Public networks keep following block time.
@@ -3147,7 +3229,7 @@ export default function AuctionCanvas({
         cancelled = true;
       };
     }
-    if (mimicLocalTime) {
+    if (useBrowserAuctionClock) {
       const tick = () => {
         const nextNowSec = Date.now() / 1000;
         liveNowSecRef.current = nextNowSec;
@@ -3177,7 +3259,7 @@ export default function AuctionCanvas({
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [fixtureState, provider, mimicLocalTime]);
+  }, [fixtureState, provider, useBrowserAuctionClock]);
 
   // Before the first bid, keep notices/countdowns live. On devnet, keep the
   // active curve growing with browser time for local visual development.
@@ -3203,7 +3285,7 @@ export default function AuctionCanvas({
         cancelled = true;
       };
     }
-    if (mimicLocalTime) {
+    if (useBrowserAuctionClock) {
       const tick = () => {
         const nextNowSec = Date.now() / 1000;
         nowSecRef.current = nextNowSec;
@@ -3230,10 +3312,11 @@ export default function AuctionCanvas({
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [fixtureState, bids.length, provider, mimicLocalTime]);
+  }, [fixtureState, bids.length, provider, useBrowserAuctionClock]);
 
   // Fallback: fetch config directly if the core hook never fills it.
   useEffect(() => {
+    if (!allowDirectAuction) return;
     if (fixtureState) return;
     if (core?.config) {
       if (fallbackConfig) setFallbackConfig(null);
@@ -3285,6 +3368,7 @@ export default function AuctionCanvas({
     provider,
     fallbackConfig,
     fixtureState,
+    allowDirectAuction,
   ]);
 
   const activeConfig = core?.config ?? fallbackConfig ?? null;
@@ -3378,7 +3462,7 @@ export default function AuctionCanvas({
       return toNumberSafe(decStr);
     };
 
-    const directState = !fixtureState ? coreData?.state : null;
+    const directState = !fixtureState && allowDirectAuction ? coreData?.state : null;
     const directStateEpoch = Number(directState?.epochIndex);
     const directStateImpliesActive =
       Boolean(directState?.active) ||
@@ -3564,7 +3648,16 @@ export default function AuctionCanvas({
       maxY,
       reason: null,
     };
-  }, [activeConfig, bids, coreData?.state, coreLoading, fallbackError, decimals, fixtureState]);
+  }, [
+    activeConfig,
+    allowDirectAuction,
+    bids,
+    coreData?.state,
+    coreLoading,
+    fallbackError,
+    decimals,
+    fixtureState,
+  ]);
 
   const activeCurveQuoteKey = useMemo(() => {
     if (linkedStatic.reason || !linkedStatic.segments.length) return "";

--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -2279,6 +2279,8 @@ export default function AuctionCanvas({
     refreshMs,
     enabled: bidHistoryEnabled,
     maxBids,
+    preferCacheApi: !allowDirectAuction,
+    allowDirectFallback: allowDirectAuction,
   });
   const bids = fixtureState?.bids ?? bidsHook;
   const paymentToken = useMemo(() => resolvePaymentToken(), []);

--- a/apps/home/src/hooks/useAuctionBids.ts
+++ b/apps/home/src/hooks/useAuctionBids.ts
@@ -14,6 +14,8 @@ export function useAuctionBids(opts: {
   maxBids?: number;
   chunkSize?: number;
   reorgDepth?: number;
+  preferCacheApi?: boolean;
+  allowDirectFallback?: boolean;
 }) {
   const enabled = opts.enabled ?? true;
   const refreshMs = opts.refreshMs ?? 0;
@@ -39,6 +41,8 @@ export function useAuctionBids(opts: {
         maxBids: opts.maxBids,
         chunkSize: opts.chunkSize,
         reorgDepth: opts.reorgDepth,
+        preferCacheApi: opts.preferCacheApi,
+        allowDirectFallback: opts.allowDirectFallback,
       });
       setReady(true);
     } catch (e) {
@@ -56,6 +60,8 @@ export function useAuctionBids(opts: {
     opts.maxBids,
     opts.chunkSize,
     opts.reorgDepth,
+    opts.preferCacheApi,
+    opts.allowDirectFallback,
   ]);
 
   // Subscribe to updates

--- a/apps/home/src/services/auction/bidsService.ts
+++ b/apps/home/src/services/auction/bidsService.ts
@@ -318,10 +318,16 @@ export function createBidsService(opts: {
   maxBids?: number; // default 200
   chunkSize?: number; // default 5_000 blocks
   reorgDepth?: number; // default 2 blocks
+  preferCacheApi?: boolean; // public UI should read the indexed snapshot first
+  allowDirectFallback?: boolean; // explicit/debug paths may fall back to raw logs
 }) {
   const address = opts.address;
   const provider: ProviderInterface = opts.provider ?? getDefaultProvider();
-  const useCacheApi = !opts.provider;
+  const useCacheApi =
+    opts.preferCacheApi ??
+    (typeof globalThis.fetch === "function" &&
+      typeof globalThis.location !== "undefined");
+  const allowDirectFallback = opts.allowDirectFallback ?? !useCacheApi;
   const maxBids = opts.maxBids ?? 200;
   const initialChunkSize = Math.max(1, opts.chunkSize ?? DEFAULT_LOG_CHUNK_SIZE);
   const reorgDepth = opts.reorgDepth ?? 2;
@@ -494,7 +500,8 @@ export function createBidsService(opts: {
           return fresh;
         }
       } catch {
-        // Fall back to direct sale log reads when the cached API is unavailable.
+        if (!allowDirectFallback) return fresh;
+        // Explicit/debug callers may fall back to direct sale log reads.
       }
     }
 

--- a/apps/home/tests/AuctionCanvas.test.tsx
+++ b/apps/home/tests/AuctionCanvas.test.tsx
@@ -1268,6 +1268,31 @@ describe("AuctionCanvas", () => {
     expect(container.querySelector(".dotfield__curve")).toBeTruthy();
   });
 
+  test("public home uses indexed auction cache without enabling direct RPC core", () => {
+    (globalThis as any).__VITE_ENV__ = {
+      VITE_NETWORK: "sepolia",
+      VITE_EXPECTED_CHAIN_ID: "0xaa36a7",
+      VITE_PULSE_AUCTION: TEST_AUCTION_ADDRESS,
+      VITE_PAYMENT_TOKEN: TEST_PAYMENT_TOKEN,
+      VITE_PAYMENT_TOKEN_SYMBOL: "ETH",
+      VITE_PATH_RPC_URL: "/api/path-rpc",
+    };
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+
+    expect(mockUseAuctionCore).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+    expect(mockUseAuctionBids).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        preferCacheApi: true,
+        allowDirectFallback: false,
+      })
+    );
+    expect(mockCallContract).not.toHaveBeenCalled();
+  });
+
   test("shows no deployment message when no protocol release is loaded", () => {
     (globalThis as any).__VITE_ENV__ = {
       VITE_NETWORK: "mainnet",

--- a/apps/home/tests/bidsService.test.ts
+++ b/apps/home/tests/bidsService.test.ts
@@ -87,6 +87,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -135,6 +136,70 @@ describe("auction bids service", () => {
     );
   });
 
+  test("uses the cached API even when a provider is available", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        lastScannedBlock: 123,
+        bids: [
+          {
+            key: "tx:cached-with-provider",
+            atMs: 1_778_888_000_000,
+            bidder: BUYER,
+            amount: { raw: { low: "100", high: "0" }, dec: "100" },
+            floorB: { raw: { low: "10", high: "0" }, dec: "10" },
+            blockNumber: 120,
+            epochIndex: 7,
+          },
+        ],
+      }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const provider = {
+      request: jest.fn(async () => {
+        throw new Error("direct RPC should not be used");
+      }),
+    };
+
+    const service = createBidsService({
+      address: AUCTION,
+      provider,
+      fromBlock: 1,
+      reorgDepth: 0,
+    });
+
+    const fresh = await service.pullOnce();
+    expect(fresh.map((bid) => bid.key)).toEqual(["tx:cached-with-provider"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/pulse-auction"),
+      expect.objectContaining({ headers: { accept: "application/json" } })
+    );
+    expect(provider.request).not.toHaveBeenCalled();
+  });
+
+  test("does not fall back to direct RPC when the cached API fails by default", async () => {
+    globalThis.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const provider = {
+      request: jest.fn(async () => {
+        throw new Error("direct RPC should not be used");
+      }),
+    };
+
+    const service = createBidsService({
+      address: AUCTION,
+      provider,
+      fromBlock: 1,
+      reorgDepth: 0,
+    });
+
+    await expect(service.pullOnce()).resolves.toEqual([]);
+    expect(provider.request).not.toHaveBeenCalled();
+  });
+
   test("adapts when the PATH RPC gate says the log range is too large", async () => {
     const logs = [saleLog(12, 1n, 100n), saleLog(31, 2n, 120n)];
     const provider = {
@@ -162,6 +227,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -200,6 +266,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       reorgDepth: 0,
     });
@@ -239,6 +306,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -274,6 +342,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -316,6 +385,7 @@ describe("auction bids service", () => {
     const firstService = createBidsService({
       address: AUCTION,
       provider: firstProvider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -334,6 +404,7 @@ describe("auction bids service", () => {
     const secondService = createBidsService({
       address: AUCTION,
       provider: secondProvider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -375,6 +446,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -420,6 +492,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,
@@ -466,6 +539,7 @@ describe("auction bids service", () => {
     const service = createBidsService({
       address: AUCTION,
       provider,
+      preferCacheApi: false,
       fromBlock: 1,
       chunkSize: 40_000,
       reorgDepth: 0,


### PR DESCRIPTION
## Summary
- Route home auction history through the indexed /api/pulse-auction cache first.
- Disable public-home direct auction RPC core reads unless direct debug mode is explicitly enabled.
- Keep wallet/mint and explicit direct debug RPC paths intact.

## Checks run locally
- pnpm --filter @inshell/home test -- --runTestsByPath tests/AuctionCanvas.test.tsx tests/bidsService.test.ts
- pnpm run lint
- pnpm run build:home
- gitleaks detect --no-git --redact

## Staging verification
- https://staging.inshell-art.pages.dev/ renders without curve error.
- Browser verification saw /api/pulse-auction status 200, /api/path-rpc calls 0, SVG curve paths 25.