### PR TITLE
Merge staging indexer ingest rollout into main

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -703,6 +703,102 @@ describe("chain cache Pages functions", () => {
     expect(response.headers.get("x-db-write")).toBe("1");
   });
 
+  test("protected indexer event updates path tokens read model", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    const txHash = `0x${"abcde".padStart(64, "0")}`;
+    const d1 = createD1Mock({
+      "path-tokens:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PATH_NFT,
+        fromBlock: 10854123,
+        lastScannedBlock: 10860000,
+        items: [],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method?: string;
+      };
+      if (body.method === "eth_getTransactionReceipt") {
+        return rpcResponse({
+          transactionHash: txHash,
+          to: PATH_NFT,
+          blockNumber: "0xa5a7ec",
+          status: "0x1",
+        });
+      }
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse("0xa5a7ef");
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcResponse([
+          {
+            address: PATH_NFT,
+            blockNumber: "0xa5a7ec",
+            data: "0x",
+            logIndex: "0x2",
+            topics: [TRANSFER_TOPIC, ZERO_TOPIC, addressTopic(OWNER), tokenTopic(1n)],
+            transactionHash: txHash,
+          },
+        ]);
+      }
+      if (body.method === "eth_call") {
+        return rpcResponse(`0x${"00".repeat(32)}`);
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerEventPost({
+      request: new Request("https://preview.inshell.art/api/indexer/event", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          source: "ops-chain-event-ingress",
+          network: "sepolia",
+          target: "path-tokens",
+          txHash,
+          blockNumber: 10856428,
+          logIndex: 2,
+          contractAddress: PATH_NFT,
+          topic0: TRANSFER_TOPIC,
+        }),
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        CHAIN_CACHE_DIAGNOSTICS: "1",
+      },
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      target?: string;
+      applied?: boolean;
+      eventStatus?: { persisted?: boolean; statusSource?: string };
+    };
+    const pathStored = JSON.parse(d1.rows.get("path-tokens:v1:sepolia") ?? "{}") as {
+      items?: Array<{ tokenId?: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.target).toBe("path-tokens");
+    expect(payload.applied).toBe(true);
+    expect(pathStored.items?.length).toBeGreaterThan(0);
+    expect(response.headers.get("x-indexer-event-status-write")).toBe("1");
+    expect(response.headers.get("x-indexer-event-status-source")).toBe("d1");
+    expect(response.headers.get("x-db-write")).toBe("1");
+  });
+
   test("indexer event requires refresh token", async () => {
     globalThis.Request = TestRequest as unknown as typeof Request;
     globalThis.Response = TestResponse as unknown as typeof Response;
@@ -926,10 +1022,10 @@ describe("chain cache Pages functions", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(payload.routes?.event?.route).toBe("/api/indexer/event");
-    expect(payload.routes?.event?.targets).toEqual(["pulse-auction"]);
+    expect(payload.routes?.event?.targets).toEqual(["pulse-auction", "path-tokens", "thought-gallery"]);
     expect(payload.indexerEventIngest?.enabled).toBe(true);
     expect(payload.indexerEventIngest?.route).toBe("/api/indexer/event");
-    expect(payload.indexerEventIngest?.targets).toEqual(["pulse-auction"]);
+    expect(payload.indexerEventIngest?.targets).toEqual(["pulse-auction", "path-tokens", "thought-gallery"]);
     expect(payload.indexerEventIngest?.statusSource).toBe("d1");
     expect(payload.indexerEventIngest?.statusError).toBeNull();
     expect(payload.indexerEventIngest?.lastAcceptedAt).toBe("2026-06-16T11:00:00.000Z");

--- a/functions/api/indexer/event-status.ts
+++ b/functions/api/indexer/event-status.ts
@@ -9,7 +9,7 @@ type IndexerEventStatus = {
   updatedAt: string;
   lastAcceptedAt: string;
   lastAppliedAt: string | null;
-  lastAppliedTarget: "pulse-auction" | null;
+  lastAppliedTarget: "pulse-auction" | "path-tokens" | "thought-gallery" | null;
   lastTxHash: string;
   lastBlockNumber: number;
   lastLogIndex: number;
@@ -22,7 +22,7 @@ type IndexerEventStatus = {
 };
 
 type WriteIndexerEventStatusInput = {
-  target: "pulse-auction";
+  target: "pulse-auction" | "path-tokens" | "thought-gallery";
   txHash: string;
   blockNumber: number;
   logIndex: number;
@@ -165,7 +165,10 @@ function isIndexerEventStatus(value: unknown): value is IndexerEventStatus {
     Boolean(status) &&
     status?.version === STATUS_VERSION &&
     typeof status.lastAcceptedAt === "string" &&
-    (status.lastAppliedTarget === "pulse-auction" || status.lastAppliedTarget === null) &&
+    (status.lastAppliedTarget === "pulse-auction" ||
+      status.lastAppliedTarget === "path-tokens" ||
+      status.lastAppliedTarget === "thought-gallery" ||
+      status.lastAppliedTarget === null) &&
     typeof status.lastTxHash === "string" &&
     typeof status.lastBlockNumber === "number" &&
     typeof status.lastLogIndex === "number" &&

--- a/functions/api/indexer/event.ts
+++ b/functions/api/indexer/event.ts
@@ -1,6 +1,10 @@
 import {
+  PATH_NFT_ADDRESS,
   PULSE_AUCTION_ADDRESS,
   PULSE_SALE_TOPIC,
+  THOUGHT_MINTED_TOPIC,
+  THOUGHT_NFT_ADDRESS,
+  TRANSFER_TOPIC,
   createChainCacheDiagnostics,
   createStats,
   emitUsage,
@@ -8,12 +12,17 @@ import {
   json,
   onOptions,
   withChainCacheDiagnostics,
+  type ChainCacheDiagnostics,
+  type IndexedSnapshot,
   type PagesContextLike,
-  type PulseBidApiItem,
 } from "../chain-cache";
-import { refreshPulseAuctionForTx } from "../pulse-auction";
+import { refreshPathTokens } from "../path-tokens";
+import { refreshPulseAuction, refreshPulseAuctionForTx } from "../pulse-auction";
+import { refreshThoughtGallery } from "../thought-gallery";
 import { isIndexerAuthorized } from "./auth";
 import { writeIndexerEventStatus } from "./event-status";
+
+type EventTarget = "pulse-auction" | "path-tokens" | "thought-gallery";
 
 type IndexerEventEnvelope = {
   version?: unknown;
@@ -27,8 +36,77 @@ type IndexerEventEnvelope = {
   topic0?: unknown;
 };
 
-const SNAPSHOT_KEY = "pulse-auction:v1:sepolia";
+type ValidEvent = {
+  target: EventTarget;
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  contractAddress: string;
+  topic0: string;
+};
+
 const EVENT_SOURCE = "ops-chain-event-ingress";
+
+const PULSE_LAUNCH_CONFIGURED_TOPIC =
+  "0xb50a0ea9bb6d2c2a03f4e905919179629acdfa89f0d32153740080caf002ddea";
+const PATH_METADATA_UPDATE_TOPIC =
+  "0xf8e1a15aba9398e019f0b49df1a4fde98ee17ae345cb5f6b5e2c27f5033e8ce7";
+const PATH_MOVEMENT_CONSUMED_TOPIC =
+  "0x419d6a4af86af053d21c8b6823e44940b6593b32919e0c4763c6af0a461428c8";
+const PATH_THOUGHT_CONSUMED_TOPIC =
+  "0xe0e6a445ac8ff8a030e836836e44e3bac120e57cbd845e01ee33f2ba46a1f68f";
+
+const EVENT_TARGETS: Record<
+  EventTarget,
+  {
+    snapshotKey: string;
+    service: "path" | "thought";
+    statsRoute: string;
+    contractAddresses: string[];
+    topic0s: Set<string>;
+    refresh: (
+      ctx: PagesContextLike,
+      stats: ReturnType<typeof createStats>,
+      diagnostics: ChainCacheDiagnostics,
+      event: ValidEvent,
+    ) => Promise<IndexedSnapshot<unknown>>;
+  }
+> = {
+  "pulse-auction": {
+    snapshotKey: "pulse-auction:v1:sepolia",
+    service: "path",
+    statsRoute: "indexer-event:pulse-auction",
+    contractAddresses: [PULSE_AUCTION_ADDRESS.toLowerCase()],
+    topic0s: new Set([PULSE_SALE_TOPIC, PULSE_LAUNCH_CONFIGURED_TOPIC]),
+    refresh: async (ctx, stats, diagnostics, event) => {
+      if (event.topic0 === PULSE_LAUNCH_CONFIGURED_TOPIC) {
+        return await refreshPulseAuction(ctx, stats, diagnostics);
+      }
+      return await refreshPulseAuctionForTx(ctx, stats, diagnostics, event.txHash);
+    },
+  },
+  "path-tokens": {
+    snapshotKey: "path-tokens:v1:sepolia",
+    service: "path",
+    statsRoute: "indexer-event:path-tokens",
+    contractAddresses: [PATH_NFT_ADDRESS.toLowerCase(), THOUGHT_NFT_ADDRESS.toLowerCase()],
+    topic0s: new Set([
+      TRANSFER_TOPIC,
+      PATH_METADATA_UPDATE_TOPIC,
+      PATH_MOVEMENT_CONSUMED_TOPIC,
+      PATH_THOUGHT_CONSUMED_TOPIC,
+    ]),
+    refresh: async (ctx, stats, diagnostics) => refreshPathTokens(ctx, stats, diagnostics),
+  },
+  "thought-gallery": {
+    snapshotKey: "thought-gallery:v1:sepolia",
+    service: "thought",
+    statsRoute: "indexer-event:thought-gallery",
+    contractAddresses: [THOUGHT_NFT_ADDRESS.toLowerCase()],
+    topic0s: new Set([THOUGHT_MINTED_TOPIC]),
+    refresh: async (ctx, stats, diagnostics) => refreshThoughtGallery(ctx, stats, diagnostics),
+  },
+};
 
 export const onRequestOptions = onOptions;
 
@@ -38,26 +116,25 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
   }
 
   const body = await readJsonBody(ctx.request);
-  const event = validateEvent(body);
-  if (!event.ok) return json(400, { error: event.error });
+  const parsed = validateEvent(body);
+  if (!parsed.ok) return json(400, { error: parsed.error });
 
-  const diagnostics = createChainCacheDiagnostics(SNAPSHOT_KEY);
-  const stats = createStats("path", "indexer-event:pulse-auction", ctx.env);
+  const event = parsed.event;
+  const config = EVENT_TARGETS[event.target];
+  const diagnostics = createChainCacheDiagnostics(config.snapshotKey);
+  const stats = createStats(config.service, config.statsRoute, ctx.env);
   try {
-    const snapshot = await refreshPulseAuctionForTx(
-      ctx,
-      stats,
-      diagnostics,
-      event.txHash,
-    );
+    const snapshot = await config.refresh(ctx, stats, diagnostics, event);
     emitUsage(ctx, stats);
-    const normalizedTxHash = event.txHash.toLowerCase();
-    const applied = snapshot.items.some(
-      (item: PulseBidApiItem) => item.txHash?.toLowerCase() === normalizedTxHash,
-    );
+
+    const applied = event.target === "pulse-auction" && event.topic0 !== PULSE_LAUNCH_CONFIGURED_TOPIC
+      ? snapshot.items.some((item: { txHash?: string }) =>
+        item.txHash?.toLowerCase() === event.txHash.toLowerCase()
+      )
+      : true;
     const source = diagnostics.dbWrite ? "d1" : diagnostics.source;
     const statusWrite = await writeIndexerEventStatus(ctx.env, {
-      target: "pulse-auction",
+      target: event.target,
       txHash: event.txHash,
       blockNumber: event.blockNumber,
       logIndex: event.logIndex,
@@ -66,9 +143,10 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       lastScannedBlock: snapshot.lastScannedBlock,
       source,
     });
+
     const response = json(200, {
       ok: true,
-      target: "pulse-auction",
+      target: event.target,
       applied,
       cachedAt: snapshot.cachedAt,
       lastScannedBlock: snapshot.lastScannedBlock,
@@ -94,25 +172,44 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
 }
 
 function validateEvent(body: IndexerEventEnvelope):
-  | { ok: true; txHash: string; blockNumber: number; logIndex: number }
+  | { ok: true; event: ValidEvent }
   | { ok: false; error: string } {
   if (body.version !== 1) return { ok: false, error: "invalid event version" };
   if (body.source !== EVENT_SOURCE) return { ok: false, error: "invalid event source" };
   if (body.network !== "sepolia") return { ok: false, error: "invalid event network" };
-  if (body.target !== "pulse-auction") return { ok: false, error: "invalid event target" };
+
+  const target = readString(body.target);
+  if (target !== "pulse-auction" && target !== "path-tokens" && target !== "thought-gallery") {
+    return { ok: false, error: "invalid event target" };
+  }
+
   const txHash = readString(body.txHash);
   if (!isTxHash(txHash)) return { ok: false, error: "invalid transaction hash" };
+
   const contractAddress = readString(body.contractAddress).toLowerCase();
-  if (contractAddress !== PULSE_AUCTION_ADDRESS.toLowerCase()) {
+  const topic0 = readString(body.topic0).toLowerCase();
+  const config = EVENT_TARGETS[target];
+  if (!config.contractAddresses.includes(contractAddress)) {
     return { ok: false, error: "invalid event contract" };
   }
-  const topic0 = readString(body.topic0).toLowerCase();
-  if (topic0 !== PULSE_SALE_TOPIC.toLowerCase()) {
+  if (!config.topic0s.has(topic0)) {
     return { ok: false, error: "invalid event topic" };
   }
+
   if (!isNonNegativeInteger(body.logIndex)) return { ok: false, error: "invalid log index" };
   if (!isPositiveInteger(body.blockNumber)) return { ok: false, error: "invalid block number" };
-  return { ok: true, txHash, blockNumber: body.blockNumber, logIndex: body.logIndex };
+
+  return {
+    ok: true,
+    event: {
+      target,
+      txHash,
+      blockNumber: body.blockNumber,
+      logIndex: body.logIndex,
+      contractAddress,
+      topic0,
+    },
+  };
 }
 
 async function readJsonBody(request: Request): Promise<IndexerEventEnvelope> {

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -46,7 +46,7 @@ const ROUTES = {
     route: "/api/indexer/event",
     method: "POST",
     auth: "bearer-token-required",
-    targets: ["pulse-auction"],
+    targets: ["pulse-auction", "path-tokens", "thought-gallery"],
   },
   publicFeed: [
     "/rss.xml",
@@ -112,7 +112,7 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
     indexerEventIngest: {
       enabled: true,
       route: "/api/indexer/event",
-      targets: ["pulse-auction"],
+      targets: ["pulse-auction", "path-tokens", "thought-gallery"],
       auth: "bearer-token-required",
       statusSource: eventStatus.source,
       statusError: eventStatus.error,


### PR DESCRIPTION
## Summary\n- Merge staging rollout for indexer event ingress target expansion and status diagnostics.\n- Expands /api/indexer/event to accept pulse-auction, path-tokens, thought-gallery targets.\n- Updates /api/ops/status route/target metadata for indexer-event-ingest.\n- Extends event-status typing and coverage for multi-target event ingest.\n\n## Checks run\n- pnpm build:home\n- gitleaks detect --no-git --redact\n- tsc --noEmit (type-check)\n- test:unit