### PR TITLE
Promote staging route hardening

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -95,6 +95,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes wrangler@4.94.0 pages deploy dist/home --project-name="$CLOUDFLARE_PAGES_PROJECT_HOME" --branch="${{ github.event.inputs.branch }}"
+      - name: Smoke home API routes
+        run: |
+          if [ "${{ github.event.inputs.branch }}" = "main" ]; then
+            pnpm run smoke:api-routes -- --scope home --home-base https://inshell.art
+          else
+            pnpm run smoke:api-routes -- --scope home --home-base https://staging.inshell-art.pages.dev
+          fi
 
   deploy-thought:
     if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'thought' }}
@@ -167,3 +174,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes wrangler@4.94.0 pages deploy dist/thought --project-name="$CLOUDFLARE_PAGES_PROJECT_THOUGHT" --branch="${{ github.event.inputs.branch }}"
+      - name: Smoke THOUGHT API routes
+        run: |
+          if [ "${{ github.event.inputs.branch }}" = "main" ]; then
+            pnpm run smoke:api-routes -- --scope thought --thought-base https://thought.inshell.art
+          else
+            pnpm run smoke:api-routes -- --scope thought --thought-base https://staging.thought-inshell-art.pages.dev
+          fi

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "test:fast": "jest --runTestsByPath tests/num.test.ts tests/pulseCurve.test.ts",
     "test:presepolia": "jest --runTestsByPath tests/App.test.tsx tests/pathTokens.test.ts tests/AuctionCanvas.test.tsx tests/middlewareFunction.test.ts",
-    "test:unit": "jest --runTestsByPath tests/App.test.tsx tests/AuctionCanvas.test.tsx tests/AuctionCanvasPulseFixtures.test.tsx tests/AuctionCanvasLook.test.tsx tests/HeaderWalletCTA.test.tsx tests/Movements.test.tsx tests/bidsService.test.ts tests/cloudflareWebAnalytics.test.ts tests/coreService.test.ts tests/ethereumClient.test.ts tests/middlewareFunction.test.ts tests/num.test.ts tests/pathTokens.test.ts tests/pulseCurve.test.ts tests/thoughtPreviewFunction.test.ts",
+    "test:unit": "jest --runTestsByPath tests/App.test.tsx tests/AuctionCanvas.test.tsx tests/AuctionCanvasPulseFixtures.test.tsx tests/AuctionCanvasLook.test.tsx tests/HeaderWalletCTA.test.tsx tests/Movements.test.tsx tests/bidsService.test.ts tests/chainCacheFunction.test.ts tests/cloudflareWebAnalytics.test.ts tests/coreService.test.ts tests/ethereumClient.test.ts tests/ethRpcFunction.test.ts tests/middlewareFunction.test.ts tests/num.test.ts tests/pathTokens.test.ts tests/pulseCurve.test.ts tests/thoughtPreviewFunction.test.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "preview": "vite preview --host 127.0.0.1 --port 4173 --strictPort"

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -11476,6 +11476,20 @@ const fetchPathTokenIdsForWalletFromApi = async (walletAddress: string) => {
   return tokenIds;
 };
 
