### PR TITLE
Promote staging Web Analytics performance fix

### DIFF
--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -36,6 +36,10 @@ class TestHeaders {
   set(key: string, value: string) {
     this.values.set(key.toLowerCase(), value);
   }
+
+  delete(key: string) {
+    this.values.delete(key.toLowerCase());
+  }
 }
 
 class TestRequest {
@@ -258,7 +262,8 @@ describe("Pages middleware canonical routes", () => {
     const response = await onRequest(ctx);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
+    expect(response.headers.get("clear-site-data")).toBeNull();
     expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
     expect(ctx.next).not.toHaveBeenCalled();
   });

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -2,7 +2,7 @@ const PUBLIC_FEED_RSS_URL = "https://inshell-public-feed.pages.dev/rss.xml";
 const PUBLIC_FEED_ALIAS_URL = "https://inshell-public-feed.pages.dev/feed.xml";
 const PUBLIC_FEED_SEPOLIA_RSS_URL = "https://inshell-public-feed.pages.dev/rss.sepolia.xml";
 const PUBLIC_FEED_BASE_URL = "https://inshell-public-feed.pages.dev";
-const TEMP_CLEAR_SITE_DATA_CACHE = "\"cache\"";
+const APP_SHELL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
 type PagesAssets = {
   fetch: (request: Request) => Promise<Response>;
@@ -149,9 +149,8 @@ async function serveAppShell(ctx: MiddlewareContext): Promise<Response> {
 
 function withAppShellHeaders(response: Response) {
   const headers = new Headers(response.headers);
-  // Temporary cleanup for cached 308 route redirects from the RSS hotfix window.
-  headers.set("clear-site-data", TEMP_CLEAR_SITE_DATA_CACHE);
-  headers.set("cache-control", "no-store, max-age=0");
+  headers.delete("clear-site-data");
+  headers.set("cache-control", APP_SHELL_CACHE_CONTROL);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/scripts/validate-production-surface.ts
+++ b/scripts/validate-production-surface.ts
@@ -542,7 +542,7 @@ function checkCloudflareRpcProxy() {
     "PUBLIC_FEED_ALIAS_URL",
     "PUBLIC_FEED_SEPOLIA_RSS_URL",
     "PUBLIC_FEED_BASE_URL",
-    "TEMP_CLEAR_SITE_DATA_CACHE",
+    "APP_SHELL_CACHE_CONTROL",
     "temporarySepoliaHostRedirect",
     "sepolia.inshell.art",
     "getPublicFeedArtifactUrl",
@@ -564,7 +564,8 @@ function checkCloudflareRpcProxy() {
     "/thought",
     "application/rss+xml; charset=utf-8",
     "public, max-age=60",
-    "clear-site-data",
+    "stale-while-revalidate=300",
+    'headers.delete("clear-site-data")',
   ]);
   requireSnippets("functions/api/rpc-gate.ts", [
     "PATH_PRIMARY_RPC_UPSTREAM",


### PR DESCRIPTION
## Summary
- Stop sending no-store app-shell headers and remove the temporary clear-site-data cache purge.
- Cache app-shell routes briefly with stale-while-revalidate to improve returning-visit load behavior and LCP.
- Update the production-surface validator to enforce the new app-shell cache policy.

## Checks already run on staging
- pnpm run check:deployment
- pnpm --filter @inshell/home test -- middlewareFunction.test.ts
- pnpm run build:home
- gitleaks detect --no-git --redact
- GitHub staging test workflow passed
- GitHub staging CodeQL workflow passed