### PR TITLE
Promote bounded read-model refresh

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -597,6 +597,321 @@ describe("chain cache Pages functions", () => {
     expect(response.headers.get("x-live-rpc-calls")).toBe("3");
   });
 
+  test("authenticated pulse auction refresh advances a bounded partial window", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const latestBlock = 10860050;
+    const d1 = createD1Mock({
+      "pulse-auction:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PULSE_AUCTION,
+        fromBlock: 10854123,
+        lastScannedBlock: 10860000,
+        items: [],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method?: string;
+        params?: any[];
+      };
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse(`0x${latestBlock.toString(16)}`);
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcResponse([]);
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerRefreshPost({
+      request: new Request("https://preview.inshell.art/api/indexer/refresh?target=pulse-auction", {
+        method: "POST",
+        headers: { authorization: "Bearer secret-token" },
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        INDEXER_REFRESH_MAX_LOG_CHUNKS: "2",
+        CHAIN_CACHE_DIAGNOSTICS: "1",
+      },
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      results?: Array<{
+        complete?: boolean;
+        partial?: boolean;
+        scannedFromBlock?: number;
+        scannedToBlock?: number;
+        latestBlock?: number;
+        remainingBlocks?: number;
+        maxBlocks?: number;
+      }>;
+    };
+    const stored = JSON.parse(d1.rows.get("pulse-auction:v1:sepolia") ?? "{}") as {
+      lastScannedBlock?: number;
+    };
+    const ranges = fetchMock.mock.calls
+      .map(([, init]) => JSON.parse(String((init as any)?.body ?? "{}")))
+      .filter((body) => body.method === "eth_getLogs")
+      .map((body) => [body.params?.[0]?.fromBlock, body.params?.[0]?.toBlock]);
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.results?.[0]).toMatchObject({
+      complete: false,
+      partial: true,
+      scannedFromBlock: 10859998,
+      scannedToBlock: 10860017,
+      latestBlock,
+      remainingBlocks: 33,
+      maxBlocks: 20,
+    });
+    expect(stored.lastScannedBlock).toBe(10860017);
+    expect(ranges).toEqual([
+      ["0xa5b5de", "0xa5b5e7"],
+      ["0xa5b5e8", "0xa5b5f1"],
+    ]);
+    expect(response.headers.get("x-live-rpc-calls")).toBe("3");
+  });
+
+  test("authenticated path token refresh preserves untouched items without historical eth_call fanout", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const latestBlock = 10860050;
+    const existingItems = Array.from({ length: 25 }, (_, index) => ({
+      tokenId: String(index + 1),
+      tokenIdLabel: String(index + 1),
+      owner: OWNER,
+      tokenUri: index === 0 ? "" : `data:application/json,${encodeURIComponent("{}")}`,
+      metadata: {},
+      blockNumber: 10859000 + index,
+      txHash: `0x${String(index + 1).padStart(64, "0")}`,
+    }));
+    const d1 = createD1Mock({
+      "path-tokens:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PATH_NFT,
+        fromBlock: 10854121,
+        lastScannedBlock: 10860000,
+        items: existingItems,
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse(`0x${latestBlock.toString(16)}`);
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcResponse([]);
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerRefreshPost({
+      request: new Request("https://preview.inshell.art/api/indexer/refresh?target=path-tokens", {
+        method: "POST",
+        headers: { authorization: "Bearer secret-token" },
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        INDEXER_REFRESH_MAX_LOG_CHUNKS: "2",
+      },
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      results?: Array<{ partial?: boolean; scannedToBlock?: number; items?: number }>;
+    };
+    const stored = JSON.parse(d1.rows.get("path-tokens:v1:sepolia") ?? "{}") as {
+      lastScannedBlock?: number;
+      items?: Array<{ tokenId?: string; tokenUri?: string }>;
+    };
+    const methods = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String((init as any)?.body ?? "{}")).method
+    );
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.results?.[0]).toMatchObject({
+      partial: true,
+      scannedToBlock: 10860017,
+      items: 25,
+    });
+    expect(stored.lastScannedBlock).toBe(10860017);
+    expect(stored.items?.map((item) => item.tokenId)).toHaveLength(25);
+    expect(stored.items?.[0]?.tokenUri).toBe("");
+    expect(methods).toEqual(["eth_blockNumber", "eth_getLogs", "eth_getLogs"]);
+  });
+
+  test("authenticated refresh reports safe diagnostics for bounded getLogs failures", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const d1 = createD1Mock({
+      "path-tokens:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: PATH_NFT,
+        fromBlock: 10854121,
+        lastScannedBlock: 10860000,
+        items: [],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse("0xa5b612");
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcError(400, "block range too large; token=upstream-secret");
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerRefreshPost({
+      request: new Request("https://preview.inshell.art/api/indexer/refresh?target=path-tokens", {
+        method: "POST",
+        headers: { authorization: "Bearer secret-token" },
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        PATH_PRIMARY_RPC_UPSTREAM: "https://path-rpc.example/sepolia",
+        PATH_PRIMARY_RPC_LABEL: "path-primary-test",
+        INDEXER_REFRESH_MAX_LOG_CHUNKS: "2",
+      },
+    });
+    const payload = (await response.json()) as {
+      error?: string;
+      diagnostics?: {
+        target?: string;
+        stage?: string;
+        upstreamLabel?: string;
+        blockRange?: { fromBlock?: number; toBlock?: number };
+        providerError?: { kind?: string; message?: string };
+      };
+    };
+
+    expect(response.status).toBe(500);
+    expect(payload.error).toBe("indexer refresh failed");
+    expect(payload.diagnostics).toMatchObject({
+      target: "path-tokens",
+      stage: "getLogs",
+      upstreamLabel: "path-primary-test",
+      blockRange: { fromBlock: 10859998, toBlock: 10860017 },
+      providerError: { kind: "block-range" },
+    });
+    expect(payload.diagnostics?.providerError?.message).toContain("token=<redacted>");
+    expect(response.body).not.toContain("upstream-secret");
+  });
+
+  test("authenticated thought gallery refresh advances a bounded partial window", async () => {
+    globalThis.Request = TestRequest as unknown as typeof Request;
+    globalThis.Response = TestResponse as unknown as typeof Response;
+    globalThis.Headers = TestHeaders as unknown as typeof Headers;
+    (globalThis as any).caches = undefined;
+    const latestBlock = 10874050;
+    const d1 = createD1Mock({
+      "thought-gallery:v1:sepolia": {
+        version: 1,
+        cachedAt: Date.now() - 120_000,
+        chainId: 11155111,
+        contract: THOUGHT_NFT,
+        fromBlock: 10872879,
+        lastScannedBlock: 10874000,
+        items: [
+          {
+            tokenId: 1,
+            pathId: "24",
+            minter: OWNER,
+            textHash: "0xold",
+            promptHash: "",
+            provenanceHash: "0xold",
+            thoughtSpecId: "0xold",
+            thoughtSpecHash: "0xold",
+            mintedAt: 1,
+            rawText: "old thought",
+            prompt: "",
+            mode: "",
+            provider: "",
+            model: "",
+            returnedText: "",
+            returnedTextHash: "",
+            provenanceJson: "",
+            image: "",
+            tokenUri: "",
+            txHash: `0x${"1".padStart(64, "0")}`,
+            blockNumber: 10873000,
+          },
+        ],
+      } satisfies IndexedSnapshot<unknown>,
+    });
+    const fetchMock = jest.fn(async (_url: unknown, init?: any) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "eth_blockNumber") {
+        return rpcResponse(`0x${latestBlock.toString(16)}`);
+      }
+      if (body.method === "eth_getLogs") {
+        return rpcResponse([]);
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onIndexerRefreshPost({
+      request: new Request("https://preview.inshell.art/api/indexer/refresh?target=thought-gallery", {
+        method: "POST",
+        headers: { authorization: "Bearer secret-token" },
+      }),
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        INSHELL_INDEXER_REFRESH_TOKEN: "secret-token",
+        THOUGHT_PRIMARY_RPC_UPSTREAM: "https://thought-rpc.example/sepolia",
+        INDEXER_REFRESH_MAX_LOG_CHUNKS: "2",
+      },
+    });
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      results?: Array<{ partial?: boolean; scannedToBlock?: number; items?: number }>;
+    };
+    const stored = JSON.parse(d1.rows.get("thought-gallery:v1:sepolia") ?? "{}") as {
+      lastScannedBlock?: number;
+      items?: Array<{ tokenId?: number; rawText?: string }>;
+    };
+    const methods = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String((init as any)?.body ?? "{}")).method
+    );
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.results?.[0]).toMatchObject({
+      partial: true,
+      scannedToBlock: 10874017,
+      items: 1,
+    });
+    expect(stored.lastScannedBlock).toBe(10874017);
+    expect(stored.items).toEqual([
+      expect.objectContaining({ tokenId: 1, rawText: "old thought" }),
+    ]);
+    expect(methods).toEqual(["eth_blockNumber", "eth_getLogs", "eth_getLogs"]);
+  });
+
   test("protected indexer event updates the pulse auction read model", async () => {
     globalThis.Request = TestRequest as unknown as typeof Request;
     globalThis.Response = TestResponse as unknown as typeof Response;

--- a/functions/api/chain-cache.ts
+++ b/functions/api/chain-cache.ts
@@ -38,6 +38,8 @@ export type ChainCacheEnv = {
   INSHELL_CHAIN_DATA_KV?: KVNamespaceLike;
   INSHELL_CHAIN_DATA_DB?: D1DatabaseLike;
   INSHELL_INDEXER_REFRESH_TOKEN?: string;
+  INDEXER_REFRESH_MAX_BLOCKS?: string;
+  INDEXER_REFRESH_MAX_LOG_CHUNKS?: string;
   CHAIN_CACHE_DIAGNOSTICS?: string;
 };
 
@@ -102,6 +104,7 @@ const JSON_HEADERS = {
 const RPC_TIMEOUT_MS = 12_000;
 const REORG_DEPTH = 3;
 const DEFAULT_LOG_CHUNK_SIZE = 10;
+const DEFAULT_REFRESH_MAX_LOG_CHUNKS = 20;
 const EDGE_CACHE_PREFIX = "https://inshell.local/chain-cache/";
 const RESPONSE_CACHE_PREFIX = "https://inshell.local/chain-response/";
 const KV_SNAPSHOT_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -230,6 +233,26 @@ export type IndexedSnapshot<T> = {
   fromBlock: number;
   lastScannedBlock: number;
   items: T[];
+};
+
+export type RefreshProgress = {
+  fromBlock: number;
+  toBlock: number;
+  latestBlock: number;
+  chunkSize: number;
+  maxBlocks: number;
+  complete: boolean;
+  remainingBlocks: number;
+};
+
+export type RefreshOutcome<T> = {
+  snapshot: IndexedSnapshot<T>;
+  progress: RefreshProgress;
+};
+
+type WriteSnapshotOptions = {
+  strictD1?: boolean;
+  waitForPersistence?: boolean;
 };
 
 type JsonSafe =
@@ -609,6 +632,7 @@ export async function writeSnapshot<T>(
   edgeTtlSeconds: number,
   diagnostics?: ChainCacheDiagnostics,
   previous?: IndexedSnapshot<T> | null,
+  options: WriteSnapshotOptions = {},
 ) {
   memoryCache.set(key, { cachedAt: Date.now(), value: snapshot });
   if (diagnostics) diagnostics.snapshotBlock = snapshot.lastScannedBlock;
@@ -616,7 +640,7 @@ export async function writeSnapshot<T>(
   const tasks: Array<Promise<unknown>> = [writeEdgeCache(key, snapshot, edgeTtlSeconds)];
   if (ctx.env.INSHELL_CHAIN_DATA_DB && shouldWriteD1Snapshot(previous ?? null, snapshot)) {
     if (diagnostics) diagnostics.dbWrite = 1;
-    tasks.push(writeD1Snapshot(ctx.env, key, snapshot));
+    tasks.push(writeD1Snapshot(ctx.env, key, snapshot, options.strictD1));
   }
   const shouldPersist = shouldWriteKvSnapshot(previous ?? null, snapshot);
   if (shouldPersist && ctx.env.INSHELL_CHAIN_DATA_KV) {
@@ -627,8 +651,13 @@ export async function writeSnapshot<T>(
       }),
     );
   }
-  const joined = Promise.all(tasks).then(() => undefined).catch(() => undefined);
-  if (ctx.waitUntil) ctx.waitUntil(joined);
+  const joined = Promise.all(tasks)
+    .then(() => undefined)
+    .catch((error) => {
+      if (options.strictD1) throw error;
+      return undefined;
+    });
+  if (ctx.waitUntil && !options.waitForPersistence) ctx.waitUntil(joined);
   else await joined;
 }
 
@@ -711,6 +740,33 @@ export function refreshFromBlock(snapshot: IndexedSnapshot<unknown> | null, depl
       ? Math.max(deployBlock, snapshot.lastScannedBlock - REORG_DEPTH + 1)
       : deployBlock;
   return Math.min(Math.max(0, start), latestBlock);
+}
+
+export function fullRefreshRange(
+  snapshot: IndexedSnapshot<unknown> | null | undefined,
+  deployBlock: number,
+  latestBlock: number,
+): RefreshProgress {
+  const fromBlock = refreshFromBlock(snapshot ?? null, deployBlock, latestBlock);
+  return refreshProgress(fromBlock, latestBlock, latestBlock, latestBlock - fromBlock + 1);
+}
+
+export function boundedRefreshRange(
+  env: ChainCacheEnv,
+  snapshot: IndexedSnapshot<unknown> | null | undefined,
+  deployBlock: number,
+  latestBlock: number,
+  options: { maxLogChunks?: number } = {},
+): RefreshProgress {
+  const fromBlock = refreshFromBlock(snapshot ?? null, deployBlock, latestBlock);
+  const maxLogChunks = readRefreshMaxLogChunks(env, options.maxLogChunks);
+  const configuredMaxBlocks = readPositiveInteger(
+    env.INDEXER_REFRESH_MAX_BLOCKS,
+    maxLogChunks * DEFAULT_LOG_CHUNK_SIZE,
+  );
+  const maxBlocks = Math.max(1, Math.min(configuredMaxBlocks, maxLogChunks * DEFAULT_LOG_CHUNK_SIZE));
+  const toBlock = Math.min(latestBlock, fromBlock + maxBlocks - 1);
+  return refreshProgress(fromBlock, toBlock, latestBlock, maxBlocks);
 }
 
 export function pruneReorgWindow<T extends { blockNumber?: number }>(
@@ -1006,6 +1062,38 @@ function snapshotBlock(value: unknown) {
   return typeof block === "number" && Number.isFinite(block) ? block : undefined;
 }
 
+function refreshProgress(
+  fromBlock: number,
+  toBlock: number,
+  latestBlock: number,
+  maxBlocks: number,
+): RefreshProgress {
+  return {
+    fromBlock,
+    toBlock,
+    latestBlock,
+    chunkSize: DEFAULT_LOG_CHUNK_SIZE,
+    maxBlocks,
+    complete: toBlock >= latestBlock,
+    remainingBlocks: Math.max(0, latestBlock - toBlock),
+  };
+}
+
+function readRefreshMaxLogChunks(env: ChainCacheEnv, routeCap?: number) {
+  const configured = readPositiveInteger(
+    env.INDEXER_REFRESH_MAX_LOG_CHUNKS,
+    DEFAULT_REFRESH_MAX_LOG_CHUNKS,
+  );
+  if (!Number.isFinite(routeCap) || routeCap == null) return configured;
+  return Math.max(1, Math.min(configured, Math.trunc(routeCap)));
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.trunc(parsed);
+}
+
 async function ensureD1SnapshotTable(db: D1DatabaseLike) {
   if (!db.exec || ensuredD1Tables.has(db as object)) return;
   await db.exec(
@@ -1049,6 +1137,7 @@ async function writeD1Snapshot<T>(
   env: ChainCacheEnv,
   key: string,
   snapshot: IndexedSnapshot<T>,
+  strict = false,
 ) {
   const db = env.INSHELL_CHAIN_DATA_DB;
   if (!db) return;
@@ -1075,7 +1164,8 @@ async function writeD1Snapshot<T>(
         Date.now(),
       )
       .run();
-  } catch {
+  } catch (error) {
+    if (strict) throw error;
     // D1 is a read-model optimization; edge/KV/live fallback still serve the route.
   }
 }

--- a/functions/api/indexer/refresh.ts
+++ b/functions/api/indexer/refresh.ts
@@ -10,13 +10,16 @@ import {
   type ChainCacheDiagnostics,
   type IndexedSnapshot,
   type PagesContextLike,
+  type RefreshProgress,
 } from "../chain-cache";
-import { refreshPathTokens } from "../path-tokens";
-import { refreshPulseAuction, refreshPulseAuctionForTx } from "../pulse-auction";
-import { refreshThoughtGallery } from "../thought-gallery";
+import { refreshPathTokensBounded } from "../path-tokens";
+import { refreshPulseAuctionBounded, refreshPulseAuctionForTx } from "../pulse-auction";
+import { refreshThoughtGalleryBounded } from "../thought-gallery";
 import { isIndexerAuthorized } from "./auth";
 
 type RefreshTarget = "pulse-auction" | "path-tokens" | "thought-gallery" | "all";
+
+const ALL_TARGET_MAX_LOG_CHUNKS = 6;
 
 type RefreshResult = {
   target: Exclude<RefreshTarget, "all">;
@@ -24,6 +27,13 @@ type RefreshResult = {
   lastScannedBlock: number;
   items: number;
   source: string;
+  complete?: boolean;
+  partial?: boolean;
+  scannedFromBlock?: number;
+  scannedToBlock?: number;
+  latestBlock?: number;
+  remainingBlocks?: number;
+  maxBlocks?: number;
 };
 
 export const onRequestOptions = onOptions;
@@ -49,6 +59,9 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
   const diagnostics: ChainCacheDiagnostics[] = [];
   const statsList: ReturnType<typeof createStats>[] = [];
   const snapshots: IndexedSnapshot<unknown>[] = [];
+  const boundedOptions = normalizedTarget === "all"
+    ? { maxLogChunks: ALL_TARGET_MAX_LOG_CHUNKS }
+    : {};
   let activeTarget: Exclude<RefreshTarget, "all"> | null = null;
   let activeStats: ReturnType<typeof createStats> | null = null;
   try {
@@ -57,14 +70,17 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       const currentDiagnostics = createChainCacheDiagnostics("pulse-auction:v1:sepolia");
       const stats = createStats("path", "indexer-refresh:pulse-auction", ctx.env);
       activeStats = stats;
-      const snapshot = targetedPublicRefresh
-        ? await refreshPulseAuctionForTx(ctx, stats, currentDiagnostics, txHash)
-        : await refreshPulseAuction(ctx, stats, currentDiagnostics);
+      const outcome = targetedPublicRefresh
+        ? {
+          snapshot: await refreshPulseAuctionForTx(ctx, stats, currentDiagnostics, txHash),
+          progress: undefined,
+        }
+        : await refreshPulseAuctionBounded(ctx, stats, currentDiagnostics, boundedOptions);
       emitUsage(ctx, stats);
       diagnostics.push(currentDiagnostics);
       statsList.push(stats);
-      snapshots.push(snapshot as IndexedSnapshot<unknown>);
-      results.push(resultFor("pulse-auction", snapshot, currentDiagnostics));
+      snapshots.push(outcome.snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("pulse-auction", outcome.snapshot, currentDiagnostics, outcome.progress));
     }
 
     if (normalizedTarget === "path-tokens" || normalizedTarget === "all") {
@@ -72,12 +88,12 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       const currentDiagnostics = createChainCacheDiagnostics("path-tokens:v1:sepolia");
       const stats = createStats("path", "indexer-refresh:path-tokens", ctx.env);
       activeStats = stats;
-      const snapshot = await refreshPathTokens(ctx, stats, currentDiagnostics);
+      const outcome = await refreshPathTokensBounded(ctx, stats, currentDiagnostics, boundedOptions);
       emitUsage(ctx, stats);
       diagnostics.push(currentDiagnostics);
       statsList.push(stats);
-      snapshots.push(snapshot as IndexedSnapshot<unknown>);
-      results.push(resultFor("path-tokens", snapshot, currentDiagnostics));
+      snapshots.push(outcome.snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("path-tokens", outcome.snapshot, currentDiagnostics, outcome.progress));
     }
 
     if (normalizedTarget === "thought-gallery" || normalizedTarget === "all") {
@@ -85,12 +101,12 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
       const currentDiagnostics = createChainCacheDiagnostics("thought-gallery:v1:sepolia");
       const stats = createStats("thought", "indexer-refresh:thought-gallery", ctx.env);
       activeStats = stats;
-      const snapshot = await refreshThoughtGallery(ctx, stats, currentDiagnostics);
+      const outcome = await refreshThoughtGalleryBounded(ctx, stats, currentDiagnostics, boundedOptions);
       emitUsage(ctx, stats);
       diagnostics.push(currentDiagnostics);
       statsList.push(stats);
-      snapshots.push(snapshot as IndexedSnapshot<unknown>);
-      results.push(resultFor("thought-gallery", snapshot, currentDiagnostics));
+      snapshots.push(outcome.snapshot as IndexedSnapshot<unknown>);
+      results.push(resultFor("thought-gallery", outcome.snapshot, currentDiagnostics, outcome.progress));
     }
   } catch (error) {
     for (const stats of statsList) emitUsage(ctx, stats);
@@ -156,6 +172,7 @@ function resultFor<T>(
   target: Exclude<RefreshTarget, "all">,
   snapshot: IndexedSnapshot<T>,
   diagnostics: ChainCacheDiagnostics,
+  progress?: RefreshProgress,
 ): RefreshResult {
   return {
     target,
@@ -163,5 +180,12 @@ function resultFor<T>(
     lastScannedBlock: snapshot.lastScannedBlock,
     items: snapshot.items.length,
     source: diagnostics.source,
+    complete: progress?.complete,
+    partial: progress ? !progress.complete : undefined,
+    scannedFromBlock: progress?.fromBlock,
+    scannedToBlock: progress?.toBlock,
+    latestBlock: progress?.latestBlock,
+    remainingBlocks: progress?.remainingBlocks,
+    maxBlocks: progress?.maxBlocks,
   };
 }

--- a/functions/api/path-tokens.ts
+++ b/functions/api/path-tokens.ts
@@ -6,6 +6,7 @@ import {
   PATH_THOUGHT_CONSUMED_TOPIC,
   THOUGHT_NFT_ADDRESS,
   TRANSFER_TOPIC,
+  boundedRefreshRange,
   chainFailure,
   createChainCacheDiagnostics,
   createStats,
@@ -13,6 +14,7 @@ import {
   decodeStringResult,
   emitUsage,
   ethCall,
+  fullRefreshRange,
   getBlockNumber,
   getLogsChunked,
   hexToNumber,
@@ -25,7 +27,6 @@ import {
   readModelEnabled,
   readSnapshot,
   readResponseCache,
-  refreshFromBlock,
   sortByBlockLog,
   sortByTokenId,
   tokenUriData,
@@ -40,6 +41,7 @@ import {
   type IndexedSnapshot,
   type PagesContextLike,
   type PathTokenApiItem,
+  type RefreshOutcome,
 } from "./chain-cache";
 
 const SNAPSHOT_KEY = "path-tokens:v1:sepolia";
@@ -75,7 +77,7 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
 
   const stats = createStats("path", "path-tokens", ctx.env);
   try {
-    const snapshot = await loadPathTokens(ctx.env, ctx, stats, diagnostics, previous);
+    const { snapshot } = await loadPathTokens(ctx.env, ctx, stats, diagnostics, previous);
     emitUsage(ctx, stats);
     const response = responseFromSnapshot(snapshot);
     writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, snapshot.lastScannedBlock);
@@ -94,35 +96,55 @@ async function loadPathTokens(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
   previousOverride?: IndexedSnapshot<PathTokenApiItem> | null,
-  force = false,
-): Promise<IndexedSnapshot<PathTokenApiItem>> {
+  options: { force?: boolean; bounded?: boolean; maxLogChunks?: number } = {},
+): Promise<RefreshOutcome<PathTokenApiItem>> {
   const previous =
     previousOverride === undefined
       ? await readSnapshot<PathTokenApiItem>(env, SNAPSHOT_KEY, diagnostics)
       : previousOverride;
-  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
-    return previous;
+  if (!options.force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+    return {
+      snapshot: previous,
+      progress: fullRefreshRange(previous, PATH_NFT_DEPLOY_BLOCK, previous.lastScannedBlock),
+    };
   }
 
   const latestBlock = await getBlockNumber(env, "path", stats);
-  const refreshStart = refreshFromBlock(previous, PATH_NFT_DEPLOY_BLOCK, latestBlock);
-  const logs = await getLogsChunked(env, "path", stats, {
-    address: PATH_NFT_ADDRESS,
-    fromBlock: refreshStart,
-    toBlock: latestBlock,
-    topics: [TRANSFER_TOPIC],
-  });
+  const progress = options.bounded
+    ? boundedRefreshRange(env, previous, PATH_NFT_DEPLOY_BLOCK, latestBlock, {
+      maxLogChunks: options.maxLogChunks,
+    })
+    : fullRefreshRange(previous, PATH_NFT_DEPLOY_BLOCK, latestBlock);
+  let logs: ChainLog[];
+  try {
+    logs = await getLogsChunked(env, "path", stats, {
+      address: PATH_NFT_ADDRESS,
+      fromBlock: progress.fromBlock,
+      toBlock: progress.toBlock,
+      topics: [TRANSFER_TOPIC],
+      chunkSize: progress.chunkSize,
+    });
+  } catch (error) {
+    throw chainFailure("path tokens refresh getLogs failed", {
+      target: "path-tokens",
+      stage: "getLogs",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
 
   const tokens = new Map<string, PathTokenApiItem>();
-  for (const item of pruneReorgWindow(previous?.items ?? [], refreshStart)) {
+  for (const item of pruneReorgWindow(previous?.items ?? [], progress.fromBlock)) {
     tokens.set(item.tokenId, item);
   }
 
+  const changedTokenIds = new Set<string>();
   for (const log of logs.sort(sortByBlockLog)) {
     if (log.removed) continue;
     const tokenId = topicToBigInt(log.topics[3]);
     if (tokenId == null) continue;
     const tokenIdLabel = tokenId.toString();
+    changedTokenIds.add(tokenIdLabel);
     const to = lowerTopicAddress(log.topics[2]);
     if (to === ZERO_TOPIC) {
       tokens.delete(tokenIdLabel);
@@ -141,22 +163,27 @@ async function loadPathTokens(
   }
 
   for (const item of tokens.values()) {
-    try {
-      item.owner = normalizeAddressResult(
-        await ethCall(env, "path", stats, PATH_NFT_ADDRESS, ownerOfData(item.tokenId)),
-      );
-    } catch {
-      // Keep the last Transfer owner if ownerOf is temporarily unavailable.
+    const changed = changedTokenIds.has(item.tokenId);
+    if (!options.bounded || changed) {
+      try {
+        item.owner = normalizeAddressResult(
+          await ethCall(env, "path", stats, PATH_NFT_ADDRESS, ownerOfData(item.tokenId)),
+        );
+      } catch {
+        // Keep the last Transfer owner if ownerOf is temporarily unavailable.
+      }
     }
-    if (!item.tokenUri) {
+    if (!options.bounded || changed) {
       try {
         item.tokenUri = decodeStringResult(
           await ethCall(env, "path", stats, PATH_NFT_ADDRESS, tokenUriData(item.tokenId)),
         );
         item.metadata = parseMetadata(item.tokenUri);
       } catch {
-        item.tokenUri = "";
-        item.metadata = {};
+        if (!item.tokenUri) {
+          item.tokenUri = "";
+          item.metadata = {};
+        }
       }
     }
     if (!metadataString(item.metadata.name)) {
@@ -170,11 +197,28 @@ async function loadPathTokens(
     chainId: 11155111,
     contract: PATH_NFT_ADDRESS,
     fromBlock: PATH_NFT_DEPLOY_BLOCK,
-    lastScannedBlock: latestBlock,
+    lastScannedBlock: progress.toBlock,
     items: sortByTokenId([...tokens.values()]),
   };
-  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
-  return snapshot;
+  try {
+    await writeSnapshot(
+      ctx,
+      SNAPSHOT_KEY,
+      snapshot,
+      EDGE_SNAPSHOT_SECONDS,
+      diagnostics,
+      previous,
+      options.bounded ? { strictD1: true, waitForPersistence: true } : undefined,
+    );
+  } catch (error) {
+    throw chainFailure("path tokens refresh snapshot write failed", {
+      target: "path-tokens",
+      stage: "writeSnapshot",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
+  return { snapshot, progress };
 }
 
 export async function refreshPathTokens(
@@ -182,7 +226,9 @@ export async function refreshPathTokens(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
 ) {
-  const snapshot = await loadPathTokens(ctx.env, ctx, stats, diagnostics, undefined, true);
+  const { snapshot } = await loadPathTokens(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+  });
   writeResponseCache(
     ctx,
     SNAPSHOT_KEY,
@@ -191,6 +237,27 @@ export async function refreshPathTokens(
     snapshot.lastScannedBlock,
   );
   return snapshot;
+}
+
+export async function refreshPathTokensBounded(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  options: { maxLogChunks?: number } = {},
+) {
+  const outcome = await loadPathTokens(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+    bounded: true,
+    maxLogChunks: options.maxLogChunks,
+  });
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(outcome.snapshot),
+    RESPONSE_CACHE_SECONDS,
+    outcome.snapshot.lastScannedBlock,
+  );
+  return outcome;
 }
 
 export async function refreshPathTokensForEvent(

--- a/functions/api/pulse-auction.ts
+++ b/functions/api/pulse-auction.ts
@@ -2,9 +2,12 @@ import {
   PULSE_AUCTION_ADDRESS,
   PULSE_AUCTION_DEPLOY_BLOCK,
   PULSE_SALE_TOPIC,
+  boundedRefreshRange,
+  chainFailure,
   createChainCacheDiagnostics,
   createStats,
   emitUsage,
+  fullRefreshRange,
   getBlockNumber,
   getLogsChunked,
   getTransactionReceipt,
@@ -16,7 +19,6 @@ import {
   readModelEnabled,
   readSnapshot,
   readResponseCache,
-  refreshFromBlock,
   safeNumber,
   sortByBlockLog,
   topicToAddress,
@@ -31,6 +33,7 @@ import {
   type IndexedSnapshot,
   type PagesContextLike,
   type PulseBidApiItem,
+  type RefreshOutcome,
 } from "./chain-cache";
 
 const SNAPSHOT_KEY = "pulse-auction:v1:sepolia";
@@ -75,28 +78,63 @@ async function loadPulseAuction(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
   previousOverride?: IndexedSnapshot<PulseBidApiItem> | null,
-  force = false,
-): Promise<IndexedSnapshot<PulseBidApiItem>> {
+  options: { force?: boolean; bounded?: boolean; maxLogChunks?: number } = {},
+): Promise<RefreshOutcome<PulseBidApiItem>> {
   const previous =
     previousOverride === undefined
       ? await readSnapshot<PulseBidApiItem>(env, SNAPSHOT_KEY, diagnostics)
       : previousOverride;
-  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
-    return previous;
+  if (!options.force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+    return {
+      snapshot: previous,
+      progress: fullRefreshRange(previous, PULSE_AUCTION_DEPLOY_BLOCK, previous.lastScannedBlock),
+    };
   }
 
   const latestBlock = await getBlockNumber(env, "path", stats);
-  const refreshStart = refreshFromBlock(previous, PULSE_AUCTION_DEPLOY_BLOCK, latestBlock);
-  const logs = await getLogsChunked(env, "path", stats, {
-    address: PULSE_AUCTION_ADDRESS,
-    fromBlock: refreshStart,
-    toBlock: latestBlock,
-    topics: [PULSE_SALE_TOPIC],
-  });
+  const progress = options.bounded
+    ? boundedRefreshRange(env, previous, PULSE_AUCTION_DEPLOY_BLOCK, latestBlock, {
+      maxLogChunks: options.maxLogChunks,
+    })
+    : fullRefreshRange(previous, PULSE_AUCTION_DEPLOY_BLOCK, latestBlock);
+  let logs: ChainLog[];
+  try {
+    logs = await getLogsChunked(env, "path", stats, {
+      address: PULSE_AUCTION_ADDRESS,
+      fromBlock: progress.fromBlock,
+      toBlock: progress.toBlock,
+      topics: [PULSE_SALE_TOPIC],
+      chunkSize: progress.chunkSize,
+    });
+  } catch (error) {
+    throw chainFailure("pulse auction refresh getLogs failed", {
+      target: "pulse-auction",
+      stage: "getLogs",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
 
-  const snapshot = mergePulseSnapshot(previous, logs, refreshStart, latestBlock);
-  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
-  return snapshot;
+  const snapshot = mergePulseSnapshot(previous, logs, progress.fromBlock, progress.toBlock);
+  try {
+    await writeSnapshot(
+      ctx,
+      SNAPSHOT_KEY,
+      snapshot,
+      EDGE_SNAPSHOT_SECONDS,
+      diagnostics,
+      previous,
+      options.bounded ? { strictD1: true, waitForPersistence: true } : undefined,
+    );
+  } catch (error) {
+    throw chainFailure("pulse auction refresh snapshot write failed", {
+      target: "pulse-auction",
+      stage: "writeSnapshot",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
+  return { snapshot, progress };
 }
 
 export async function refreshPulseAuction(
@@ -104,7 +142,9 @@ export async function refreshPulseAuction(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
 ) {
-  const snapshot = await loadPulseAuction(ctx.env, ctx, stats, diagnostics, undefined, true);
+  const { snapshot } = await loadPulseAuction(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+  });
   writeResponseCache(
     ctx,
     SNAPSHOT_KEY,
@@ -113,6 +153,27 @@ export async function refreshPulseAuction(
     snapshot.lastScannedBlock,
   );
   return snapshot;
+}
+
+export async function refreshPulseAuctionBounded(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  options: { maxLogChunks?: number } = {},
+) {
+  const outcome = await loadPulseAuction(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+    bounded: true,
+    maxLogChunks: options.maxLogChunks,
+  });
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(outcome.snapshot),
+    RESPONSE_CACHE_SECONDS,
+    outcome.snapshot.lastScannedBlock,
+  );
+  return outcome;
 }
 
 export async function refreshPulseAuctionForTx(

--- a/functions/api/thought-gallery.ts
+++ b/functions/api/thought-gallery.ts
@@ -2,12 +2,14 @@ import {
   THOUGHT_MINTED_TOPIC,
   THOUGHT_NFT_ADDRESS,
   THOUGHT_NFT_DEPLOY_BLOCK,
+  boundedRefreshRange,
   chainFailure,
   createChainCacheDiagnostics,
   createStats,
   decodeStringResult,
   emitUsage,
   ethCall,
+  fullRefreshRange,
   getBlockNumber,
   getLogsChunked,
   hexToNumber,
@@ -24,7 +26,6 @@ import {
   readModelEnabled,
   readSnapshot,
   readResponseCache,
-  refreshFromBlock,
   sortByTokenId,
   tokenImage,
   tokenUriData,
@@ -38,6 +39,7 @@ import {
   type ChainLog,
   type IndexedSnapshot,
   type PagesContextLike,
+  type RefreshOutcome,
   type ThoughtGalleryApiItem,
 } from "./chain-cache";
 
@@ -72,7 +74,7 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
 
   const stats = createStats("thought", "thought-gallery", ctx.env);
   try {
-    const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, previous);
+    const { snapshot } = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, previous);
     emitUsage(ctx, stats);
     const response = responseFromSnapshot(snapshot);
     writeResponseCache(ctx, SNAPSHOT_KEY, response, RESPONSE_CACHE_SECONDS, snapshot.lastScannedBlock);
@@ -91,27 +93,45 @@ async function loadThoughtGallery(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
   previousOverride?: IndexedSnapshot<ThoughtGalleryApiItem> | null,
-  force = false,
-): Promise<IndexedSnapshot<ThoughtGalleryApiItem>> {
+  options: { force?: boolean; bounded?: boolean; maxLogChunks?: number } = {},
+): Promise<RefreshOutcome<ThoughtGalleryApiItem>> {
   const previous =
     previousOverride === undefined
       ? await readSnapshot<ThoughtGalleryApiItem>(env, SNAPSHOT_KEY, diagnostics)
       : previousOverride;
-  if (!force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
-    return previous;
+  if (!options.force && previous && Date.now() - previous.cachedAt < RESPONSE_CACHE_SECONDS * 1000) {
+    return {
+      snapshot: previous,
+      progress: fullRefreshRange(previous, THOUGHT_NFT_DEPLOY_BLOCK, previous.lastScannedBlock),
+    };
   }
 
   const latestBlock = await getBlockNumber(env, "thought", stats);
-  const refreshStart = refreshFromBlock(previous, THOUGHT_NFT_DEPLOY_BLOCK, latestBlock);
-  const logs = await getLogsChunked(env, "thought", stats, {
-    address: THOUGHT_NFT_ADDRESS,
-    fromBlock: refreshStart,
-    toBlock: latestBlock,
-    topics: [THOUGHT_MINTED_TOPIC],
-  });
+  const progress = options.bounded
+    ? boundedRefreshRange(env, previous, THOUGHT_NFT_DEPLOY_BLOCK, latestBlock, {
+      maxLogChunks: options.maxLogChunks,
+    })
+    : fullRefreshRange(previous, THOUGHT_NFT_DEPLOY_BLOCK, latestBlock);
+  let logs: ChainLog[];
+  try {
+    logs = await getLogsChunked(env, "thought", stats, {
+      address: THOUGHT_NFT_ADDRESS,
+      fromBlock: progress.fromBlock,
+      toBlock: progress.toBlock,
+      topics: [THOUGHT_MINTED_TOPIC],
+      chunkSize: progress.chunkSize,
+    });
+  } catch (error) {
+    throw chainFailure("thought gallery refresh getLogs failed", {
+      target: "thought-gallery",
+      stage: "getLogs",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
 
   const existing = new Map<string, ThoughtGalleryApiItem>();
-  for (const item of pruneReorgWindow(previous?.items ?? [], refreshStart)) {
+  for (const item of pruneReorgWindow(previous?.items ?? [], progress.fromBlock)) {
     existing.set(item.tokenId.toString(), item);
   }
 
@@ -127,11 +147,28 @@ async function loadThoughtGallery(
     chainId: 11155111,
     contract: THOUGHT_NFT_ADDRESS,
     fromBlock: THOUGHT_NFT_DEPLOY_BLOCK,
-    lastScannedBlock: latestBlock,
+    lastScannedBlock: progress.toBlock,
     items: sortByTokenId([...existing.values()]),
   };
-  await writeSnapshot(ctx, SNAPSHOT_KEY, snapshot, EDGE_SNAPSHOT_SECONDS, diagnostics, previous);
-  return snapshot;
+  try {
+    await writeSnapshot(
+      ctx,
+      SNAPSHOT_KEY,
+      snapshot,
+      EDGE_SNAPSHOT_SECONDS,
+      diagnostics,
+      previous,
+      options.bounded ? { strictD1: true, waitForPersistence: true } : undefined,
+    );
+  } catch (error) {
+    throw chainFailure("thought gallery refresh snapshot write failed", {
+      target: "thought-gallery",
+      stage: "writeSnapshot",
+      upstreamLabel: stats.upstreamLabel,
+      blockRange: { fromBlock: progress.fromBlock, toBlock: progress.toBlock },
+    }, error);
+  }
+  return { snapshot, progress };
 }
 
 export async function refreshThoughtGallery(
@@ -139,7 +176,9 @@ export async function refreshThoughtGallery(
   stats: ReturnType<typeof createStats>,
   diagnostics: ChainCacheDiagnostics,
 ) {
-  const snapshot = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, undefined, true);
+  const { snapshot } = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+  });
   writeResponseCache(
     ctx,
     SNAPSHOT_KEY,
@@ -148,6 +187,27 @@ export async function refreshThoughtGallery(
     snapshot.lastScannedBlock,
   );
   return snapshot;
+}
+
+export async function refreshThoughtGalleryBounded(
+  ctx: PagesContextLike,
+  stats: ReturnType<typeof createStats>,
+  diagnostics: ChainCacheDiagnostics,
+  options: { maxLogChunks?: number } = {},
+) {
+  const outcome = await loadThoughtGallery(ctx.env, ctx, stats, diagnostics, undefined, {
+    force: true,
+    bounded: true,
+    maxLogChunks: options.maxLogChunks,
+  });
+  writeResponseCache(
+    ctx,
+    SNAPSHOT_KEY,
+    responseFromSnapshot(outcome.snapshot),
+    RESPONSE_CACHE_SECONDS,
+    outcome.snapshot.lastScannedBlock,
+  );
+  return outcome;
 }
 
 export async function refreshThoughtGalleryForEvent(


### PR DESCRIPTION
Promotes staging commit 605397a to production.\n\nSummary:\n- Bounds scheduled /api/indexer/refresh work under Worker subrequest limits.\n- Keeps /api/indexer/event targeted fast path intact.\n- Preserves D1 snapshot lastScannedBlock as the refresh cursor with partial progress responses.\n\nValidation:\n- staging deploy-pages run 27856031892 passed for home and THOUGHT.\n- staging authenticated refresh passed for pulse-auction, path-tokens, thought-gallery, and all.\n- local lint, type-check, test:unit, check:deployment, thought runtime, builds, and gitleaks passed.