### PR TITLE
Promote staging: event ingest status marker diagnostics

### DIFF
--- a/.ops/dev-chain/event-driven-chain-indexer-ops-followup.md
+++ b/.ops/dev-chain/event-driven-chain-indexer-ops-followup.md
@@ -67,3 +67,43 @@ Before OPS enables the production fast path:
 - confirm preview testing requirements if `https://preview.inshell.art/api/indexer/event` stays behind Cloudflare Access.
 
 No website route shape change is requested from OPS. The browser should not call provider webhooks, OPS endpoints, hosted indexers, or raw RPC.
+
+## DEV Follow-Up: 2026-06-16
+
+DEV patched the event-ingest status contract so `/api/ops/status` is no longer a static capability-only response for event ingest.
+
+`POST /api/indexer/event` now writes a non-secret status marker into the D1-backed `chain_snapshots` table under:
+
+```txt
+indexer-event-ingest-status:v1:sepolia
+```
+
+`/api/ops/status.indexerEventIngest` now exposes:
+
+- `statusSource`
+- `lastAcceptedAt`
+- `lastAppliedAt`
+- `lastAppliedTarget`
+- `lastTxHash`
+- `lastBlockNumber`
+- `lastLogIndex`
+- `lastResultApplied`
+- `lastResultSource`
+- `cachedAt`
+- `lastScannedBlock`
+- `acceptedCount`
+- `appliedCount`
+
+The status route is now `no-store` so OPS monitoring does not receive stale event-ingest state from HTTP cache.
+
+Preview testing policy:
+
+- Default OPS preview target should be the Cloudflare Pages branch alias:
+  `https://staging.inshell-art.pages.dev/api/indexer/event`
+- The matching status endpoint is:
+  `https://staging.inshell-art.pages.dev/api/ops/status`
+- `https://preview.inshell.art/...` remains behind Cloudflare Access. OPS should use it only with Access service-token headers, unless the operator explicitly approves a bypass policy.
+
+`/api/pulse-auction` remains the public website read path for PATH/Pulse UI.
+
+`/api/indexer/refresh` remains valid as the scheduled reconciliation fallback.

