### PR TITLE
Ignore generated public feed JSON artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,9 @@ src/.DS_Store
 /public/events.json
 /public/rss.*.xml
 /public/events.*.json
+/public/post-on-x.*.json
+/public/public-feed-surface.*.json
+/public/x-manual.*.json
 /public/source/
 /public/source-assets/
 


### PR DESCRIPTION
## Summary
- Ignore generated public feed/X posting JSON files under public/
- Keeps Signal Hub/Public Feed output from appearing as untracked source in this repo

## Validation
- pre-commit hook passed: lint, type-check, test:fast
- pre-push hook passed: lint, type-check, test:unit
- git check-ignore confirms the generated files are ignored