### PR TITLE
Reconcile source proxy hotfix to staging

### DIFF
--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -5,6 +5,7 @@ const originalRequest = globalThis.Request;
 const originalResponse = globalThis.Response;
 const originalHeaders = globalThis.Headers;
 const originalFetch = globalThis.fetch;
+const publicFeedSourceBaseUrl = "https://d807d286.inshell-public-feed.pages.dev";
 
 class TestHeaders {
   private readonly values = new Map<string, string>();
@@ -178,7 +179,7 @@ describe("Pages middleware canonical routes", () => {
     expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("public, max-age=60");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://inshell-public-feed.pages.dev/events.json",
+      `${publicFeedSourceBaseUrl}/events.json`,
       expect.objectContaining({
         headers: expect.objectContaining({
           accept: "application/json, */*;q=0.1",
@@ -207,7 +208,36 @@ describe("Pages middleware canonical routes", () => {
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("public, max-age=60");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://inshell-public-feed.pages.dev/source/thought-9.html?via=rss",
+      `${publicFeedSourceBaseUrl}/source/thought-9.html?via=rss`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: "text/html, application/xhtml+xml;q=0.9, */*;q=0.1",
+        }),
+      }),
+    );
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("preserves encoded Public Feed cloud source ids", async () => {
+    const fetchMock = jest.fn(
+      async () =>
+        new Response("<!doctype html><title>cloud source</title>", {
+          status: 200,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const cloudId =
+      "sepolia%3Acloud%3Amovement.minted%3A0x88632290a357c40d8af1cb6c9edee44a02b7ce828b605613510e9a98a0a06847";
+    const ctx = middlewareContext(`https://inshell.art/source/sepolia/cloud/${cloudId}`);
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${publicFeedSourceBaseUrl}/source/sepolia/cloud/${cloudId}`,
       expect.objectContaining({
         headers: expect.objectContaining({
           accept: "text/html, application/xhtml+xml;q=0.9, */*;q=0.1",
@@ -236,7 +266,38 @@ describe("Pages middleware canonical routes", () => {
     expect(response.headers.get("content-type")).toBe("text/css; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("public, max-age=60");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://inshell-public-feed.pages.dev/source-assets/feed.css",
+      `${publicFeedSourceBaseUrl}/source-assets/feed.css`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: "*/*",
+        }),
+      }),
+    );
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("preserves encoded Public Feed cloud media ids", async () => {
+    const fetchMock = jest.fn(
+      async () =>
+        new Response("<svg></svg>", {
+          status: 200,
+          headers: {
+            "content-type": "image/svg+xml",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const cloudId =
+      "sepolia%3Acloud%3Amovement.minted%3A0x88632290a357c40d8af1cb6c9edee44a02b7ce828b605613510e9a98a0a06847";
+    const ctx = middlewareContext(
+      `https://inshell.art/source-assets/sepolia/cloud/${cloudId}/thought.svg`,
+    );
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${publicFeedSourceBaseUrl}/source-assets/sepolia/cloud/${cloudId}/thought.svg`,
       expect.objectContaining({
         headers: expect.objectContaining({
           accept: "*/*",

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,7 +1,7 @@
 const PUBLIC_FEED_RSS_URL = "https://inshell-public-feed.pages.dev/rss.xml";
 const PUBLIC_FEED_ALIAS_URL = "https://inshell-public-feed.pages.dev/feed.xml";
 const PUBLIC_FEED_SEPOLIA_RSS_URL = "https://inshell-public-feed.pages.dev/rss.sepolia.xml";
-const PUBLIC_FEED_BASE_URL = "https://inshell-public-feed.pages.dev";
+const PUBLIC_FEED_BASE_URL = "https://d807d286.inshell-public-feed.pages.dev";
 const APP_SHELL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
 type PagesAssets = {
@@ -39,7 +39,7 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   if (pathname === "/rss.sepolia.xml") {
     return proxyFeed(PUBLIC_FEED_SEPOLIA_RSS_URL, ctx.request);
   }
-  const publicFeedArtifactUrl = getPublicFeedArtifactUrl(url);
+  const publicFeedArtifactUrl = getPublicFeedArtifactUrl(ctx.request.url);
   if (publicFeedArtifactUrl) {
     return proxyPublicFeedArtifact(publicFeedArtifactUrl, ctx.request);
   }
@@ -132,7 +132,8 @@ function isGalleryIntent(hostname: string, pathname: string, url: UrlInstance) {
   );
 }
 
-function getPublicFeedArtifactUrl(url: UrlInstance) {
+function getPublicFeedArtifactUrl(requestUrl: string) {
+  const url = new globalThis.URL(requestUrl);
   if (
     url.pathname === "/events.json" ||
     url.pathname === "/source" ||
@@ -140,12 +141,28 @@ function getPublicFeedArtifactUrl(url: UrlInstance) {
     url.pathname === "/source-assets" ||
     url.pathname.startsWith("/source-assets/")
   ) {
-    const target = new globalThis.URL(url.pathname, PUBLIC_FEED_BASE_URL);
-    target.search = url.search;
-    return target.toString();
+    return `${PUBLIC_FEED_BASE_URL}${encodedPathnameForProxy(url.pathname)}${url.search}`;
   }
 
   return null;
+}
+
+function encodedPathnameForProxy(pathname: string) {
+  return (
+    pathname
+      .split("/")
+      .map((segment) => encodePathSegment(segment))
+      .join("/") || "/"
+  );
+}
+
+function encodePathSegment(segment: string) {
+  if (!segment) return "";
+  try {
+    return encodeURIComponent(decodeURIComponent(segment));
+  } catch {
+    return encodeURIComponent(segment);
+  }
 }
 
 async function serveAppShell(ctx: MiddlewareContext): Promise<Response> {


### PR DESCRIPTION
## Summary\n- cherry-pick the production public feed source/media proxy hotfix onto staging\n- keep encoded cloud source/media regression coverage aligned with main\n\n## Checks\n- pnpm --filter @inshell/home test -- --runTestsByPath tests/middlewareFunction.test.ts\n- pnpm run check:deployment\n- gitleaks detect --no-git --redact\n- git diff --check HEAD~1..HEAD\n- pre-push hook: lint, type-check, test:unit