--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -87,7 +87,11 @@ function createD1Mock(
   const rows = new Map<string, string>(
     Object.entries(seed).map(([key, value]) => [key, JSON.stringify(value)]),
   );
-  const exec = jest.fn(async () => undefined);
+  const exec = jest.fn(async (query: string) => {
+    if (/create\s+table/i.test(query) && /\n/.test(query)) {
+      throw new Error("mock D1 exec rejects multiline CREATE TABLE statements");
+    }
+  });
   const prepare = jest.fn((query: string) => {
     let bound: unknown[] = [];
     const statement = {

--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -80,7 +80,10 @@ function rpcError(status: number, message: string) {
   };
 }
 
-function createD1Mock(seed: Record<string, unknown> = {}) {
+function createD1Mock(
+  seed: Record<string, unknown> = {},
+  options: { failWritesForKeys?: string[]; failReadsForKeys?: string[] } = {},
+) {
   const rows = new Map<string, string>(
     Object.entries(seed).map(([key, value]) => [key, JSON.stringify(value)]),
   );
@@ -95,6 +98,9 @@ function createD1Mock(seed: Record<string, unknown> = {}) {
       first: jest.fn(async () => {
         if (/select\s+snapshot_json/i.test(query)) {
           const key = String(bound[0] ?? "");
+          if (options.failReadsForKeys?.includes(key)) {
+            throw new Error(`forced D1 read failure for ${key}`);
+          }
           const snapshot_json = rows.get(key);
           return snapshot_json ? { snapshot_json } : null;
         }
@@ -102,7 +108,11 @@ function createD1Mock(seed: Record<string, unknown> = {}) {
       }),
       run: jest.fn(async () => {
         if (/insert\s+into\s+chain_snapshots/i.test(query)) {
-          rows.set(String(bound[0] ?? ""), String(bound[1] ?? ""));
+          const key = String(bound[0] ?? "");
+          if (options.failWritesForKeys?.includes(key)) {
+            throw new Error(`forced D1 write failure for ${key}`);
+          }
+          rows.set(key, String(bound[1] ?? ""));
         }
         return {};
       }),
@@ -638,7 +648,16 @@ describe("chain cache Pages functions", () => {
         CHAIN_CACHE_DIAGNOSTICS: "1",
       },
     });
-    const payload = (await response.json()) as { ok?: boolean; applied?: boolean };
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      applied?: boolean;
+      eventStatus?: {
+        persisted?: boolean;
+        statusSource?: string;
+        lastAcceptedAt?: string | null;
+        error?: string | null;
+      };
+    };
     const stored = JSON.parse(d1.rows.get("pulse-auction:v1:sepolia") ?? "{}") as {
       items?: Array<{ txHash?: string; amount?: { dec?: string } }>;
     };
@@ -670,6 +689,12 @@ describe("chain cache Pages functions", () => {
     expect(status.lastResultSource).toBe("d1");
     expect(status.acceptedCount).toBe(1);
     expect(status.appliedCount).toBe(1);
+    expect(payload.eventStatus?.persisted).toBe(true);
+    expect(payload.eventStatus?.statusSource).toBe("d1");
+    expect(payload.eventStatus?.lastAcceptedAt).toEqual(expect.any(String));
+    expect(payload.eventStatus?.error).toBeNull();
+    expect(response.headers.get("x-indexer-event-status-write")).toBe("1");
+    expect(response.headers.get("x-indexer-event-status-source")).toBe("d1");
     expect(response.headers.get("x-live-rpc-calls")).toBe("3");
     expect(response.headers.get("x-db-write")).toBe("1");
   });
@@ -775,6 +800,81 @@ describe("chain cache Pages functions", () => {
     expect(response.headers.get("x-live-rpc-calls")).toBe("0");
   });
 
+  test("indexer event reports marker persistence failure without hiding ingest success", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const txHash = `0x${"abc".padStart(64, "0")}`;
+    const d1 = createD1Mock(
+      {
+        "pulse-auction:v1:sepolia": {
+          version: 1,
+          cachedAt: Date.now() - 120_000,
+          chainId: 11155111,
+          contract: PULSE_AUCTION,
+          fromBlock: 10854123,
+          lastScannedBlock: 10860000,
+          items: [
+            {
+              key: `sale:${txHash}:2`,
+              txHash,
+              atMs: 1_780_000_000_000,
+              amount: { raw: { low: "12", high: "0" }, dec: "12" },
+            },
+          ],
+        } satisfies IndexedSnapshot<unknown>,
+      },
+      { failWritesForKeys: ["indexer-event-ingest-status:v1:sepolia"] },
+    );
+    const fetchMock = jest.fn(async () => {
+      throw new Error("live RPC should not be called for an already indexed tx");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerEventPost({
+      request: new Request("https://preview.inshell.art/api/indexer/event", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          source: "ops-chain-event-ingress",
+          network: "sepolia",
+          target: "pulse-auction",
+          txHash,
+          blockNumber: 10856428,
+          logIndex: 2,
+          contractAddress: PULSE_AUCTION,
+          topic0: PULSE_SALE_TOPIC,
+        }),
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        CHAIN_CACHE_DIAGNOSTICS: "1",
+      },
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      applied?: boolean;
+      eventStatus?: { persisted?: boolean; statusSource?: string; error?: string | null };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.applied).toBe(true);
+    expect(payload.eventStatus?.persisted).toBe(false);
+    expect(payload.eventStatus?.statusSource).toBe("error");
+    expect(payload.eventStatus?.error).toContain("forced D1 write failure");
+    expect(response.headers.get("x-indexer-event-status-write")).toBe("0");
+    expect(response.headers.get("x-indexer-event-status-source")).toBe("error");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("ops status advertises event-driven indexer ingest state", async () => {
     globalThis.Request = TestRequest as unknown as typeof Request;
     globalThis.Response = TestResponse as unknown as typeof Response;
@@ -815,6 +915,7 @@ describe("chain cache Pages functions", () => {
         lastTxHash?: string | null;
         acceptedCount?: number;
         appliedCount?: number;
+        statusError?: string | null;
       };
     };
 
@@ -826,6 +927,7 @@ describe("chain cache Pages functions", () => {
     expect(payload.indexerEventIngest?.route).toBe("/api/indexer/event");
     expect(payload.indexerEventIngest?.targets).toEqual(["pulse-auction"]);
     expect(payload.indexerEventIngest?.statusSource).toBe("d1");
+    expect(payload.indexerEventIngest?.statusError).toBeNull();
     expect(payload.indexerEventIngest?.lastAcceptedAt).toBe("2026-06-16T11:00:00.000Z");
     expect(payload.indexerEventIngest?.lastAppliedAt).toBe("2026-06-16T11:00:00.000Z");
     expect(payload.indexerEventIngest?.lastAppliedTarget).toBe("pulse-auction");

--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -642,12 +642,34 @@ describe("chain cache Pages functions", () => {
     const stored = JSON.parse(d1.rows.get("pulse-auction:v1:sepolia") ?? "{}") as {
       items?: Array<{ txHash?: string; amount?: { dec?: string } }>;
     };
+    const status = JSON.parse(
+      d1.rows.get("indexer-event-ingest-status:v1:sepolia") ?? "{}",
+    ) as {
+      lastAcceptedAt?: string;
+      lastAppliedTarget?: string;
+      lastTxHash?: string;
+      lastBlockNumber?: number;
+      lastLogIndex?: number;
+      lastResultApplied?: boolean;
+      lastResultSource?: string;
+      acceptedCount?: number;
+      appliedCount?: number;
+    };
 
     expect(response.status).toBe(200);
     expect(payload.ok).toBe(true);
     expect(payload.applied).toBe(true);
     expect(stored.items?.[0]?.txHash).toBe(txHash);
     expect(stored.items?.[0]?.amount?.dec).toBe("12");
+    expect(status.lastAcceptedAt).toEqual(expect.any(String));
+    expect(status.lastAppliedTarget).toBe("pulse-auction");
+    expect(status.lastTxHash).toBe(txHash);
+    expect(status.lastBlockNumber).toBe(10856428);
+    expect(status.lastLogIndex).toBe(2);
+    expect(status.lastResultApplied).toBe(true);
+    expect(status.lastResultSource).toBe("d1");
+    expect(status.acceptedCount).toBe(1);
+    expect(status.appliedCount).toBe(1);
     expect(response.headers.get("x-live-rpc-calls")).toBe("3");
     expect(response.headers.get("x-db-write")).toBe("1");
   });
@@ -753,26 +775,63 @@ describe("chain cache Pages functions", () => {
     expect(response.headers.get("x-live-rpc-calls")).toBe("0");
   });
 
-  test("ops status advertises event-driven indexer ingest", async () => {
+  test("ops status advertises event-driven indexer ingest state", async () => {
     globalThis.Request = TestRequest as unknown as typeof Request;
     globalThis.Response = TestResponse as unknown as typeof Response;
     globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    const d1 = createD1Mock({
+      "indexer-event-ingest-status:v1:sepolia": {
+        version: 1,
+        updatedAt: "2026-06-16T11:00:00.000Z",
+        lastAcceptedAt: "2026-06-16T11:00:00.000Z",
+        lastAppliedAt: "2026-06-16T11:00:00.000Z",
+        lastAppliedTarget: "pulse-auction",
+        lastTxHash: `0x${"456".padStart(64, "0")}`,
+        lastBlockNumber: 10856428,
+        lastLogIndex: 2,
+        lastResultApplied: true,
+        lastResultSource: "d1",
+        cachedAt: 1_781_000_000_000,
+        lastScannedBlock: 10856500,
+        acceptedCount: 3,
+        appliedCount: 2,
+      },
+    });
 
     const response = await onOpsStatusGet({
       request: new Request("https://preview.inshell.art/api/ops/status"),
-      env: {},
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
     const payload = (await response.json()) as {
       routes?: { event?: { route?: string; targets?: string[] } };
-      indexerEventIngest?: { enabled?: boolean; route?: string; targets?: string[] };
+      indexerEventIngest?: {
+        enabled?: boolean;
+        route?: string;
+        targets?: string[];
+        statusSource?: string;
+        lastAcceptedAt?: string | null;
+        lastAppliedAt?: string | null;
+        lastAppliedTarget?: string | null;
+        lastTxHash?: string | null;
+        acceptedCount?: number;
+        appliedCount?: number;
+      };
     };
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(payload.routes?.event?.route).toBe("/api/indexer/event");
     expect(payload.routes?.event?.targets).toEqual(["pulse-auction"]);
     expect(payload.indexerEventIngest?.enabled).toBe(true);
     expect(payload.indexerEventIngest?.route).toBe("/api/indexer/event");
     expect(payload.indexerEventIngest?.targets).toEqual(["pulse-auction"]);
+    expect(payload.indexerEventIngest?.statusSource).toBe("d1");
+    expect(payload.indexerEventIngest?.lastAcceptedAt).toBe("2026-06-16T11:00:00.000Z");
+    expect(payload.indexerEventIngest?.lastAppliedAt).toBe("2026-06-16T11:00:00.000Z");
+    expect(payload.indexerEventIngest?.lastAppliedTarget).toBe("pulse-auction");
+    expect(payload.indexerEventIngest?.lastTxHash).toBe(`0x${"456".padStart(64, "0")}`);
+    expect(payload.indexerEventIngest?.acceptedCount).toBe(3);
+    expect(payload.indexerEventIngest?.appliedCount).toBe(2);
   });
 
   test("writes KV when snapshot content changes", async () => {

--- a/functions/api/chain-cache.ts
+++ b/functions/api/chain-cache.ts
@@ -944,16 +944,16 @@ function snapshotBlock(value: unknown) {
 
 async function ensureD1SnapshotTable(db: D1DatabaseLike) {
   if (!db.exec || ensuredD1Tables.has(db as object)) return;
-  await db.exec(`
-    CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (
-      key TEXT PRIMARY KEY,
-      snapshot_json TEXT NOT NULL,
-      cached_at INTEGER NOT NULL,
-      last_scanned_block INTEGER NOT NULL,
-      content_hash TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `);
+  await db.exec(
+    `CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (` +
+      "key TEXT PRIMARY KEY, " +
+      "snapshot_json TEXT NOT NULL, " +
+      "cached_at INTEGER NOT NULL, " +
+      "last_scanned_block INTEGER NOT NULL, " +
+      "content_hash TEXT NOT NULL, " +
+      "updated_at INTEGER NOT NULL" +
+      ")",
+  );
   ensuredD1Tables.add(db as object);
 }
 

--- a/functions/api/indexer/event-status.ts
+++ b/functions/api/indexer/event-status.ts
@@ -145,16 +145,15 @@ export async function writeIndexerEventStatus(
 
 async function ensureStatusTable(db: NonNullable<ChainCacheEnv["INSHELL_CHAIN_DATA_DB"]>) {
   if (ensuredStatusTables.has(db as object)) return;
-  const query = `
-    CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (
-      key TEXT PRIMARY KEY,
-      snapshot_json TEXT NOT NULL,
-      cached_at INTEGER NOT NULL,
-      last_scanned_block INTEGER NOT NULL,
-      content_hash TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `;
+  const query =
+    `CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (` +
+    "key TEXT PRIMARY KEY, " +
+    "snapshot_json TEXT NOT NULL, " +
+    "cached_at INTEGER NOT NULL, " +
+    "last_scanned_block INTEGER NOT NULL, " +
+    "content_hash TEXT NOT NULL, " +
+    "updated_at INTEGER NOT NULL" +
+    ")";
   if (db.exec) await db.exec(query);
   else await db.prepare(query).run();
   ensuredStatusTables.add(db as object);

--- a/functions/api/indexer/event-status.ts
+++ b/functions/api/indexer/event-status.ts
@@ -32,38 +32,68 @@ type WriteIndexerEventStatusInput = {
   source: string;
 };
 
+export type IndexerEventStatusRead =
+  | { source: "d1"; status: IndexerEventStatus; error: null }
+  | { source: "empty"; status: null; error: null }
+  | { source: "unavailable"; status: null; error: string }
+  | { source: "error"; status: null; error: string };
+
+export type IndexerEventStatusWrite =
+  | { persisted: true; source: "d1"; status: IndexerEventStatus; error: null }
+  | { persisted: false; source: "unavailable" | "error"; status: null; error: string };
+
 const ensuredStatusTables = new WeakSet<object>();
 
 export async function readIndexerEventStatus(
   env: ChainCacheEnv,
-): Promise<IndexerEventStatus | null> {
+): Promise<IndexerEventStatusRead> {
   const db = env.INSHELL_CHAIN_DATA_DB;
-  if (!db) return null;
+  if (!db) {
+    return { source: "unavailable", status: null, error: "INSHELL_CHAIN_DATA_DB is not bound" };
+  }
   try {
-    await ensureStatusTable(env);
+    await ensureStatusTable(db);
     const row = await db
       .prepare(`SELECT snapshot_json FROM ${D1_SNAPSHOT_TABLE} WHERE key = ?1`)
       .bind(STATUS_KEY)
       .first<{ snapshot_json?: string }>();
     const raw = row?.snapshot_json;
-    if (!raw) return null;
+    if (!raw) return { source: "empty", status: null, error: null };
     const parsed = JSON.parse(raw);
-    if (isIndexerEventStatus(parsed)) return parsed;
-  } catch {
-    return null;
+    if (isIndexerEventStatus(parsed)) {
+      return { source: "d1", status: parsed, error: null };
+    }
+    return { source: "error", status: null, error: "invalid indexer event status payload" };
+  } catch (error) {
+    return { source: "error", status: null, error: readableError(error) };
   }
-  return null;
 }
 
 export async function writeIndexerEventStatus(
   env: ChainCacheEnv,
   input: WriteIndexerEventStatusInput,
-) {
+): Promise<IndexerEventStatusWrite> {
   const db = env.INSHELL_CHAIN_DATA_DB;
-  if (!db) return;
+  if (!db) {
+    return {
+      persisted: false,
+      source: "unavailable",
+      status: null,
+      error: "INSHELL_CHAIN_DATA_DB is not bound",
+    };
+  }
   try {
-    await ensureStatusTable(env);
-    const previous = await readIndexerEventStatus(env);
+    await ensureStatusTable(db);
+    const previousResult = await readIndexerEventStatus(env);
+    if (previousResult.source === "error") {
+      return {
+        persisted: false,
+        source: "error",
+        status: null,
+        error: previousResult.error,
+      };
+    }
+    const previous = previousResult.status;
     const now = new Date().toISOString();
     const status: IndexerEventStatus = {
       version: STATUS_VERSION,
@@ -107,15 +137,15 @@ export async function writeIndexerEventStatus(
         Date.now(),
       )
       .run();
-  } catch {
-    // Event ingest should not fail only because the monitoring marker failed.
+    return { persisted: true, source: "d1", status, error: null };
+  } catch (error) {
+    return { persisted: false, source: "error", status: null, error: readableError(error) };
   }
 }
 
-async function ensureStatusTable(env: ChainCacheEnv) {
-  const db = env.INSHELL_CHAIN_DATA_DB;
-  if (!db?.exec || ensuredStatusTables.has(db as object)) return;
-  await db.exec(`
+async function ensureStatusTable(db: NonNullable<ChainCacheEnv["INSHELL_CHAIN_DATA_DB"]>) {
+  if (ensuredStatusTables.has(db as object)) return;
+  const query = `
     CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (
       key TEXT PRIMARY KEY,
       snapshot_json TEXT NOT NULL,
@@ -124,7 +154,9 @@ async function ensureStatusTable(env: ChainCacheEnv) {
       content_hash TEXT NOT NULL,
       updated_at INTEGER NOT NULL
     )
-  `);
+  `;
+  if (db.exec) await db.exec(query);
+  else await db.prepare(query).run();
   ensuredStatusTables.add(db as object);
 }
 
@@ -142,4 +174,12 @@ function isIndexerEventStatus(value: unknown): value is IndexerEventStatus {
     typeof status.cachedAt === "number" &&
     typeof status.lastScannedBlock === "number"
   );
+}
+
+function readableError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer <redacted>")
+    .replace(/(token=)[A-Za-z0-9._~+/=-]+/gi, "$1<redacted>")
+    .slice(0, 300);
 }

--- a/functions/api/indexer/event-status.ts
+++ b/functions/api/indexer/event-status.ts
@@ -1,0 +1,145 @@
+import type { ChainCacheEnv } from "../chain-cache";
+
+const STATUS_KEY = "indexer-event-ingest-status:v1:sepolia";
+const D1_SNAPSHOT_TABLE = "chain_snapshots";
+const STATUS_VERSION = 1;
+
+type IndexerEventStatus = {
+  version: 1;
+  updatedAt: string;
+  lastAcceptedAt: string;
+  lastAppliedAt: string | null;
+  lastAppliedTarget: "pulse-auction" | null;
+  lastTxHash: string;
+  lastBlockNumber: number;
+  lastLogIndex: number;
+  lastResultApplied: boolean;
+  lastResultSource: string;
+  cachedAt: number;
+  lastScannedBlock: number;
+  acceptedCount: number;
+  appliedCount: number;
+};
+
+type WriteIndexerEventStatusInput = {
+  target: "pulse-auction";
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  applied: boolean;
+  cachedAt: number;
+  lastScannedBlock: number;
+  source: string;
+};
+
+const ensuredStatusTables = new WeakSet<object>();
+
+export async function readIndexerEventStatus(
+  env: ChainCacheEnv,
+): Promise<IndexerEventStatus | null> {
+  const db = env.INSHELL_CHAIN_DATA_DB;
+  if (!db) return null;
+  try {
+    await ensureStatusTable(env);
+    const row = await db
+      .prepare(`SELECT snapshot_json FROM ${D1_SNAPSHOT_TABLE} WHERE key = ?1`)
+      .bind(STATUS_KEY)
+      .first<{ snapshot_json?: string }>();
+    const raw = row?.snapshot_json;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (isIndexerEventStatus(parsed)) return parsed;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export async function writeIndexerEventStatus(
+  env: ChainCacheEnv,
+  input: WriteIndexerEventStatusInput,
+) {
+  const db = env.INSHELL_CHAIN_DATA_DB;
+  if (!db) return;
+  try {
+    await ensureStatusTable(env);
+    const previous = await readIndexerEventStatus(env);
+    const now = new Date().toISOString();
+    const status: IndexerEventStatus = {
+      version: STATUS_VERSION,
+      updatedAt: now,
+      lastAcceptedAt: now,
+      lastAppliedAt: input.applied ? now : previous?.lastAppliedAt ?? null,
+      lastAppliedTarget: input.applied ? input.target : previous?.lastAppliedTarget ?? null,
+      lastTxHash: input.txHash,
+      lastBlockNumber: input.blockNumber,
+      lastLogIndex: input.logIndex,
+      lastResultApplied: input.applied,
+      lastResultSource: input.source,
+      cachedAt: input.cachedAt,
+      lastScannedBlock: input.lastScannedBlock,
+      acceptedCount: (previous?.acceptedCount ?? 0) + 1,
+      appliedCount: (previous?.appliedCount ?? 0) + (input.applied ? 1 : 0),
+    };
+    await db
+      .prepare(`
+        INSERT INTO ${D1_SNAPSHOT_TABLE}
+          (key, snapshot_json, cached_at, last_scanned_block, content_hash, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(key) DO UPDATE SET
+          snapshot_json = excluded.snapshot_json,
+          cached_at = excluded.cached_at,
+          last_scanned_block = excluded.last_scanned_block,
+          content_hash = excluded.content_hash,
+          updated_at = excluded.updated_at
+      `)
+      .bind(
+        STATUS_KEY,
+        JSON.stringify(status),
+        input.cachedAt,
+        input.lastScannedBlock,
+        JSON.stringify({
+          txHash: input.txHash,
+          blockNumber: input.blockNumber,
+          logIndex: input.logIndex,
+          applied: input.applied,
+        }),
+        Date.now(),
+      )
+      .run();
+  } catch {
+    // Event ingest should not fail only because the monitoring marker failed.
+  }
+}
+
+async function ensureStatusTable(env: ChainCacheEnv) {
+  const db = env.INSHELL_CHAIN_DATA_DB;
+  if (!db?.exec || ensuredStatusTables.has(db as object)) return;
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS ${D1_SNAPSHOT_TABLE} (
+      key TEXT PRIMARY KEY,
+      snapshot_json TEXT NOT NULL,
+      cached_at INTEGER NOT NULL,
+      last_scanned_block INTEGER NOT NULL,
+      content_hash TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  ensuredStatusTables.add(db as object);
+}
+
+function isIndexerEventStatus(value: unknown): value is IndexerEventStatus {
+  const status = value as Partial<IndexerEventStatus> | null;
+  return (
+    Boolean(status) &&
+    status?.version === STATUS_VERSION &&
+    typeof status.lastAcceptedAt === "string" &&
+    (status.lastAppliedTarget === "pulse-auction" || status.lastAppliedTarget === null) &&
+    typeof status.lastTxHash === "string" &&
+    typeof status.lastBlockNumber === "number" &&
+    typeof status.lastLogIndex === "number" &&
+    typeof status.lastResultApplied === "boolean" &&
+    typeof status.cachedAt === "number" &&
+    typeof status.lastScannedBlock === "number"
+  );
+}

--- a/functions/api/indexer/event.ts
+++ b/functions/api/indexer/event.ts
@@ -13,6 +13,7 @@ import {
 } from "../chain-cache";
 import { refreshPulseAuctionForTx } from "../pulse-auction";
 import { isIndexerAuthorized } from "./auth";
+import { writeIndexerEventStatus } from "./event-status";
 
 type IndexerEventEnvelope = {
   version?: unknown;
@@ -54,13 +55,24 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
     const applied = snapshot.items.some(
       (item: PulseBidApiItem) => item.txHash?.toLowerCase() === normalizedTxHash,
     );
+    const source = diagnostics.dbWrite ? "d1" : diagnostics.source;
+    await writeIndexerEventStatus(ctx.env, {
+      target: "pulse-auction",
+      txHash: event.txHash,
+      blockNumber: event.blockNumber,
+      logIndex: event.logIndex,
+      applied,
+      cachedAt: snapshot.cachedAt,
+      lastScannedBlock: snapshot.lastScannedBlock,
+      source,
+    });
     const response = json(200, {
       ok: true,
       target: "pulse-auction",
       applied,
       cachedAt: snapshot.cachedAt,
       lastScannedBlock: snapshot.lastScannedBlock,
-      source: diagnostics.dbWrite ? "d1" : diagnostics.source,
+      source,
       txHash: event.txHash,
     });
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
@@ -71,7 +83,7 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
 }
 
 function validateEvent(body: IndexerEventEnvelope):
-  | { ok: true; txHash: string }
+  | { ok: true; txHash: string; blockNumber: number; logIndex: number }
   | { ok: false; error: string } {
   if (body.version !== 1) return { ok: false, error: "invalid event version" };
   if (body.source !== EVENT_SOURCE) return { ok: false, error: "invalid event source" };
@@ -89,7 +101,7 @@ function validateEvent(body: IndexerEventEnvelope):
   }
   if (!isNonNegativeInteger(body.logIndex)) return { ok: false, error: "invalid log index" };
   if (!isPositiveInteger(body.blockNumber)) return { ok: false, error: "invalid block number" };
-  return { ok: true, txHash };
+  return { ok: true, txHash, blockNumber: body.blockNumber, logIndex: body.logIndex };
 }
 
 async function readJsonBody(request: Request): Promise<IndexerEventEnvelope> {

--- a/functions/api/indexer/event.ts
+++ b/functions/api/indexer/event.ts
@@ -56,7 +56,7 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       (item: PulseBidApiItem) => item.txHash?.toLowerCase() === normalizedTxHash,
     );
     const source = diagnostics.dbWrite ? "d1" : diagnostics.source;
-    await writeIndexerEventStatus(ctx.env, {
+    const statusWrite = await writeIndexerEventStatus(ctx.env, {
       target: "pulse-auction",
       txHash: event.txHash,
       blockNumber: event.blockNumber,
@@ -74,7 +74,18 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       lastScannedBlock: snapshot.lastScannedBlock,
       source,
       txHash: event.txHash,
+      eventStatus: {
+        persisted: statusWrite.persisted,
+        statusSource: statusWrite.source,
+        lastAcceptedAt: statusWrite.status?.lastAcceptedAt ?? null,
+        lastAppliedTarget: statusWrite.status?.lastAppliedTarget ?? null,
+        acceptedCount: statusWrite.status?.acceptedCount ?? null,
+        appliedCount: statusWrite.status?.appliedCount ?? null,
+        error: statusWrite.error,
+      },
     });
+    response.headers.set("x-indexer-event-status-write", statusWrite.persisted ? "1" : "0");
+    response.headers.set("x-indexer-event-status-source", statusWrite.source);
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
   } catch {
     emitUsage(ctx, stats);

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -12,6 +12,7 @@ import {
   type ChainCacheEnv,
   type PagesContextLike,
 } from "../chain-cache";
+import { readIndexerEventStatus } from "../indexer/event-status";
 
 type EnvKey = keyof ChainCacheEnv;
 
@@ -72,6 +73,12 @@ export const onRequestOptions = onOptions;
 
 export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
   const url = new globalThis.URL(ctx.request.url);
+  const eventStatus = await readIndexerEventStatus(ctx.env);
+  const eventStatusSource = ctx.env.INSHELL_CHAIN_DATA_DB
+    ? eventStatus
+      ? "d1"
+      : "empty"
+    : "unavailable";
   const payload = {
     ok: true,
     contract: {
@@ -112,8 +119,19 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
       route: "/api/indexer/event",
       targets: ["pulse-auction"],
       auth: "bearer-token-required",
-      lastAcceptedAt: null,
-      lastAppliedTarget: null,
+      statusSource: eventStatusSource,
+      lastAcceptedAt: eventStatus?.lastAcceptedAt ?? null,
+      lastAppliedAt: eventStatus?.lastAppliedAt ?? null,
+      lastAppliedTarget: eventStatus?.lastAppliedTarget ?? null,
+      lastTxHash: eventStatus?.lastTxHash ?? null,
+      lastBlockNumber: eventStatus?.lastBlockNumber ?? null,
+      lastLogIndex: eventStatus?.lastLogIndex ?? null,
+      lastResultApplied: eventStatus?.lastResultApplied ?? null,
+      lastResultSource: eventStatus?.lastResultSource ?? null,
+      cachedAt: eventStatus?.cachedAt ?? null,
+      lastScannedBlock: eventStatus?.lastScannedBlock ?? null,
+      acceptedCount: eventStatus?.acceptedCount ?? 0,
+      appliedCount: eventStatus?.appliedCount ?? 0,
     },
     cache: {
       readModelEnabled: readModelEnabled(ctx.env),
@@ -173,7 +191,7 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
     },
   };
 
-  return json(200, payload, 30);
+  return json(200, payload);
 }
 
 function appForHost(hostname: string) {

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -74,11 +74,6 @@ export const onRequestOptions = onOptions;
 export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
   const url = new globalThis.URL(ctx.request.url);
   const eventStatus = await readIndexerEventStatus(ctx.env);
-  const eventStatusSource = ctx.env.INSHELL_CHAIN_DATA_DB
-    ? eventStatus
-      ? "d1"
-      : "empty"
-    : "unavailable";
   const payload = {
     ok: true,
     contract: {
@@ -119,19 +114,20 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
       route: "/api/indexer/event",
       targets: ["pulse-auction"],
       auth: "bearer-token-required",
-      statusSource: eventStatusSource,
-      lastAcceptedAt: eventStatus?.lastAcceptedAt ?? null,
-      lastAppliedAt: eventStatus?.lastAppliedAt ?? null,
-      lastAppliedTarget: eventStatus?.lastAppliedTarget ?? null,
-      lastTxHash: eventStatus?.lastTxHash ?? null,
-      lastBlockNumber: eventStatus?.lastBlockNumber ?? null,
-      lastLogIndex: eventStatus?.lastLogIndex ?? null,
-      lastResultApplied: eventStatus?.lastResultApplied ?? null,
-      lastResultSource: eventStatus?.lastResultSource ?? null,
-      cachedAt: eventStatus?.cachedAt ?? null,
-      lastScannedBlock: eventStatus?.lastScannedBlock ?? null,
-      acceptedCount: eventStatus?.acceptedCount ?? 0,
-      appliedCount: eventStatus?.appliedCount ?? 0,
+      statusSource: eventStatus.source,
+      statusError: eventStatus.error,
+      lastAcceptedAt: eventStatus.status?.lastAcceptedAt ?? null,
+      lastAppliedAt: eventStatus.status?.lastAppliedAt ?? null,
+      lastAppliedTarget: eventStatus.status?.lastAppliedTarget ?? null,
+      lastTxHash: eventStatus.status?.lastTxHash ?? null,
+      lastBlockNumber: eventStatus.status?.lastBlockNumber ?? null,
+      lastLogIndex: eventStatus.status?.lastLogIndex ?? null,
+      lastResultApplied: eventStatus.status?.lastResultApplied ?? null,
+      lastResultSource: eventStatus.status?.lastResultSource ?? null,
+      cachedAt: eventStatus.status?.cachedAt ?? null,
+      lastScannedBlock: eventStatus.status?.lastScannedBlock ?? null,
+      acceptedCount: eventStatus.status?.acceptedCount ?? 0,
+      appliedCount: eventStatus.status?.appliedCount ?? 0,
     },
     cache: {
       readModelEnabled: readModelEnabled(ctx.env),


### PR DESCRIPTION
## Summary

Promote the event-ingest status marker follow-up from `staging` to `main`.

This includes:

- D1-backed `/api/ops/status.indexerEventIngest` live state for event ingest health.
- Observable marker write diagnostics from `POST /api/indexer/event` via response body and headers.
- Sanitized marker read/write error surfacing through `/api/ops/status.statusError`.
- Compact D1 `CREATE TABLE` SQL for shared chain snapshots and event-status marker creation, fixing the staging D1 exec failure.
- Regression coverage for successful marker persistence and marker-write failure visibility.

## Root Cause

The first status-marker implementation still let marker persistence failures disappear behind a successful event ingest response. Staging then exposed a real D1 table-ensure failure from the multiline `CREATE TABLE` statement; the new diagnostics surfaced that failure, and this promotion includes the compact SQL fix.

## Validation

Staging head verified: `7b599e90e8a7dd2a0d2bc9aa29b8aacc59cc7a34`.

Local validation:

- `pnpm --filter @inshell/home test -- --runTestsByPath tests/chainCacheFunction.test.ts`
- `pnpm --filter @inshell/home build`
- `git diff --check`
- `gitleaks detect --no-git --redact`
- commit/push hooks: lint, type-check, fast/unit tests

Live staging validation:

- `GET /api/ops/status` returned HTTP 200 with `cache-control: no-store` and commit `7b599e90e8a7dd2a0d2bc9aa29b8aacc59cc7a34`.
- Unauthenticated `POST /api/indexer/event` returned HTTP 401.
- Authenticated replay of tx `0xb67027ba6ad1a73854ea3e11a0298194f73a87acbddbdef791331225861526cd`, block `10986902`, log index `470` returned HTTP 200 with `eventStatus.persisted: true`, `x-indexer-event-status-write: 1`, and `x-indexer-event-status-source: d1`.
- `GET /api/ops/status` after replay reported `statusSource: d1`, `statusError: null`, and populated tx/block/log/count fields.
- `GET /api/pulse-auction` returned HTTP 200 after replay.

## Promotion Note

Operator explicitly approved promotion in Codex: `promote staging to main`.
