### PR TITLE
Promote GitHub quality loop stale-run fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "smoke:api-routes": "node scripts/smoke-cloudflare-api-routes.mjs",
     "check:web-analytics-token": "node scripts/check-cloudflare-web-analytics-token.mjs",
     "quality:github": "node scripts/dev-github-quality-loop.mjs",
+    "test:dev-quality": "node --test scripts/dev-github-quality-loop.test.mjs",
     "validate:contracts": "node scripts/validate-inshell-contracts.mjs",
     "sync:path-release": "tsx scripts/sync-path-release.ts",
     "sync:thought-release": "tsx scripts/sync-thought-release.ts",

--- a/scripts/dev-github-quality-loop.mjs
+++ b/scripts/dev-github-quality-loop.mjs
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -140,7 +141,74 @@ const issue = ({ kind, severity = "medium", summary, url, details = {} }) => ({
   ...(Object.keys(details).length ? { details } : {}),
 });
 
-const inspectActions = async ({ repo, branch, maxActionRuns }) => {
+export const selectCurrentHeadWorkflowRuns = ({ workflowRuns, branchHeadSha }) => {
+  const runs = Array.isArray(workflowRuns) ? workflowRuns : [];
+  if (!branchHeadSha) {
+    return {
+      currentHeadRuns: runs,
+      ignoredStaleRuns: [],
+    };
+  }
+
+  const currentHeadRuns = [];
+  const ignoredStaleRuns = [];
+  for (const run of runs) {
+    if (run.head_sha === branchHeadSha) {
+      currentHeadRuns.push(run);
+    } else {
+      ignoredStaleRuns.push(run);
+    }
+  }
+
+  return {
+    currentHeadRuns,
+    ignoredStaleRuns,
+  };
+};
+
+export const latestWorkflowRuns = (workflowRuns) => {
+  const latestByWorkflow = new Map();
+  for (const run of workflowRuns) {
+    const key = run.workflow_id ?? run.name ?? run.path ?? run.id;
+    if (!latestByWorkflow.has(key)) {
+      latestByWorkflow.set(key, run);
+    }
+  }
+  return Array.from(latestByWorkflow.values());
+};
+
+const inspectBranchHead = async ({ repo, branch }) => {
+  const response = await ghApi(`repos/${repo}/branches/${encodeURIComponent(branch)}`);
+  if (!response.ok) {
+    return {
+      sha: null,
+      readError: {
+        kind: "github_branch_head",
+        summary: `Unable to read current GitHub branch head for ${branch}.`,
+        error: response.error,
+      },
+    };
+  }
+
+  const sha = response.data?.commit?.sha;
+  if (!sha) {
+    return {
+      sha: null,
+      readError: {
+        kind: "github_branch_head",
+        summary: `GitHub branch ${branch} did not return a commit SHA.`,
+        error: {
+          status: null,
+          message: "Missing commit.sha in branch response.",
+        },
+      },
+    };
+  }
+
+  return { sha, readError: null };
+};
+
+const inspectActions = async ({ repo, branch, maxActionRuns, branchHeadSha }) => {
   const endpoint =
     `repos/${repo}/actions/runs?branch=${encodeURIComponent(branch)}&status=completed&per_page=${maxActionRuns}`;
   const response = await ghApi(endpoint);
@@ -156,17 +224,15 @@ const inspectActions = async ({ repo, branch, maxActionRuns }) => {
   }
 
   const workflowRuns = Array.isArray(response.data?.workflow_runs) ? response.data.workflow_runs : [];
-  const latestByWorkflow = new Map();
-  for (const run of workflowRuns) {
-    const key = run.workflow_id ?? run.name ?? run.path ?? run.id;
-    if (!latestByWorkflow.has(key)) {
-      latestByWorkflow.set(key, run);
-    }
-  }
+  const { currentHeadRuns, ignoredStaleRuns } = selectCurrentHeadWorkflowRuns({
+    workflowRuns,
+    branchHeadSha,
+  });
+  const latestRuns = latestWorkflowRuns(currentHeadRuns);
 
   const badConclusions = new Set(["failure", "timed_out", "action_required", "startup_failure"]);
   const issues = [];
-  for (const run of latestByWorkflow.values()) {
+  for (const run of latestRuns) {
     if (!badConclusions.has(run.conclusion)) {
       continue;
     }
@@ -183,11 +249,23 @@ const inspectActions = async ({ repo, branch, maxActionRuns }) => {
         displayTitle: run.display_title,
         createdAt: run.created_at,
         updatedAt: run.updated_at,
+        headSha: run.head_sha,
+        currentBranchHeadSha: branchHeadSha,
       },
     }));
   }
 