+const appendCliPathInventory = (ownedPaths: Array<{ pathId: bigint; status: string }>) => {
+  appendCliOutput([
+    "wallet $PATHs for THOUGHT mint.",
+    `wallet: ${formatCliAddress(walletState.address ?? "")}`,
+    "",
+    ...(ownedPaths.length
+      ? ownedPaths.map(({ pathId, status }) => `#${pathId.toString()} ${status}`)
+      : ["none found."]),
+    "",
+    "use: path <id>",
+    "need $PATH: mint-path",
+  ]);
+};
+
 const listCliPaths = async () => {
   await withCliLoading("loading...", async () => {
     await refreshWalletState();
@@ -11495,23 +11509,36 @@ const listCliPaths = async () => {
       return;
     }
 
-    const provider = getPathReadProvider();
-    const pathNft = getReadPathNft();
-    if (!provider || !pathNft || !PATH_NFT_ADDRESS || !THOUGHT_NFT_ADDRESS) {
-      appendCliOutput([
-        "wallet $PATHs for THOUGHT mint.",
-        "",
-        "path list unavailable.",
-        "need $PATH: mint-path",
-      ]);
-      return;
-    }
-
     try {
-      let candidateIds: Set<bigint>;
+      let candidateIds: Set<bigint> | null = null;
       try {
         candidateIds = await fetchPathTokenIdsForWalletFromApi(walletState.address);
       } catch {
+        // Fall through to direct log reads when the chain-cache API is unavailable.
+      }
+
+      const provider = getPathReadProvider();
+      const pathNft = getReadPathNft();
+      if ((!provider || !pathNft || !PATH_NFT_ADDRESS || !THOUGHT_NFT_ADDRESS) && candidateIds) {
+        appendCliPathInventory(
+          [...candidateIds]
+            .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+            .map((pathId) => ({ pathId, status: "unknown" })),
+        );
+        return;
+      }
+
+      if (!provider || !pathNft || !PATH_NFT_ADDRESS || !THOUGHT_NFT_ADDRESS) {
+        appendCliOutput([
+          "wallet $PATHs for THOUGHT mint.",
+          "",
+          "path list unavailable.",
+          "need $PATH: mint-path",
+        ]);
+        return;
+      }
+
+      if (!candidateIds) {
         const walletTopic = indexedAddressTopic(walletState.address);
         const transferLogs = await fetchPathTransferLogsForWallet(provider, walletTopic);
         candidateIds = new Set<bigint>();
@@ -11523,10 +11550,16 @@ const listCliPaths = async () => {
         }
       }
 
-      const [authorizedMinter, movementQuota] = await Promise.all([
-        pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
-        pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
-      ]);
+      let authorizedMinter = "";
+      let movementQuota = 0n;
+      try {
+        [authorizedMinter, movementQuota] = await Promise.all([
+          pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
+          pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
+        ]);
+      } catch {
+        // Keep listing owned IDs even when availability metadata cannot be read.
+      }
       const wallet = walletState.address.toLowerCase();
       const ownedPaths = (
         await Promise.all(
@@ -11538,7 +11571,9 @@ const listCliPaths = async () => {
                 if (owner.toLowerCase() !== wallet) {
                   return null;
                 }
-                const status = await cliPathAvailability(pathNft, pathId, authorizedMinter, movementQuota);
+                const status = authorizedMinter && movementQuota > 0n
+                  ? await cliPathAvailability(pathNft, pathId, authorizedMinter, movementQuota)
+                  : "unknown";
                 return { pathId, status };
               } catch {
                 return { pathId, status: "unknown" };
@@ -11547,17 +11582,7 @@ const listCliPaths = async () => {
         )
       ).filter((path): path is { pathId: bigint; status: string } => path !== null);
 
-      appendCliOutput([
-        "wallet $PATHs for THOUGHT mint.",
-        `wallet: ${formatCliAddress(walletState.address)}`,
-        "",
-        ...(ownedPaths.length
-          ? ownedPaths.map(({ pathId, status }) => `#${pathId.toString()} ${status}`)
-          : ["none found."]),
-        "",
-        "use: path <id>",
-        "need $PATH: mint-path",
-      ]);
+      appendCliPathInventory(ownedPaths);
     } catch {
       appendCliOutput([
         "wallet $PATHs for THOUGHT mint.",

--- a/docs/cloudflare-web-analytics.md
+++ b/docs/cloudflare-web-analytics.md
@@ -1,0 +1,50 @@
+# Cloudflare Web Analytics
+
+## Runtime Beacon
+
+`static.cloudflareinsights.com/beacon.min.js` is Cloudflare's browser beacon loader for Web Analytics. The frontend loads it only when a public `VITE_CLOUDFLARE_WEB_ANALYTICS_*` site token is present in the production build.
+
+`VITE_*` values are public because Vite bakes them into client JavaScript. Treat these as site identifiers, not secrets.
+
+## Token Types
+
+Use different names for different token classes:
+
+- `VITE_CLOUDFLARE_WEB_ANALYTICS_HOME_TOKEN`: public site token for the home/PATH bundle.
+- `VITE_CLOUDFLARE_WEB_ANALYTICS_THOUGHT_TOKEN`: public site token for the THOUGHT/gallery bundle.
+- `INSHELL_CLOUDFLARE_WEB_ANALYTICS_READ_TOKEN`: private Cloudflare API token for reading RUM/Web Analytics site metadata.
+
+Do not reuse Pages deploy, KV, Access, or Account Settings Write tokens for Web Analytics API reads. A token that can edit account settings can still return `403` from `/rum/site_info/list` if it lacks RUM/Web Analytics metadata read access.
+
+Check the private API token with:
+
+```bash
+pnpm run check:web-analytics-token
+```
+
+The checker reads `CLOUDFLARE_ACCOUNT_ID` and `INSHELL_CLOUDFLARE_WEB_ANALYTICS_READ_TOKEN` from the shell or the private operator env file at `~/.inshell-secrets/inshell-sepolia.env`. It never prints token values.
+
+## Interpreting Poor Metrics
+
+Cloudflare Web Analytics can show poor Web Vitals from tiny samples. First separate low-sample noise from persistent problems:
+
+- Filter by hostname: `inshell.art`, `gallery.inshell.art`, `thought.inshell.art`, and `sepolia.inshell.art`.
+- Filter by route: `/`, `/path`, `/gallery`, `/thought/<id>`, `/pulse`, `/color-font`.
+- Compare desktop/mobile and country/network slices before treating a single red card as product-wide.
+
+If poor cards persist, the likely frontend causes are:
+
+- Large SVG/canvas first render on home/PATH and gallery/detail pages.
+- Chain-read/API waits before the user sees useful cached content.
+- Font loading or layout shift from late terminal-font measurement.
+- Wallet/RPC initialization work running before first paint.
+
+Concrete fixes should stay local to frontend behavior:
+
+- Keep fixed layout boxes for canvas/SVG areas.
+- Render cached API snapshots before live refresh.
+- Defer noncritical wallet/RPC work until user intent.
+- Preload or stabilize the terminal font.
+- Keep source/feed pages static and avoid app-shell fallbacks for generated artifacts.
+
+Do not add new third-party telemetry to solve this. Cloudflare Web Analytics is the only analytics surface currently approved for this repo.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,8 @@
 
 - `npm run test:unit`
   - Runs all Jest unit tests (UI + fixtures).
+  - Includes Cloudflare function-route unit coverage for cache/RPC routes such as
+    `chainCacheFunction.test.ts` and `ethRpcFunction.test.ts`.
 
 ## Full local check
 
@@ -19,6 +21,21 @@
 
 - `pnpm run check:production`
   - Validates Cloudflare Pages deploy surface, security headers, redirects, dev-server binding, Sepolia release artifacts, imported ABI JSON, lint, type-check, unit tests, both app builds, and whitespace diff.
+
+## Cloudflare API route smoke
+
+- `pnpm run smoke:api-routes -- --scope home --home-base https://staging.inshell-art.pages.dev`
+  - Checks live home Pages bindings for `/api/path-rpc`, `/api/pulse-auction`, and `/api/path-tokens`.
+- `pnpm run smoke:api-routes -- --scope thought --thought-base https://staging.thought-inshell-art.pages.dev`
+  - Checks live THOUGHT Pages bindings for `/api/path-rpc`, `/api/thought-rpc`, `/api/thought-preview`, `/api/thought-gallery`, and `/api/path-tokens`.
+
+These smoke checks run after Cloudflare Pages deploys in `deploy-pages.yml` so env/binding drift is caught by the deployment, not by a wallet or browser session.
+
+## Cloudflare Web Analytics token check
+
+- `pnpm run check:web-analytics-token`
+  - Reads the private operator env file and verifies the Cloudflare token can read RUM/Web Analytics site metadata.
+  - This validates the private API token only. It is separate from the public `VITE_CLOUDFLARE_WEB_ANALYTICS_*` site token shipped in frontend bundles.
 
 ## E2E (optional)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "check:presepolia": "pnpm --filter @inshell/home lint && pnpm run test:presepolia && pnpm run test:thought-runtime && pnpm run build:home && pnpm run check:deployment && git diff --check",
     "check:deployment": "node scripts/check-deployment.mjs",
     "check:deployment:live": "node scripts/check-deployment.mjs --live",
+    "smoke:api-routes": "node scripts/smoke-cloudflare-api-routes.mjs",
+    "check:web-analytics-token": "node scripts/check-cloudflare-web-analytics-token.mjs",
     "quality:github": "node scripts/dev-github-quality-loop.mjs",
     "validate:contracts": "node scripts/validate-inshell-contracts.mjs",
     "sync:path-release": "tsx scripts/sync-path-release.ts",

--- a/scripts/check-cloudflare-web-analytics-token.mjs
+++ b/scripts/check-cloudflare-web-analytics-token.mjs
@@ -86,7 +86,7 @@ async function main() {
   }
   if (tokenKey !== TOKEN_ENV_KEYS[0]) {
     console.warn(
-      `[web-analytics] using ${tokenKey}; prefer ${TOKEN_ENV_KEYS[0]} for least-privilege RUM metadata reads.`,
+      "[web-analytics] using a non-preferred token; prefer the dedicated least-privilege RUM metadata read token.",
     );
   }
 
@@ -110,7 +110,7 @@ async function main() {
     const message = firstError?.message || response.statusText || "request failed";
     if (response.status === 403) {
       throw new Error(
-        `Cloudflare returned 403 for RUM site metadata. ${tokenKey} needs Web Analytics/RUM metadata read access for account ${accountId}; Account Settings Write alone is not enough. (${message})`,
+        `Cloudflare returned 403 for RUM site metadata. The token needs Web Analytics/RUM metadata read access; Account Settings Write alone is not enough. (${message})`,
       );
     }
     throw new Error(`Cloudflare RUM site metadata request failed with HTTP ${response.status}: ${message}`);
@@ -124,7 +124,7 @@ async function main() {
     console.log(`[web-analytics] site ${host} tag=${String(tag).slice(0, 8)}...`);
   }
   if (loadedEnvPath) {
-    console.log(`[web-analytics] private env loaded: ${loadedEnvPath}`);
+    console.log("[web-analytics] private env loaded");
   }
 }
 

--- a/scripts/check-cloudflare-web-analytics-token.mjs
+++ b/scripts/check-cloudflare-web-analytics-token.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const DEFAULT_PRIVATE_ENV = resolve(homedir(), ".inshell-secrets/inshell-sepolia.env");
+const TOKEN_ENV_KEYS = [
+  "INSHELL_CLOUDFLARE_WEB_ANALYTICS_READ_TOKEN",
+  "CLOUDFLARE_WEB_ANALYTICS_API_TOKEN",
+  "INSHELL_CLOUDFLARE_WEB_ANALYTICS_EDIT",
+];
+
+function parseEnvValue(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function expandPath(input) {
+  if (input.startsWith("~/")) {
+    return resolve(homedir(), input.slice(2));
+  }
+  return resolve(input);
+}
+
+function loadPrivateEnv() {
+  const candidates = [
+    process.env.INSHELL_SECRETS_ENV_FILE,
+    process.env.INSHELL_PRIVATE_ENV_FILE,
+    DEFAULT_PRIVATE_ENV,
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const envPath = expandPath(candidate);
+    if (!existsSync(envPath)) {
+      continue;
+    }
+    const text = readFileSync(envPath, "utf8");
+    for (const rawLine of text.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) {
+        continue;
+      }
+      const normalized = line.startsWith("export ") ? line.slice("export ".length).trim() : line;
+      const separator = normalized.indexOf("=");
+      if (separator <= 0) {
+        continue;
+      }
+      const key = normalized.slice(0, separator).trim();
+      if (!key || process.env[key]) {
+        continue;
+      }
+      process.env[key] = parseEnvValue(normalized.slice(separator + 1));
+    }
+    return envPath;
+  }
+  return null;
+}
+
+function resolveConfig() {
+  const loadedEnvPath = loadPrivateEnv();
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID;
+  const tokenKey = TOKEN_ENV_KEYS.find((key) => process.env[key]);
+  return {
+    accountId,
+    tokenKey,
+    token: tokenKey ? process.env[tokenKey] : undefined,
+    loadedEnvPath,
+  };
+}
+
+async function main() {
+  const { accountId, tokenKey, token, loadedEnvPath } = resolveConfig();
+  if (!accountId) {
+    throw new Error("Missing CLOUDFLARE_ACCOUNT_ID.");
+  }
+  if (!token || !tokenKey) {
+    throw new Error(
+      `Missing Web Analytics read token. Set ${TOKEN_ENV_KEYS[0]} in the private env file.`,
+    );
+  }
+  if (tokenKey !== TOKEN_ENV_KEYS[0]) {
+    console.warn(
+      `[web-analytics] using ${tokenKey}; prefer ${TOKEN_ENV_KEYS[0]} for least-privilege RUM metadata reads.`,
+    );
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/rum/site_info/list`;
+  const response = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json",
+    },
+  });
+  const text = await response.text();
+  let payload = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`Cloudflare returned non-JSON response with HTTP ${response.status}.`);
+  }
+
+  if (!response.ok || payload?.success === false) {
+    const firstError = Array.isArray(payload?.errors) ? payload.errors[0] : null;
+    const message = firstError?.message || response.statusText || "request failed";
+    if (response.status === 403) {
+      throw new Error(
+        `Cloudflare returned 403 for RUM site metadata. ${tokenKey} needs Web Analytics/RUM metadata read access for account ${accountId}; Account Settings Write alone is not enough. (${message})`,
+      );
+    }
+    throw new Error(`Cloudflare RUM site metadata request failed with HTTP ${response.status}: ${message}`);
+  }
+
+  const sites = Array.isArray(payload?.result) ? payload.result : [];
+  console.log(`[web-analytics] ok: ${sites.length} site(s) readable`);
+  for (const site of sites) {
+    const host = site?.host || site?.hostname || site?.site || site?.name || "unknown";
+    const tag = site?.site_tag || site?.siteTag || site?.token || "unknown";
+    console.log(`[web-analytics] site ${host} tag=${String(tag).slice(0, 8)}...`);
+  }
+  if (loadedEnvPath) {
+    console.log(`[web-analytics] private env loaded: ${loadedEnvPath}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[web-analytics] failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-cloudflare-api-routes.mjs
+++ b/scripts/smoke-cloudflare-api-routes.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+const DEFAULT_HOME_BASE = "https://inshell.art";
+const DEFAULT_THOUGHT_BASE = "https://thought.inshell.art";
+const STAGING_HOME_BASE = "https://staging.inshell-art.pages.dev";
+const STAGING_THOUGHT_BASE = "https://staging.thought-inshell-art.pages.dev";
+const SEPOLIA_CHAIN_ID = "0xaa36a7";
+const ATTEMPT_DELAYS_MS = [0, 1_000, 3_000, 6_000];
+const REQUEST_TIMEOUT_MS = 12_000;
+
+function parseArgs(argv) {
+  const args = {
+    scope: "all",
+    homeBase: DEFAULT_HOME_BASE,
+    thoughtBase: DEFAULT_THOUGHT_BASE,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--scope" && next) {
+      args.scope = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--home-base" && next) {
+      args.homeBase = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--thought-base" && next) {
+      args.thoughtBase = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown or incomplete argument: ${arg}`);
+  }
+
+  if (!["all", "home", "thought"].includes(args.scope)) {
+    throw new Error(`Invalid --scope ${args.scope}; expected all, home, or thought.`);
+  }
+  return args;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchJsonWithTimeout(url, init) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+        ...(init?.body ? { "content-type": "application/json" } : {}),
+        ...(init?.headers ?? {}),
+      },
+    });
+    const text = await response.text();
+    let payload = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      throw new Error(`${url} returned non-JSON response with status ${response.status}`);
+    }
+    if (!response.ok) {
+      throw new Error(`${url} returned HTTP ${response.status}: ${JSON.stringify(payload).slice(0, 240)}`);
+    }
+    return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function retry(label, fn) {
+  let lastError;
+  for (const delay of ATTEMPT_DELAYS_MS) {
+    if (delay > 0) {
+      await sleep(delay);
+    }
+    try {
+      const result = await fn();
+      console.log(`[smoke] ok ${label}`);
+      return result;
+    } catch (error) {
+      lastError = error;
+      console.log(`[smoke] retry ${label}: ${error.message}`);
+    }
+  }
+  throw new Error(`${label} failed after ${ATTEMPT_DELAYS_MS.length} attempts: ${lastError?.message ?? "unknown error"}`);
+}
+
+function urlFor(base, path) {
+  return new URL(path, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
+async function checkRpcChainId(base, path, label) {
+  await retry(label, async () => {
+    const payload = await fetchJsonWithTimeout(urlFor(base, path), {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+      }),
+    });
+    if (payload?.result !== SEPOLIA_CHAIN_ID) {
+      throw new Error(`expected Sepolia chain id ${SEPOLIA_CHAIN_ID}, got ${JSON.stringify(payload)}`);
+    }
+  });
+}
+
+async function checkGetArrayField(base, path, field, label) {
+  await retry(label, async () => {
+    const payload = await fetchJsonWithTimeout(urlFor(base, path), { method: "GET" });
+    if (!Array.isArray(payload?.[field])) {
+      throw new Error(`expected JSON array field "${field}"`);
+    }
+  });
+}
+
+async function checkThoughtPreview(base) {
+  await retry("thought /api/thought-preview", async () => {
+    const payload = await fetchJsonWithTimeout(urlFor(base, "/api/thought-preview"), {
+      method: "POST",
+      body: JSON.stringify({ rawReturn: "HELLO" }),
+    });
+    if (!payload || typeof payload.ok !== "boolean") {
+      throw new Error("expected preview payload with boolean ok");
+    }
+  });
+}
+
+async function checkHome(base) {
+  await checkRpcChainId(base, "/api/path-rpc", "home /api/path-rpc");
+  await checkGetArrayField(base, "/api/pulse-auction", "bids", "home /api/pulse-auction");
+  await checkGetArrayField(base, "/api/path-tokens", "items", "home /api/path-tokens");
+}
+
+async function checkThought(base) {
+  await checkRpcChainId(base, "/api/path-rpc", "thought /api/path-rpc");
+  await checkRpcChainId(base, "/api/thought-rpc", "thought /api/thought-rpc");
+  await checkThoughtPreview(base);
+  await checkGetArrayField(base, "/api/thought-gallery", "thoughts", "thought /api/thought-gallery");
+  await checkGetArrayField(base, "/api/path-tokens", "items", "thought /api/path-tokens");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.scope === "home" || args.scope === "all") {
+    await checkHome(args.homeBase);
+  }
+  if (args.scope === "thought" || args.scope === "all") {
+    await checkThought(args.thoughtBase);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[smoke] failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/validate-production-surface.ts
+++ b/scripts/validate-production-surface.ts
@@ -34,6 +34,11 @@ const DEPLOY_WORKFLOW_SNIPPETS = [
   "VITE_THOUGHT_EXPLORER_BASE_URL",
   "VITE_WALLETCONNECT_PROJECT_ID",
   "check:deployment",
+  "Smoke home API routes",
+  "Smoke THOUGHT API routes",
+  "smoke:api-routes",
+  "staging.inshell-art.pages.dev",
+  "staging.thought-inshell-art.pages.dev",
 ] as const;
 
 const HOME_DEV_SCRIPT_SNIPPETS = [
@@ -167,6 +172,14 @@ function checkPackageScripts() {
   if (!productionCheck.includes("check:deployment")) {
     fail("package.json is missing check:production coverage for check:deployment");
   }
+  const smokeApiRoutes = String(rootPkg?.scripts?.["smoke:api-routes"] ?? "");
+  if (!smokeApiRoutes.includes("smoke-cloudflare-api-routes.mjs")) {
+    fail("package.json is missing smoke:api-routes coverage for smoke-cloudflare-api-routes.mjs");
+  }
+  const webAnalyticsTokenCheck = String(rootPkg?.scripts?.["check:web-analytics-token"] ?? "");
+  if (!webAnalyticsTokenCheck.includes("check-cloudflare-web-analytics-token.mjs")) {
+    fail("package.json is missing check:web-analytics-token coverage for check-cloudflare-web-analytics-token.mjs");
+  }
   const deploymentCheckSource = read("scripts/check-deployment.mjs");
   for (const snippet of [
     "validate-production-surface.ts",
@@ -185,6 +198,33 @@ function checkPackageScripts() {
   const rootHomeDevnetBuild = String(rootPkg?.scripts?.["build:home:devnet"] ?? "");
   if (!rootHomeDevnetBuild.includes("@inshell/home build")) {
     fail("package.json build:home:devnet must preserve the explicit devnet-capable build path");
+  }
+
+  const smokeApiRoutesSource = read("scripts/smoke-cloudflare-api-routes.mjs");
+  for (const snippet of [
+    "/api/path-rpc",
+    "/api/thought-rpc",
+    "/api/thought-preview",
+    "/api/pulse-auction",
+    "/api/path-tokens",
+    "/api/thought-gallery",
+    "staging.inshell-art.pages.dev",
+    "staging.thought-inshell-art.pages.dev",
+  ]) {
+    if (!smokeApiRoutesSource.includes(snippet)) {
+      fail(`scripts/smoke-cloudflare-api-routes.mjs is missing ${snippet}`);
+    }
+  }
+
+  const webAnalyticsTokenSource = read("scripts/check-cloudflare-web-analytics-token.mjs");
+  for (const snippet of [
+    "INSHELL_CLOUDFLARE_WEB_ANALYTICS_READ_TOKEN",
+    "rum/site_info/list",
+    "CLOUDFLARE_ACCOUNT_ID",
+  ]) {
+    if (!webAnalyticsTokenSource.includes(snippet)) {
+      fail(`scripts/check-cloudflare-web-analytics-token.mjs is missing ${snippet}`);
+    }
   }
 }
 


### PR DESCRIPTION
Promotes staging changes for Cloudflare route smoke checks, THOUGHT CLI path-list fallback behavior, and Web Analytics token diagnostics.\n\nValidation already run on staging:\n- pnpm lint\n- pnpm --filter @inshell/home test:unit\n- pnpm --filter @inshell/thought type-check\n- pnpm run test:thought-runtime\n- pnpm run check:deployment\n- gitleaks detect --no-git --redact\n- staging deploy run 27466802809\n- live staging API smoke checks for home and THOUGHT\n