### PR TITLE
Promote targeted indexer event read-model updates

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -278,6 +278,7 @@ describe("chain cache Pages functions", () => {
     const fetchMock = jest.fn(async (url: unknown, init?: any) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as {
         method?: string;
+        params?: Array<{ fromBlock?: string; toBlock?: string }>;
       };
       if (body.method !== "eth_getLogs") throw new Error(`unexpected RPC method ${body.method}`);
       if (url === "https://target-path-rpc.example/sepolia") {
@@ -287,6 +288,8 @@ describe("chain cache Pages functions", () => {
         );
       }
       if (url === "https://public-fallback-rpc.example/sepolia") {
+        const filter = body.params?.[0] ?? {};
+        if (filter.fromBlock !== "0x64") return rpcResponse([]);
         return rpcResponse([
           {
             address: PATH_NFT,
@@ -310,7 +313,7 @@ describe("chain cache Pages functions", () => {
     const logs = await getLogsChunked(env, "path", stats, {
       address: PATH_NFT,
       fromBlock: 100,
-      toBlock: 5099,
+      toBlock: 119,
       topics: [TRANSFER_TOPIC],
     });
 
@@ -318,8 +321,21 @@ describe("chain cache Pages functions", () => {
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       "https://target-path-rpc.example/sepolia",
       "https://public-fallback-rpc.example/sepolia",
+      "https://target-path-rpc.example/sepolia",
+      "https://public-fallback-rpc.example/sepolia",
     ]);
-    expect(stats.calls).toBe(2);
+    expect(fetchMock.mock.calls.map(([, init]) => {
+      const body = JSON.parse(String((init as any)?.body ?? "{}"));
+      return body.params?.[0]
+        ? [body.params[0].fromBlock, body.params[0].toBlock]
+        : [];
+    })).toEqual([
+      ["0x64", "0x6d"],
+      ["0x64", "0x6d"],
+      ["0x6e", "0x77"],
+      ["0x6e", "0x77"],
+    ]);
+    expect(stats.calls).toBe(4);
   });
 
   test("does not fail open when KV is quota limited", async () => {
@@ -711,6 +727,7 @@ describe("chain cache Pages functions", () => {
     globalThis.Response = TestResponse as unknown as typeof Response;
     globalThis.Headers = TestHeaders as unknown as typeof Headers;
     const txHash = `0x${"abcde".padStart(64, "0")}`;
+    const eventBlock = 10870000;
     const d1 = createD1Mock({
       "path-tokens:v1:sepolia": {
         version: 1,
@@ -719,32 +736,35 @@ describe("chain cache Pages functions", () => {
         contract: PATH_NFT,
         fromBlock: 10854123,
         lastScannedBlock: 10860000,
-        items: [],
+        items: [
+          {
+            tokenId: "24",
+            tokenIdLabel: "24",
+            owner: OWNER,
+            tokenUri: "",
+            metadata: {},
+            blockNumber: 10860000,
+            txHash: `0x${"24".padStart(64, "0")}`,
+          },
+        ],
       } satisfies IndexedSnapshot<unknown>,
     });
     const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as {
         method?: string;
+        params?: any[];
       };
-      if (body.method === "eth_getTransactionReceipt") {
-        return rpcResponse({
-          transactionHash: txHash,
-          to: PATH_NFT,
-          blockNumber: "0xa5a7ec",
-          status: "0x1",
-        });
-      }
-      if (body.method === "eth_blockNumber") {
-        return rpcResponse("0xa5a7ef");
-      }
       if (body.method === "eth_getLogs") {
+        const filter = body.params?.[0] ?? {};
+        expect(filter.fromBlock).toBe(`0x${eventBlock.toString(16)}`);
+        expect(filter.toBlock).toBe(`0x${eventBlock.toString(16)}`);
         return rpcResponse([
           {
             address: PATH_NFT,
-            blockNumber: "0xa5a7ec",
+            blockNumber: `0x${eventBlock.toString(16)}`,
             data: "0x",
             logIndex: "0x2",
-            topics: [TRANSFER_TOPIC, ZERO_TOPIC, addressTopic(OWNER), tokenTopic(1n)],
+            topics: [TRANSFER_TOPIC, ZERO_TOPIC, addressTopic(OWNER), tokenTopic(25n)],
             transactionHash: txHash,
           },
         ]);
@@ -769,7 +789,7 @@ describe("chain cache Pages functions", () => {
           network: "sepolia",
           target: "path-tokens",
           txHash,
-          blockNumber: 10856428,
+          blockNumber: eventBlock,
           logIndex: 2,
           contractAddress: PATH_NFT,
           topic0: TRANSFER_TOPIC,
@@ -789,14 +809,21 @@ describe("chain cache Pages functions", () => {
       eventStatus?: { persisted?: boolean; statusSource?: string };
     };
     const pathStored = JSON.parse(d1.rows.get("path-tokens:v1:sepolia") ?? "{}") as {
-      items?: Array<{ tokenId?: string }>;
+      lastScannedBlock?: number;
+      items?: Array<{ tokenId?: string; txHash?: string }>;
     };
+    const methods = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String((init as any)?.body ?? "{}")).method
+    );
 
     expect(response.status).toBe(200);
     expect(payload.ok).toBe(true);
     expect(payload.target).toBe("path-tokens");
     expect(payload.applied).toBe(true);
-    expect(pathStored.items?.length).toBeGreaterThan(0);
+    expect(pathStored.items?.map((item) => item.tokenId)).toEqual(["24", "25"]);
+    expect(pathStored.items?.find((item) => item.tokenId === "25")?.txHash).toBe(txHash);
+    expect(pathStored.lastScannedBlock).toBe(10860000);
+    expect(methods).not.toContain("eth_blockNumber");
     expect(response.headers.get("x-indexer-event-status-write")).toBe("1");
     expect(response.headers.get("x-indexer-event-status-source")).toBe("d1");
     expect(response.headers.get("x-db-write")).toBe("1");
@@ -807,6 +834,22 @@ describe("chain cache Pages functions", () => {
     globalThis.Response = TestResponse as unknown as typeof Response;
     globalThis.Headers = TestHeaders as unknown as typeof Headers;
     const txHash = `0x${"def".padStart(64, "0")}`;
+    const eventBlock = 10873000;
+    const provenanceJson = JSON.stringify({
+      prompt: "test prompt",
+      route: "direct",
+      provider: "test",
+      model: "test-model",
+      output: { returnedText: "returned" },
+      hashes: { promptHash: "0xprompt", returnedTextHash: "0xreturned" },
+    });
+    const tokenUri = JSON.stringify({
+      image: "data:image/svg+xml,<svg />",
+      properties: {
+        rawText: "minted thought",
+        provenanceJson,
+      },
+    });
     const d1 = createD1Mock({
       "thought-gallery:v1:sepolia": {
         version: 1,
@@ -815,18 +858,61 @@ describe("chain cache Pages functions", () => {
         contract: THOUGHT_NFT,
         fromBlock: 10872879,
         lastScannedBlock: 10873000,
-        items: [],
+        items: [
+          {
+            tokenId: 1,
+            pathId: "24",
+            minter: OWNER,
+            textHash: "0xold",
+            promptHash: "",
+            provenanceHash: "0xold",
+            thoughtSpecId: "0xold",
+            thoughtSpecHash: "0xold",
+            mintedAt: 1,
+            rawText: "old thought",
+            prompt: "",
+            mode: "",
+            provider: "",
+            model: "",
+            returnedText: "",
+            returnedTextHash: "",
+            provenanceJson: "",
+            image: "",
+            tokenUri: "",
+            txHash: `0x${"1".padStart(64, "0")}`,
+            blockNumber: 10873000,
+          },
+        ],
       } satisfies IndexedSnapshot<unknown>,
     });
     const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as {
         method?: string;
+        params?: any[];
       };
-      if (body.method === "eth_blockNumber") {
-        return rpcResponse("0xa60000");
-      }
       if (body.method === "eth_getLogs") {
-        return rpcResponse([]);
+        const filter = body.params?.[0] ?? {};
+        expect(filter.fromBlock).toBe(`0x${eventBlock.toString(16)}`);
+        expect(filter.toBlock).toBe(`0x${eventBlock.toString(16)}`);
+        return rpcResponse([
+          {
+            address: THOUGHT_NFT,
+            blockNumber: `0x${eventBlock.toString(16)}`,
+            data: `0x${[
+              "aa".repeat(32),
+              "bb".repeat(32),
+              "cc".repeat(32),
+              "dd".repeat(32),
+              word(1_780_000_000n),
+            ].join("")}`,
+            logIndex: "0x2",
+            topics: [THOUGHT_MINTED_TOPIC, tokenTopic(2n), addressTopic(OWNER), tokenTopic(25n)],
+            transactionHash: txHash,
+          },
+        ]);
+      }
+      if (body.method === "eth_call") {
+        return rpcResponse(encodeStringResult(tokenUri));
       }
       throw new Error(`unexpected RPC method ${body.method}`);
     });
@@ -845,7 +931,7 @@ describe("chain cache Pages functions", () => {
           network: "sepolia",
           target: "thought-gallery",
           txHash,
-          blockNumber: 10873000,
+          blockNumber: eventBlock,
           logIndex: 2,
           contractAddress: THOUGHT_NFT,
           topic0: THOUGHT_MINTED_TOPIC,
@@ -867,7 +953,11 @@ describe("chain cache Pages functions", () => {
     const thoughtStored = JSON.parse(d1.rows.get("thought-gallery:v1:sepolia") ?? "{}") as {
       contract?: string;
       lastScannedBlock?: number;
+      items?: Array<{ tokenId?: number; pathId?: string; rawText?: string; txHash?: string }>;
     };
+    const methods = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String((init as any)?.body ?? "{}")).method
+    );
 
     expect(response.status).toBe(200);
     expect(payload.ok).toBe(true);
@@ -877,7 +967,14 @@ describe("chain cache Pages functions", () => {
     expect(payload.eventStatus?.statusSource).toBe("d1");
     expect(payload.eventStatus?.acceptedCount).toBe(1);
     expect(thoughtStored.contract).toBe(THOUGHT_NFT);
-    expect(thoughtStored.lastScannedBlock).toBe(10878976);
+    expect(thoughtStored.lastScannedBlock).toBe(10873000);
+    expect(thoughtStored.items?.map((item) => item.tokenId)).toEqual([1, 2]);
+    expect(thoughtStored.items?.find((item) => item.tokenId === 2)).toMatchObject({
+      pathId: "25",
+      rawText: "minted thought",
+      txHash,
+    });
+    expect(methods).not.toContain("eth_blockNumber");
     expect(response.headers.get("x-indexer-event-status-write")).toBe("1");
     expect(response.headers.get("x-indexer-event-status-source")).toBe("d1");
     expect(response.headers.get("x-db-write")).toBe("1");
@@ -917,6 +1014,81 @@ describe("chain cache Pages functions", () => {
     expect(response.status).toBe(401);
     expect(payload.error).toBe("indexer event token required");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("indexer event reports safe diagnostics for targeted getLogs failures", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    const txHash = `0x${"bad".padStart(64, "0")}`;
+    const d1 = createD1Mock({
+      "path-tokens:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PATH_NFT,
+        fromBlock: 10854123,
+        lastScannedBlock: 10860000,
+        items: [],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "eth_getLogs") {
+        return rpcError(400, "block range too large; token=upstream-secret");
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerEventPost({
+      request: new Request("https://preview.inshell.art/api/indexer/event", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          source: "ops-chain-event-ingress",
+          network: "sepolia",
+          target: "path-tokens",
+          txHash,
+          blockNumber: 10870000,
+          logIndex: 2,
+          contractAddress: PATH_NFT,
+          topic0: TRANSFER_TOPIC,
+        }),
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        PATH_PRIMARY_RPC_LABEL: "path-primary-test",
+      },
+    });
+    const payload = (await response.json()) as {
+      error?: string;
+      diagnostics?: {
+        target?: string;
+        stage?: string;
+        upstreamLabel?: string;
+        blockRange?: { fromBlock?: number; toBlock?: number };
+        providerError?: { kind?: string; message?: string };
+      };
+    };
+
+    expect(response.status).toBe(500);
+    expect(payload.error).toBe("indexer event failed");
+    expect(payload.diagnostics).toMatchObject({
+      target: "path-tokens",
+      stage: "getLogs",
+      upstreamLabel: "path-primary-test",
+      blockRange: { fromBlock: 10870000, toBlock: 10870000 },
+      providerError: { kind: "block-range" },
+    });
+    expect(payload.diagnostics?.providerError?.message).toContain("token=<redacted>");
+    expect(response.body).not.toContain("upstream-secret");
   });
 
   test("indexer event dedupes already indexed transactions and status counters without RPC", async () => {

--- a/functions/api/chain-cache.ts
+++ b/functions/api/chain-cache.ts
@@ -101,7 +101,7 @@ const JSON_HEADERS = {
 
 const RPC_TIMEOUT_MS = 12_000;
 const REORG_DEPTH = 3;
-const DEFAULT_LOG_CHUNK_SIZE = 5_000;
+const DEFAULT_LOG_CHUNK_SIZE = 10;
 const EDGE_CACHE_PREFIX = "https://inshell.local/chain-cache/";
 const RESPONSE_CACHE_PREFIX = "https://inshell.local/chain-response/";
 const KV_SNAPSHOT_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -121,6 +121,12 @@ export const THOUGHT_MINTED_TOPIC =
   "0xf83a962c31fcc481a4796d3bd1f81a4b58d1b05ec5cb34e434b2d40962596860";
 export const PULSE_SALE_TOPIC =
   "0xa789468a0212cbe853fbdd6011d2ee7d85144ebc1d67c7dd82f087a970d9593d";
+export const PATH_METADATA_UPDATE_TOPIC =
+  "0xf8e1a15aba9398e019f0b49df1a4fde98ee17ae345cb5f6b5e2c27f5033e8ce7";
+export const PATH_MOVEMENT_CONSUMED_TOPIC =
+  "0x419d6a4af86af053d21c8b6823e44940b6593b32919e0c4763c6af0a461428c8";
+export const PATH_THOUGHT_CONSUMED_TOPIC =
+  "0xe0e6a445ac8ff8a030e836836e44e3bac120e57cbd845e01ee33f2ba46a1f68f";
 
 const OWNER_OF_SELECTOR = "0x6352211e";
 const TOKEN_URI_SELECTOR = "0xc87b56dd";
@@ -234,6 +240,14 @@ type JsonSafe =
   | JsonSafe[]
   | { [key: string]: JsonSafe };
 
+export type SafeChainFailure = {
+  target: string;
+  stage: string;
+  upstreamLabel?: string;
+  blockRange?: { fromBlock: number; toBlock: number };
+  providerError?: { kind: string; message: string };
+};
+
 function safeJsonBody(body: unknown, seen = new WeakSet<object>()): JsonSafe {
   if (
     body === null ||
@@ -269,11 +283,61 @@ export function json(status: number, body: unknown, cacheSeconds = 0): Response 
   return new Response(JSON.stringify(safeJsonBody(body)), { status, headers });
 }
 
+export function chainFailure(
+  message: string,
+  failure: SafeChainFailure,
+  cause?: unknown,
+) {
+  const error = new Error(message) as Error & { safeFailure?: SafeChainFailure };
+  error.name = "ChainReadModelError";
+  error.safeFailure = {
+    ...failure,
+    providerError: failure.providerError ?? providerError(cause ?? message),
+  };
+  return error;
+}
+
+export function readSafeChainFailure(
+  error: unknown,
+  fallback: Omit<SafeChainFailure, "providerError">,
+): SafeChainFailure {
+  const safeFailure = (error as { safeFailure?: SafeChainFailure } | null)?.safeFailure;
+  if (safeFailure) return safeFailure;
+  return {
+    ...fallback,
+    providerError: providerError(error),
+  };
+}
+
+export function providerError(error: unknown) {
+  const raw = error instanceof Error ? error.message : String(error);
+  const message = raw
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer <redacted>")
+    .replace(/(token=)[A-Za-z0-9._~+/=-]+/gi, "$1<redacted>")
+    .replace(/([?&](?:api[_-]?key|key|token)=)[^&\s]+/gi, "$1<redacted>")
+    .slice(0, 240);
+  return {
+    kind: providerErrorKind(message),
+    message,
+  };
+}
+
 export function onOptions(): Response {
   return new Response(null, {
     status: 204,
     headers: JSON_HEADERS,
   });
+}
+
+function providerErrorKind(message: string) {
+  const lowerMessage = message.toLowerCase();
+  if (lowerMessage.includes("block range") || lowerMessage.includes("free tier")) {
+    return "block-range";
+  }
+  if (lowerMessage.includes("rate") || lowerMessage.includes("429")) return "rate-limit";
+  if (lowerMessage.includes("timeout") || lowerMessage.includes("abort")) return "timeout";
+  if (lowerMessage.includes("not configured")) return "config";
+  return "rpc-error";
 }
 
 export function createStats(

--- a/functions/api/indexer/event.ts
+++ b/functions/api/indexer/event.ts
@@ -1,5 +1,8 @@
 import {
+  PATH_METADATA_UPDATE_TOPIC,
+  PATH_MOVEMENT_CONSUMED_TOPIC,
   PATH_NFT_ADDRESS,
+  PATH_THOUGHT_CONSUMED_TOPIC,
   PULSE_AUCTION_ADDRESS,
   PULSE_SALE_TOPIC,
   THOUGHT_MINTED_TOPIC,
@@ -11,14 +14,15 @@ import {
   isTxHash,
   json,
   onOptions,
+  readSafeChainFailure,
   withChainCacheDiagnostics,
   type ChainCacheDiagnostics,
   type IndexedSnapshot,
   type PagesContextLike,
 } from "../chain-cache";
-import { refreshPathTokens } from "../path-tokens";
+import { refreshPathTokensForEvent } from "../path-tokens";
 import { refreshPulseAuction, refreshPulseAuctionForTx } from "../pulse-auction";
-import { refreshThoughtGallery } from "../thought-gallery";
+import { refreshThoughtGalleryForEvent } from "../thought-gallery";
 import { isIndexerAuthorized } from "./auth";
 import { writeIndexerEventStatus } from "./event-status";
 
@@ -49,12 +53,6 @@ const EVENT_SOURCE = "ops-chain-event-ingress";
 
 const PULSE_LAUNCH_CONFIGURED_TOPIC =
   "0xb50a0ea9bb6d2c2a03f4e905919179629acdfa89f0d32153740080caf002ddea";
-const PATH_METADATA_UPDATE_TOPIC =
-  "0xf8e1a15aba9398e019f0b49df1a4fde98ee17ae345cb5f6b5e2c27f5033e8ce7";
-const PATH_MOVEMENT_CONSUMED_TOPIC =
-  "0x419d6a4af86af053d21c8b6823e44940b6593b32919e0c4763c6af0a461428c8";
-const PATH_THOUGHT_CONSUMED_TOPIC =
-  "0xe0e6a445ac8ff8a030e836836e44e3bac120e57cbd845e01ee33f2ba46a1f68f";
 
 const EVENT_TARGETS: Record<
   EventTarget,
@@ -96,7 +94,8 @@ const EVENT_TARGETS: Record<
       PATH_MOVEMENT_CONSUMED_TOPIC,
       PATH_THOUGHT_CONSUMED_TOPIC,
     ]),
-    refresh: async (ctx, stats, diagnostics) => refreshPathTokens(ctx, stats, diagnostics),
+    refresh: async (ctx, stats, diagnostics, event) =>
+      refreshPathTokensForEvent(ctx, stats, diagnostics, event),
   },
   "thought-gallery": {
     snapshotKey: "thought-gallery:v1:sepolia",
@@ -104,7 +103,8 @@ const EVENT_TARGETS: Record<
     statsRoute: "indexer-event:thought-gallery",
     contractAddresses: [THOUGHT_NFT_ADDRESS.toLowerCase()],
     topic0s: new Set([THOUGHT_MINTED_TOPIC]),
-    refresh: async (ctx, stats, diagnostics) => refreshThoughtGallery(ctx, stats, diagnostics),
+    refresh: async (ctx, stats, diagnostics, event) =>
+      refreshThoughtGalleryForEvent(ctx, stats, diagnostics, event),
   },
 };
 
@@ -166,9 +166,16 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
     response.headers.set("x-indexer-event-status-write", statusWrite.persisted ? "1" : "0");
     response.headers.set("x-indexer-event-status-source", statusWrite.source);
     return withChainCacheDiagnostics(ctx, response, diagnostics, stats, snapshot);
-  } catch {
+  } catch (error) {
     emitUsage(ctx, stats);
-    return json(500, { error: "indexer event failed" });
+    return json(500, {
+      error: "indexer event failed",
+      diagnostics: readSafeChainFailure(error, {
+        target: event.target,
+        stage: "refresh",
+        upstreamLabel: stats.upstreamLabel,
+      }),
+    });
   }
 }
 

--- a/functions/api/indexer/refresh.ts
+++ b/functions/api/indexer/refresh.ts
@@ -5,6 +5,7 @@ import {
   isTxHash,
   json,
   onOptions,
+  readSafeChainFailure,
   withChainCacheDiagnostics,
   type ChainCacheDiagnostics,
   type IndexedSnapshot,
@@ -39,7 +40,8 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
 
   const targetedPublicRefresh =
     normalizedTarget === "pulse-auction" && isTxHash(txHash);
-  if (!targetedPublicRefresh && !isIndexerAuthorized(ctx)) {
+  const authorized = isIndexerAuthorized(ctx);
+  if (!targetedPublicRefresh && !authorized) {
     return json(401, { error: "indexer refresh token required" });
   }
 
@@ -47,10 +49,14 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
   const diagnostics: ChainCacheDiagnostics[] = [];
   const statsList: ReturnType<typeof createStats>[] = [];
   const snapshots: IndexedSnapshot<unknown>[] = [];
+  let activeTarget: Exclude<RefreshTarget, "all"> | null = null;
+  let activeStats: ReturnType<typeof createStats> | null = null;
   try {
     if (normalizedTarget === "pulse-auction" || normalizedTarget === "all") {
+      activeTarget = "pulse-auction";
       const currentDiagnostics = createChainCacheDiagnostics("pulse-auction:v1:sepolia");
       const stats = createStats("path", "indexer-refresh:pulse-auction", ctx.env);
+      activeStats = stats;
       const snapshot = targetedPublicRefresh
         ? await refreshPulseAuctionForTx(ctx, stats, currentDiagnostics, txHash)
         : await refreshPulseAuction(ctx, stats, currentDiagnostics);
@@ -62,8 +68,10 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
     }
 
     if (normalizedTarget === "path-tokens" || normalizedTarget === "all") {
+      activeTarget = "path-tokens";
       const currentDiagnostics = createChainCacheDiagnostics("path-tokens:v1:sepolia");
       const stats = createStats("path", "indexer-refresh:path-tokens", ctx.env);
+      activeStats = stats;
       const snapshot = await refreshPathTokens(ctx, stats, currentDiagnostics);
       emitUsage(ctx, stats);
       diagnostics.push(currentDiagnostics);
@@ -73,8 +81,10 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
     }
 
     if (normalizedTarget === "thought-gallery" || normalizedTarget === "all") {
+      activeTarget = "thought-gallery";
       const currentDiagnostics = createChainCacheDiagnostics("thought-gallery:v1:sepolia");
       const stats = createStats("thought", "indexer-refresh:thought-gallery", ctx.env);
+      activeStats = stats;
       const snapshot = await refreshThoughtGallery(ctx, stats, currentDiagnostics);
       emitUsage(ctx, stats);
       diagnostics.push(currentDiagnostics);
@@ -82,9 +92,19 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       snapshots.push(snapshot as IndexedSnapshot<unknown>);
       results.push(resultFor("thought-gallery", snapshot, currentDiagnostics));
     }
-  } catch {
+  } catch (error) {
     for (const stats of statsList) emitUsage(ctx, stats);
-    return json(500, { error: "indexer refresh failed" });
+    if (activeStats && !statsList.includes(activeStats)) emitUsage(ctx, activeStats);
+    return json(500, {
+      error: "indexer refresh failed",
+      diagnostics: authorized
+        ? readSafeChainFailure(error, {
+          target: activeTarget ?? normalizedTarget,
+          stage: "refresh",
+          upstreamLabel: activeStats?.upstreamLabel,
+        })
+        : undefined,
+    });
   }
 
   const response = json(200, {

--- a/functions/api/path-tokens.ts
+++ b/functions/api/path-tokens.ts
@@ -1,7 +1,12 @@
 import {
+  PATH_METADATA_UPDATE_TOPIC,
+  PATH_MOVEMENT_CONSUMED_TOPIC,
   PATH_NFT_ADDRESS,
   PATH_NFT_DEPLOY_BLOCK,
+  PATH_THOUGHT_CONSUMED_TOPIC,
+  THOUGHT_NFT_ADDRESS,
   TRANSFER_TOPIC,
+  chainFailure,
   createChainCacheDiagnostics,
   createStats,
   decodeAddressResult,
@@ -31,6 +36,7 @@ import {
   writeSnapshot,
   type ChainCacheDiagnostics,
   type ChainCacheEnv,
+  type ChainLog,
   type IndexedSnapshot,
   type PagesContextLike,
   type PathTokenApiItem,
@@ -41,6 +47,14 @@ const RESPONSE_CACHE_SECONDS = 60;
 const EDGE_SNAPSHOT_SECONDS = 10 * 60;
 const ZERO_TOPIC =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+type TargetedPathTokenEvent = {
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  contractAddress: string;
+  topic0: string;
+};
 
 export const onRequestOptions = onOptions;
 
@@ -179,6 +193,74 @@ export async function refreshPathTokens(
   return snapshot;
 }
 
+export async function refreshPathTokensForEvent(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  event: TargetedPathTokenEvent,
+) {
+  const previous = await readSnapshot<PathTokenApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (
+    event.topic0 === TRANSFER_TOPIC &&
+    event.contractAddress === PATH_NFT_ADDRESS.toLowerCase() &&
+    previous?.items.some((item) => item.txHash?.toLowerCase() === event.txHash.toLowerCase())
+  ) {
+    return previous;
+  }
+
+  const log = await readPathTokenEventLog(ctx.env, stats, event);
+  const tokenId = tokenIdFromPathEvent(event, log);
+  if (!tokenId) {
+    throw chainFailure("path token event did not identify a PATH token", {
+      target: "path-tokens",
+      stage: "decodeLog",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    });
+  }
+
+  const tokens = new Map<string, PathTokenApiItem>();
+  for (const item of previous?.items ?? []) {
+    tokens.set(item.tokenId, item);
+  }
+
+  if (isPathTransferBurn(log)) {
+    tokens.delete(tokenId);
+  } else {
+    const existing = tokens.get(tokenId);
+    const item = await readPathTokenItem(ctx.env, stats, tokenId, log, existing);
+    tokens.set(tokenId, item);
+  }
+
+  const lastScannedBlock = nextLastScannedBlock(previous, event.blockNumber);
+  const snapshot: IndexedSnapshot<PathTokenApiItem> = {
+    version: 1,
+    cachedAt: Date.now(),
+    chainId: 11155111,
+    contract: PATH_NFT_ADDRESS,
+    fromBlock: PATH_NFT_DEPLOY_BLOCK,
+    lastScannedBlock,
+    items: sortByTokenId([...tokens.values()]),
+  };
+  if (!isPathTransferBurn(log) && !snapshot.items.some((item) => item.tokenId === tokenId)) {
+    throw chainFailure("path token event was not represented in snapshot", {
+      target: "path-tokens",
+      stage: "mergeSnapshot",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    });
+  }
+  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
 function responseFromSnapshot(snapshot: IndexedSnapshot<PathTokenApiItem>) {
   return json(
     200,
@@ -201,4 +283,120 @@ function normalizeAddressResult(result: string) {
 function lowerTopicAddress(topic: string | undefined) {
   if (!topic) return "";
   return topic.toLowerCase();
+}
+
+async function readPathTokenEventLog(
+  env: ChainCacheEnv,
+  stats: ReturnType<typeof createStats>,
+  event: TargetedPathTokenEvent,
+) {
+  const address = event.contractAddress;
+  const topic0 = event.topic0 === TRANSFER_TOPIC && address === THOUGHT_NFT_ADDRESS.toLowerCase()
+    ? PATH_THOUGHT_CONSUMED_TOPIC
+    : event.topic0;
+  try {
+    const logs = await getLogsChunked(env, "path", stats, {
+      address,
+      fromBlock: event.blockNumber,
+      toBlock: event.blockNumber,
+      topics: [topic0],
+      chunkSize: 1,
+    });
+    const log = logs.find((candidate) =>
+      candidate.transactionHash?.toLowerCase() === event.txHash.toLowerCase() &&
+      (event.topic0 === TRANSFER_TOPIC && address === THOUGHT_NFT_ADDRESS.toLowerCase()
+        ? true
+        : hexToNumber(candidate.logIndex) === event.logIndex)
+    );
+    if (!log) {
+      throw new Error("event log not found in event block");
+    }
+    return log;
+  } catch (error) {
+    throw chainFailure("path token event getLogs failed", {
+      target: "path-tokens",
+      stage: "getLogs",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    }, error);
+  }
+}
+
+function tokenIdFromPathEvent(event: TargetedPathTokenEvent, log: ChainLog) {
+  if (event.contractAddress === PATH_NFT_ADDRESS.toLowerCase()) {
+    if (event.topic0 === TRANSFER_TOPIC) return topicToBigInt(log.topics[3])?.toString() ?? "";
+    if (event.topic0 === PATH_METADATA_UPDATE_TOPIC) return tokenIdFromEventData(log.data);
+    if (event.topic0 === PATH_MOVEMENT_CONSUMED_TOPIC) return topicToBigInt(log.topics[1])?.toString() ?? "";
+  }
+  if (event.contractAddress === THOUGHT_NFT_ADDRESS.toLowerCase()) {
+    if (event.topic0 === PATH_THOUGHT_CONSUMED_TOPIC) return topicToBigInt(log.topics[1])?.toString() ?? "";
+    if (event.topic0 === TRANSFER_TOPIC) return topicToBigInt(log.topics[1])?.toString() ?? "";
+  }
+  return "";
+}
+
+function tokenIdFromEventData(data: string) {
+  const clean = data.startsWith("0x") ? data.slice(2) : data;
+  const word = clean.slice(0, 64);
+  if (!word || /[^a-fA-F0-9]/.test(word)) return "";
+  return BigInt(`0x${word}`).toString();
+}
+
+function isPathTransferBurn(log: ChainLog) {
+  return (log.topics[0] ?? "").toLowerCase() === TRANSFER_TOPIC &&
+    lowerTopicAddress(log.topics[2]) === ZERO_TOPIC;
+}
+
+async function readPathTokenItem(
+  env: ChainCacheEnv,
+  stats: ReturnType<typeof createStats>,
+  tokenId: string,
+  log: ChainLog,
+  existing: PathTokenApiItem | undefined,
+) {
+  const transferOwner = (log.topics[0] ?? "").toLowerCase() === TRANSFER_TOPIC
+    ? topicToAddress(log.topics[2])
+    : "";
+  let owner = existing?.owner ?? transferOwner;
+  try {
+    owner = normalizeAddressResult(
+      await ethCall(env, "path", stats, PATH_NFT_ADDRESS, ownerOfData(tokenId)),
+    );
+  } catch {
+    // Keep the event or previous owner when ownerOf is temporarily unavailable.
+  }
+
+  let tokenUri = existing?.tokenUri ?? "";
+  let metadata = existing?.metadata ?? {};
+  try {
+    tokenUri = decodeStringResult(
+      await ethCall(env, "path", stats, PATH_NFT_ADDRESS, tokenUriData(tokenId)),
+    );
+    metadata = parseMetadata(tokenUri);
+  } catch {
+    if (!tokenUri) metadata = {};
+  }
+  if (!metadataString(metadata.name)) {
+    metadata = parseMetadata(tokenUri);
+  }
+
+  return {
+    tokenId,
+    tokenIdLabel: tokenId,
+    owner,
+    tokenUri,
+    metadata,
+    blockNumber: hexToNumber(log.blockNumber),
+    txHash: log.transactionHash,
+  };
+}
+
+function nextLastScannedBlock(
+  previous: IndexedSnapshot<unknown> | null | undefined,
+  eventBlock: number,
+) {
+  const previousLastScanned = previous?.lastScannedBlock ?? eventBlock;
+  return eventBlock <= previousLastScanned + 1
+    ? Math.max(previousLastScanned, eventBlock)
+    : previousLastScanned;
 }

--- a/functions/api/thought-gallery.ts
+++ b/functions/api/thought-gallery.ts
@@ -2,6 +2,7 @@ import {
   THOUGHT_MINTED_TOPIC,
   THOUGHT_NFT_ADDRESS,
   THOUGHT_NFT_DEPLOY_BLOCK,
+  chainFailure,
   createChainCacheDiagnostics,
   createStats,
   decodeStringResult,
@@ -43,6 +44,14 @@ import {
 const SNAPSHOT_KEY = "thought-gallery:v1:sepolia";
 const RESPONSE_CACHE_SECONDS = 60;
 const EDGE_SNAPSHOT_SECONDS = 10 * 60;
+
+type TargetedThoughtGalleryEvent = {
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  contractAddress: string;
+  topic0: string;
+};
 
 export const onRequestOptions = onOptions;
 
@@ -131,6 +140,62 @@ export async function refreshThoughtGallery(
   diagnostics: ChainCacheDiagnostics,
 ) {
   const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, undefined, true);
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(snapshot),
+    RESPONSE_CACHE_SECONDS,
+    snapshot.lastScannedBlock,
+  );
+  return snapshot;
+}
+
+export async function refreshThoughtGalleryForEvent(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  event: TargetedThoughtGalleryEvent,
+) {
+  const previous = await readSnapshot<ThoughtGalleryApiItem>(ctx.env, SNAPSHOT_KEY, diagnostics);
+  if (previous?.items.some((item) => item.txHash?.toLowerCase() === event.txHash.toLowerCase())) {
+    return previous;
+  }
+
+  const log = await readThoughtGalleryEventLog(ctx.env, stats, event);
+  const item = await readThoughtFromLog(ctx.env, stats, log);
+  if (!item) {
+    throw chainFailure("thought gallery event did not decode to a thought", {
+      target: "thought-gallery",
+      stage: "decodeLog",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    });
+  }
+
+  const existing = new Map<string, ThoughtGalleryApiItem>();
+  for (const thought of previous?.items ?? []) {
+    existing.set(thought.tokenId.toString(), thought);
+  }
+  existing.set(item.tokenId.toString(), item);
+
+  const snapshot: IndexedSnapshot<ThoughtGalleryApiItem> = {
+    version: 1,
+    cachedAt: Date.now(),
+    chainId: 11155111,
+    contract: THOUGHT_NFT_ADDRESS,
+    fromBlock: THOUGHT_NFT_DEPLOY_BLOCK,
+    lastScannedBlock: nextLastScannedBlock(previous, event.blockNumber),
+    items: sortByTokenId([...existing.values()]),
+  };
+  if (!snapshot.items.some((thought) => thought.tokenId === item.tokenId)) {
+    throw chainFailure("thought gallery event was not represented in snapshot", {
+      target: "thought-gallery",
+      stage: "mergeSnapshot",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    });
+  }
+  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
   writeResponseCache(
     ctx,
     SNAPSHOT_KEY,
@@ -256,4 +321,45 @@ function sortByBlockLogSafe(left: ChainLog, right: ChainLog) {
   const rightBlock = hexToNumber(right.blockNumber);
   if (leftBlock !== rightBlock) return leftBlock - rightBlock;
   return hexToNumber(left.logIndex) - hexToNumber(right.logIndex);
+}
+
+async function readThoughtGalleryEventLog(
+  env: ChainCacheEnv,
+  stats: ReturnType<typeof createStats>,
+  event: TargetedThoughtGalleryEvent,
+) {
+  try {
+    const logs = await getLogsChunked(env, "thought", stats, {
+      address: event.contractAddress,
+      fromBlock: event.blockNumber,
+      toBlock: event.blockNumber,
+      topics: [event.topic0],
+      chunkSize: 1,
+    });
+    const log = logs.find((candidate) =>
+      candidate.transactionHash?.toLowerCase() === event.txHash.toLowerCase() &&
+      hexToNumber(candidate.logIndex) === event.logIndex
+    );
+    if (!log) {
+      throw new Error("event log not found in event block");
+    }
+    return log;
+  } catch (error) {
+    throw chainFailure("thought gallery event getLogs failed", {
+      target: "thought-gallery",
+      stage: "getLogs",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: event.blockNumber, toBlock: event.blockNumber },
+    }, error);
+  }
+}
+
+function nextLastScannedBlock(
+  previous: IndexedSnapshot<unknown> | null | undefined,
+  eventBlock: number,
+) {
+  const previousLastScanned = previous?.lastScannedBlock ?? eventBlock;
+  return eventBlock <= previousLastScanned + 1
+    ? Math.max(previousLastScanned, eventBlock)
+    : previousLastScanned;
 }


### PR DESCRIPTION
## Summary
- Promote the staging fix for targeted `/api/indexer/event` read-model updates.
- PATH token and THOUGHT gallery events now merge only the affected item instead of falling back to broad scanners.
- Authenticated event/refresh failures expose safe diagnostics.
- `eth_getLogs` full-scan chunk default is provider-safe at 10 blocks.

## Staging validation
- Commit: `5440e2bf7d101e60d722cec07fbd03e20b658afe`
- GitHub deploy-pages staging run: https://github.com/inshell-art/inshell.art/actions/runs/27855268200
- Staging `/api/ops/status`: `statusSource=d1`, `statusError=null`, counters positive.
- Replayed PATH #25 event: HTTP 200; `/api/path-tokens` includes token `25`.
- Duplicate PATH #25 replay: HTTP 200, `duplicate=true`, `x-live-rpc-calls=0`.
- Replayed THOUGHT #17 and known pulse sale events: HTTP 200/idempotent.

## Local checks
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run test:unit`
- `pnpm run test:thought-runtime`
- `pnpm run check:deployment`
- `pnpm run build:home`
- `pnpm run build:thought`
- `git diff --check`
- `gitleaks detect --no-git --redact`