-  return { issues, readError: null };
+  return {
+    issues,
+    readError: null,
+    diagnostics: {
+      kind: "actions",
+      branchHeadSha,
+      completedRunsRead: workflowRuns.length,
+      currentHeadRunsRead: currentHeadRuns.length,
+      ignoredStaleRuns: ignoredStaleRuns.length,
+    },
+  };
 };
 
 const inspectDependabot = async ({ repo }) => {
@@ -371,16 +449,25 @@ const workflowRunUrl = () => {
 const main = async () => {
   const args = parseArgs(process.argv.slice(2));
   const startedAt = new Date();
+  const branchHead = await inspectBranchHead(args);
 
   const results = await Promise.all([
-    inspectActions(args),
+    inspectActions({ ...args, branchHeadSha: branchHead.sha }),
     inspectDependabot(args),
     inspectCodeScanning(args),
     inspectSecretScanning(args),
   ]);
 
   const openIssues = results.flatMap((result) => result.issues);
-  const readErrors = results.flatMap((result) => result.readError ? [result.readError] : []);
+  const readErrors = [
+    ...(branchHead.readError ? [branchHead.readError] : []),
+    ...results.flatMap((result) => result.readError ? [result.readError] : []),
+  ];
+  const diagnostics = Object.fromEntries(
+    results
+      .filter((result) => result.diagnostics)
+      .map((result) => [result.diagnostics.kind || "actions", result.diagnostics])
+  );
   const finishedAt = new Date();
   const runStatus = openIssues.length || readErrors.length ? "blocked" : "ok";
   const activeAlerts = buildOpsAlerts({ openIssues, readErrors });
@@ -412,10 +499,12 @@ const main = async () => {
       finishedAt: finishedAt.toISOString(),
       status: runStatus,
       branch: args.branch,
+      branchHeadSha: branchHead.sha,
       workflowRunUrl: workflowRunUrl(),
       checked,
       openIssues,
       readErrors,
+      diagnostics,
       repairs: [],
       repairPolicy: "DEV patches safe repo-local issues on staging from this status. The loop does not mutate provider accounts, secrets, billing, Cloudflare, or OPS config.",
     },
@@ -444,7 +533,9 @@ const main = async () => {
   }
 };
 
-main().catch((error) => {
-  console.error(error?.stack || error?.message || String(error));
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/dev-github-quality-loop.test.mjs
+++ b/scripts/dev-github-quality-loop.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  latestWorkflowRuns,
+  selectCurrentHeadWorkflowRuns,
+} from "./dev-github-quality-loop.mjs";
+
+test("ignores completed workflow runs from obsolete branch heads", () => {
+  const currentHeadSha = "ce29c6e";
+  const staleHeadSha = "48d87ee";
+  const workflowRuns = [
+    {
+      id: 27495688502,
+      workflow_id: 11,
+      name: "Dependabot Updates",
+      conclusion: "failure",
+      head_sha: staleHeadSha,
+    },
+    {
+      id: 27542398536,
+      workflow_id: 11,
+      name: "Dependabot Updates",
+      conclusion: "success",
+      head_sha: currentHeadSha,
+    },
+    {
+      id: 27542398537,
+      workflow_id: 12,
+      name: "test",
+      conclusion: "success",
+      head_sha: currentHeadSha,
+    },
+  ];
+
+  const { currentHeadRuns, ignoredStaleRuns } = selectCurrentHeadWorkflowRuns({
+    workflowRuns,
+    branchHeadSha: currentHeadSha,
+  });
+  const latestRuns = latestWorkflowRuns(currentHeadRuns);
+
+  assert.equal(ignoredStaleRuns.length, 1);
+  assert.deepEqual(latestRuns.map((run) => run.id), [27542398536, 27542398537]);
+  assert.equal(latestRuns.some((run) => run.conclusion === "failure"), false);
+});
+
+test("keeps all completed workflow runs when branch head is unavailable", () => {
+  const workflowRuns = [
+    { id: 1, workflow_id: 11, conclusion: "failure", head_sha: "old" },
+    { id: 2, workflow_id: 12, conclusion: "success", head_sha: "current" },
+  ];
+
+  const { currentHeadRuns, ignoredStaleRuns } = selectCurrentHeadWorkflowRuns({
+    workflowRuns,
+    branchHeadSha: null,
+  });
+
+  assert.deepEqual(currentHeadRuns, workflowRuns);
+  assert.deepEqual(ignoredStaleRuns, []);
+});


### PR DESCRIPTION
Promotes the DEV GitHub quality loop fix from staging to main.\n\nChanges:\n- Ignore completed GitHub Actions runs from obsolete branch head SHAs when computing quality status.\n- Add regression coverage for stale Dependabot workflow failures.\n- Add a focused test script for the quality loop.\n\nValidation already run on staging:\n- pnpm run test:dev-quality\n- pnpm run quality:github -> status ok\n- targeted eslint\n- gitleaks detect --no-git --redact\n- push hook full unit suite\n- manual dev-github-quality-loop workflow run 27544032598 -> success, artifact status ok\n