### PR TITLE
Promote PUB route layer to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -79,6 +79,8 @@ jobs:
           fi
       - name: Validate deployment gates
         run: pnpm run check:deployment
+      - name: Check PUB path boundary
+        run: pnpm run pub-boundary:check
       - name: Lint home
         run: pnpm --filter @inshell/home lint
       - name: Test home launch surface
@@ -159,6 +161,8 @@ jobs:
           fi
       - name: Validate deployment gates
         run: pnpm run check:deployment
+      - name: Check PUB path boundary
+        run: pnpm run pub-boundary:check
       - name: Test THOUGHT runtime payloads
         run: pnpm run test:thought-runtime
       - name: Type-check THOUGHT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Validate deployment gates
         run: pnpm run check:deployment
+      - name: Check PUB path boundary
+        run: pnpm run pub-boundary:check
       - name: Run linter
         run: pnpm run lint
       - name: Run type-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,34 @@
 - If OPS reports an RPC/read-model/config mismatch, first check `/api/ops/status` and API route diagnostic headers before asking the operator to relay state.
 - Keep `scripts/smoke-cloudflare-api-routes.mjs` checking `/api/ops/status` for both home and THOUGHT deployments.
 
+## PUB Path Boundary
+
+PUB owns the PUB path boundary contract.
+
+Source of truth:
+
+https://inshell-pub.pages.dev/pub/contract/pub-path-boundary.json
+
+Shared-origin smoke target:
+
+https://inshell.art/pub/contract/pub-path-boundary.json
+
+Before changing static output, app routes, API routes, workers, redirects, rewrites, edge routing, sitemap generation, or deploy config, check the PUB path boundary.
+
+DEV owns the shared `inshell.art` route layer for PUB paths. DEV may proxy reserved paths to the PUB upstream, but must not define, serve, redirect to DEV-owned content, catch with the SPA fallback, or statically emit any path reserved by the PUB contract.
+
+For the current contract, DEV must not claim:
+
+- /llms.txt
+- /pub.manifest.json
+- /pub/**
+
+DEV may link to, fetch, or route PUB paths to the PUB upstream. DEV may not own, recreate, or overwrite PUB content.
+
+If a requested change needs a PUB-reserved path, stop and ask for a PUB boundary change. Do not work around the contract.
+
+Run the DEV PUB-boundary check before commit/deploy.
+
 ## Security and Quality Routine
 - GitHub security/quality alerts are handled on `staging` first, then promoted to `main` only after operator review.
 - The midnight routine means: inspect GitHub Dependabot alerts, code scanning alerts, secret scanning alerts, Dependabot PRs, and failed quality workflows; patch on `staging`; run CI/leak checks; push preview; notify the operator.

--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -47,9 +47,9 @@ class TestRequest {
   readonly url: string;
   readonly method: string;
 
-  constructor(input: string | { url: string; method?: string }) {
+  constructor(input: string | { url: string; method?: string }, init?: { method?: string }) {
     this.url = typeof input === "string" ? input : input.url;
-    this.method = typeof input === "string" ? "GET" : (input.method ?? "GET");
+    this.method = init?.method ?? (typeof input === "string" ? "GET" : (input.method ?? "GET"));
   }
 }
 
@@ -80,15 +80,16 @@ class TestResponse {
   }
 }
 
-function middlewareContext(url: string) {
+function middlewareContext(url: string, init?: { method?: string; env?: Record<string, unknown> }) {
   const next = jest.fn(async () => new Response("next", { status: 200 }));
   const assetsFetch = jest.fn(async () => new Response("asset", { status: 200 }));
   return {
-    request: new Request(url),
+    request: new Request(url, { method: init?.method ?? "GET" }),
     env: {
       ASSETS: {
         fetch: assetsFetch,
       },
+      ...(init?.env ?? {}),
     },
     next,
     assetsFetch,
@@ -136,6 +137,60 @@ describe("Pages middleware canonical routes", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://inshell.art/path/15?source=x");
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("routes PUB reserved paths to the PUB upstream before the app shell", async () => {
+    const fetchMock = jest.fn(
+      async () =>
+        new Response("pub", {
+          status: 200,
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+            etag: "\"pub-etag\"",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    for (const path of ["/llms.txt", "/pub.manifest.json", "/pub/contract/pub-path-boundary.json?check=1"]) {
+      const ctx = middlewareContext(`https://inshell.art${path}`);
+      const response = await onRequest(ctx);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-inshell-dev-path-boundary")).toBe("pub-proxy");
+      expect(response.headers.get("etag")).toBe("\"pub-etag\"");
+      expect(ctx.next).not.toHaveBeenCalled();
+      expect(ctx.assetsFetch).not.toHaveBeenCalled();
+    }
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://inshell-pub.pages.dev/llms.txt",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://inshell-pub.pages.dev/pub.manifest.json",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://inshell-pub.pages.dev/pub/contract/pub-path-boundary.json?check=1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  test("keeps PUB artifacts read-only at the DEV route layer", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://inshell.art/pub.manifest.json", { method: "POST" });
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+    expect(response.headers.get("x-inshell-dev-path-boundary")).toBe("pub-method-not-allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ctx.next).not.toHaveBeenCalled();
     expect(ctx.assetsFetch).not.toHaveBeenCalled();
   });

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -2,6 +2,7 @@ const PUBLIC_FEED_RSS_URL = "https://inshell-public-feed.pages.dev/rss.xml";
 const PUBLIC_FEED_ALIAS_URL = "https://inshell-public-feed.pages.dev/feed.xml";
 const PUBLIC_FEED_SEPOLIA_RSS_URL = "https://inshell-public-feed.pages.dev/rss.sepolia.xml";
 const PUBLIC_FEED_BASE_URL = "https://d807d286.inshell-public-feed.pages.dev";
+const PUB_UPSTREAM_DEFAULT = "https://inshell-pub.pages.dev";
 const APP_SHELL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
 type PagesAssets = {
@@ -12,6 +13,8 @@ type MiddlewareContext = {
   request: Request;
   env: {
     ASSETS?: PagesAssets;
+    PUB_UPSTREAM?: string;
+    PUB_BOUNDARY_CONTRACT_URL?: string;
   };
   next: (request?: Request) => Promise<Response>;
 };
@@ -19,6 +22,10 @@ type UrlInstance = InstanceType<typeof globalThis.URL>;
 
 export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   const url = new globalThis.URL(ctx.request.url);
+  if (isPubRouteHost(url.hostname) && isPubReservedPathname(url.pathname)) {
+    return proxyPubArtifact(ctx.request, url, ctx.env);
+  }
+
   const pathname = normalizePathname(url.pathname);
   const sepoliaRedirect = temporarySepoliaHostRedirect(url);
   const thoughtRedirect = canonicalThoughtRedirect(url, pathname);
@@ -48,6 +55,135 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   }
 
   return ctx.next();
+}
+
+function isPubReservedPathname(pathname: string) {
+  return (
+    pathname === "/llms.txt" ||
+    pathname === "/pub.manifest.json" ||
+    pathname === "/pub/" ||
+    pathname.startsWith("/pub/")
+  );
+}
+
+function isPubRouteHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return (
+    host === "inshell.art" ||
+    host === "preview.inshell.art" ||
+    host === "inshell-art.pages.dev" ||
+    host.endsWith(".inshell-art.pages.dev")
+  );
+}
+
+async function proxyPubArtifact(request: Request, requestUrl: UrlInstance, env: MiddlewareContext["env"]) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return pubMethodNotAllowed();
+  }
+
+  const upstreamUrl = getPubArtifactUrl(requestUrl, env);
+  let upstream: Response;
+  const abortController = new globalThis.AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 8000);
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: request.method,
+      signal: abortController.signal,
+      headers: {
+        accept: pubArtifactAcceptHeader(requestUrl.pathname),
+      },
+    });
+  } catch {
+    return pubArtifactUnavailable();
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return new Response(request.method === "HEAD" ? null : upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: pubArtifactHeaders(upstream, requestUrl.pathname),
+  });
+}
+
+function getPubArtifactUrl(requestUrl: UrlInstance, env: MiddlewareContext["env"]) {
+  const upstream = normalizePubUpstream(env.PUB_UPSTREAM);
+  const url = new globalThis.URL(upstream);
+  url.pathname = encodedPathnameForProxy(requestUrl.pathname);
+  url.search = requestUrl.search;
+  return url.toString();
+}
+
+function normalizePubUpstream(value: string | undefined) {
+  const raw = value?.trim() || PUB_UPSTREAM_DEFAULT;
+  try {
+    const url = new globalThis.URL(raw);
+    if (url.protocol !== "https:") return PUB_UPSTREAM_DEFAULT;
+    url.pathname = "/";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return PUB_UPSTREAM_DEFAULT;
+  }
+}
+
+function pubArtifactAcceptHeader(pathname: string) {
+  if (pathname === "/llms.txt") return "text/plain, */*;q=0.1";
+  if (pathname === "/pub.manifest.json" || pathname === "/pub/contract/pub-path-boundary.json") {
+    return "application/json, */*;q=0.1";
+  }
+  return "*/*";
+}
+
+function pubArtifactHeaders(upstream: Response, pathname: string) {
+  const upstreamHeaders = new Headers(upstream.headers);
+  const headers = new Headers();
+  headers.set(
+    "content-type",
+    upstreamHeaders.get("content-type") ?? pubArtifactContentType(pathname),
+  );
+  headers.set("cache-control", upstreamHeaders.get("cache-control") ?? "public, max-age=60");
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("x-inshell-dev-path-boundary", "pub-proxy");
+  const etag = upstreamHeaders.get("etag");
+  if (etag) headers.set("etag", etag);
+  const lastModified = upstreamHeaders.get("last-modified");
+  if (lastModified) headers.set("last-modified", lastModified);
+  return headers;
+}
+
+function pubArtifactContentType(pathname: string) {
+  if (pathname === "/llms.txt") return "text/plain; charset=utf-8";
+  if (pathname === "/pub.manifest.json" || pathname.endsWith(".json")) {
+    return "application/json; charset=utf-8";
+  }
+  return "application/octet-stream";
+}
+
+function pubMethodNotAllowed() {
+  return new Response("PUB artifacts are read-only.", {
+    status: 405,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+      allow: "GET, HEAD",
+      "x-content-type-options": "nosniff",
+      "x-inshell-dev-path-boundary": "pub-method-not-allowed",
+    },
+  });
+}
+
+function pubArtifactUnavailable() {
+  return new Response("PUB artifact unavailable.", {
+    status: 502,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+      "x-inshell-dev-path-boundary": "pub-upstream-unavailable",
+    },
+  });
 }
 
 function temporarySepoliaHostRedirect(url: UrlInstance) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:presepolia": "pnpm --filter @inshell/home lint && pnpm run test:presepolia && pnpm run test:thought-runtime && pnpm run build:home && pnpm run check:deployment && git diff --check",
     "check:deployment": "node scripts/check-deployment.mjs",
     "check:deployment:live": "node scripts/check-deployment.mjs --live",
+    "pub-boundary:check": "node scripts/check-pub-boundary.mjs",
     "smoke:api-routes": "node scripts/smoke-cloudflare-api-routes.mjs",
     "check:web-analytics-token": "node scripts/check-cloudflare-web-analytics-token.mjs",
     "quality:github": "node scripts/dev-github-quality-loop.mjs",

--- a/scripts/check-pub-boundary.mjs
+++ b/scripts/check-pub-boundary.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_CONTRACT_URL = "https://inshell-pub.pages.dev/pub/contract/pub-path-boundary.json";
+const EXPECTED_ORIGIN = "https://inshell.art";
+const EXPECTED_OWNER = "PUB";
+const REQUEST_TIMEOUT_MS = 12_000;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+
+function parseArgs(argv) {
+  const args = {
+    contractUrl:
+      process.env.PUB_BOUNDARY_CONTRACT_URL ||
+      process.env.PUB_PATH_BOUNDARY_CONTRACT_URL ||
+      DEFAULT_CONTRACT_URL,
+    contractFile: process.env.PUB_PATH_BOUNDARY_CONTRACT_FILE || "",
+    skipContractFetch: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--contract-url" && next) {
+      args.contractUrl = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--contract-file" && next) {
+      args.contractFile = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--skip-contract-fetch") {
+      args.skipContractFetch = true;
+      continue;
+    }
+    throw new Error(`Unknown or incomplete argument: ${arg}`);
+  }
+  return args;
+}
+
+function normalizeRoutePath(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  let path = value.trim();
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      path = new URL(path).pathname;
+    } catch {
+      return null;
+    }
+  }
+  if (!path.startsWith("/")) return null;
+  return path || "/";
+}
+
+async function readContract(args) {
+  if (args.skipContractFetch) {
+    return {
+      schemaVersion: 1,
+      origin: EXPECTED_ORIGIN,
+      owner: EXPECTED_OWNER,
+      paths: {
+        exact: ["/llms.txt", "/pub.manifest.json"],
+        prefixes: ["/pub/"],
+      },
+    };
+  }
+
+  if (args.contractFile) {
+    const fullPath = resolve(repoRoot, args.contractFile);
+    return JSON.parse(readFileSync(fullPath, "utf8"));
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(args.contractUrl, {
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+      },
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`${args.contractUrl} returned HTTP ${response.status}: ${text.slice(0, 240)}`);
+    }
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      throw new Error(
+        `${args.contractUrl} returned non-JSON. PUB must deploy the path-boundary contract before DEV can treat this URL as current. Response starts: ${text.slice(0, 120).replace(/\s+/g, " ")}`,
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function validateContract(contract) {
+  const errors = [];
+  if (!contract || typeof contract !== "object" || Array.isArray(contract)) {
+    return ["contract must be a JSON object"];
+  }
+  if (contract.schemaVersion !== 1) errors.push("schemaVersion must be 1");
+  if (contract.origin !== EXPECTED_ORIGIN) errors.push(`origin must be ${EXPECTED_ORIGIN}`);
+  if (contract.owner !== EXPECTED_OWNER) errors.push(`owner must be ${EXPECTED_OWNER}`);
+  if (!contract.paths || typeof contract.paths !== "object" || Array.isArray(contract.paths)) {
+    errors.push("paths must be an object");
+    return errors;
+  }
+  for (const field of ["exact", "prefixes"]) {
+    const values = contract.paths[field];
+    if (!Array.isArray(values)) {
+      errors.push(`paths.${field} must be an array`);
+      continue;
+    }
+    for (const value of values) {
+      if (typeof value !== "string" || !value.startsWith("/")) {
+        errors.push(`paths.${field} contains invalid path ${JSON.stringify(value)}`);
+      }
+      if (field === "prefixes" && typeof value === "string" && !value.endsWith("/")) {
+        errors.push(`paths.prefixes entry must end with /: ${value}`);
+      }
+    }
+  }
+  return errors;
+}
+
+function addOwnedPath(paths, path, source, kind) {
+  const normalized = normalizeRoutePath(path);
+  if (!normalized) return;
+  paths.push({ path: normalized, source, kind });
+}
+
+function collectStaticFiles(paths, dir) {
+  const fullDir = resolve(repoRoot, dir);
+  if (!existsSync(fullDir)) return;
+  const walk = (current) => {
+    for (const name of readdirSync(current)) {
+      const fullPath = join(current, name);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      if (name === "_headers" || name === "_redirects") continue;
+      const rel = relative(fullDir, fullPath).split(sep).join("/");
+      const route = rel === "index.html"
+        ? "/"
+        : rel.endsWith("/index.html")
+          ? `/${rel.slice(0, -"index.html".length)}`
+          : `/${rel}`;
+      addOwnedPath(paths, route, relative(repoRoot, fullPath), "static");
+    }
+  };
+  walk(fullDir);
+}
+
+function collectFunctionRoutes(paths) {
+  const apiDir = resolve(repoRoot, "functions/api");
+  if (!existsSync(apiDir)) return;
+  const walk = (current) => {
+    for (const name of readdirSync(current)) {
+      const fullPath = join(current, name);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!stat.isFile() || !/\.(?:ts|js)$/.test(name)) continue;
+      const rel = relative(apiDir, fullPath).split(sep).join("/").replace(/\.(?:ts|js)$/i, "");
+      const route = rel.endsWith("/index") ? `/api/${rel.slice(0, -"/index".length)}` : `/api/${rel}`;
+      addOwnedPath(paths, route, relative(repoRoot, fullPath), "api-route");
+    }
+  };
+  walk(apiDir);
+}
+
+function collectRedirectRoutes(paths, filePath) {
+  const fullPath = resolve(repoRoot, filePath);
+  if (!existsSync(fullPath)) return;
+  const lines = readFileSync(fullPath, "utf8").split(/\r?\n/);
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const [from, to] = line.split(/\s+/);
+    addOwnedPath(paths, from, `${filePath}:${index + 1}`, "redirect-source");
+    if (to?.startsWith("/")) addOwnedPath(paths, to, `${filePath}:${index + 1}`, "redirect-target");
+  }
+}
+
+function collectMiddlewareRoutes(paths) {
+  const filePath = "functions/_middleware.ts";
+  const fullPath = resolve(repoRoot, filePath);
+  if (!existsSync(fullPath)) return;
+  const text = readFileSync(fullPath, "utf8");
+  const stringLiteralPattern = /(["'`])(\/[A-Za-z0-9._~:/?#[\]@!$&()*+,;=%-]*)\1/g;
+  let inPubRouteLayer = false;
+  let braceDepth = 0;
+  for (const line of text.split(/\r?\n/)) {
+    if (
+      line.includes("function isPubReservedPathname") ||
+      line.includes("function isPubRouteHost") ||
+      line.includes("function proxyPubArtifact") ||
+      line.includes("function getPubArtifactUrl") ||
+      line.includes("function pubArtifactAcceptHeader") ||
+      line.includes("function pubArtifactContentType")
+    ) {
+      inPubRouteLayer = true;
+      braceDepth = 0;
+    }
+    if (!inPubRouteLayer) {
+      for (const match of line.matchAll(stringLiteralPattern)) {
+        const value = match[2];
+        if (!value || value.startsWith("//")) continue;
+        addOwnedPath(paths, value, filePath, "middleware-literal");
+      }
+    }
+    if (inPubRouteLayer) {
+      braceDepth += (line.match(/{/g) ?? []).length;
+      braceDepth -= (line.match(/}/g) ?? []).length;
+      if (braceDepth <= 0 && line.includes("}")) {
+        inPubRouteLayer = false;
+      }
+    }
+  }
+}
+
+function collectDeployConfigRoutes(paths) {
+  collectRedirectRoutes(paths, "apps/home/public/_redirects");
+  collectRedirectRoutes(paths, "apps/thought/public/_redirects");
+}
+
+function collectOwnedPaths() {
+  const paths = [];
+  for (const dir of [
+    "apps/home/public",
+    "apps/thought/public",
+    "public",
+    "dist/home",
+    "dist/thought",
+  ]) {
+    collectStaticFiles(paths, dir);
+  }
+  collectFunctionRoutes(paths);
+  collectMiddlewareRoutes(paths);
+  collectDeployConfigRoutes(paths);
+  return paths;
+}
+
+function matchesReservedPath(path, contract) {
+  const exact = contract.paths.exact ?? [];
+  const prefixes = contract.paths.prefixes ?? [];
+  if (exact.includes(path)) return { type: "exact", pattern: path };
+  for (const prefix of prefixes) {
+    if (path === prefix || path.startsWith(prefix)) {
+      return { type: "prefix", pattern: prefix };
+    }
+  }
+  return null;
+}
+
+function uniqueViolations(violations) {
+  const seen = new Set();
+  return violations.filter((violation) => {
+    const key = `${violation.path}\0${violation.source}\0${violation.kind}\0${violation.pattern}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const contract = await readContract(args);
+  const contractErrors = validateContract(contract);
+  if (contractErrors.length > 0) {
+    throw new Error(`Invalid PUB path-boundary contract:\n- ${contractErrors.join("\n- ")}`);
+  }
+
+  const ownedPaths = collectOwnedPaths();
+  const violations = uniqueViolations(
+    ownedPaths
+      .map((entry) => {
+        const match = matchesReservedPath(entry.path, contract);
+        return match ? { ...entry, ...match } : null;
+      })
+      .filter(Boolean),
+  );
+
+  const middleware = readFileSync(resolve(repoRoot, "functions/_middleware.ts"), "utf8");
+  for (const snippet of [
+    "PUB_UPSTREAM_DEFAULT",
+    "https://inshell-pub.pages.dev",
+    "isPubRouteHost",
+    "isPubReservedPathname",
+    "proxyPubArtifact",
+    "pubMethodNotAllowed",
+    "pub-proxy",
+    "x-inshell-dev-path-boundary",
+  ]) {
+    if (!middleware.includes(snippet)) {
+      violations.push({
+        path: "(runtime guard)",
+        source: "functions/_middleware.ts",
+        kind: "missing-runtime-guard",
+        type: "required-snippet",
+        pattern: snippet,
+      });
+    }
+  }
+  for (const path of [...contract.paths.exact, ...contract.paths.prefixes]) {
+    if (!middleware.includes(path)) {
+      violations.push({
+        path,
+        source: "functions/_middleware.ts",
+        kind: "missing-router-coverage",
+        type: "contract-path",
+        pattern: path,
+      });
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("[pub-boundary] FAIL");
+    for (const violation of violations) {
+      console.error(
+        `- ${violation.kind} ${violation.path} from ${violation.source} matches ${violation.type} ${violation.pattern}`,
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `[pub-boundary] OK owner=${contract.owner} exact=${contract.paths.exact.length} prefixes=${contract.paths.prefixes.length} checkedPaths=${ownedPaths.length}${contract.contractVersion ? ` contractVersion=${contract.contractVersion}` : ""}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(`[pub-boundary] failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-cloudflare-api-routes.mjs
+++ b/scripts/smoke-cloudflare-api-routes.mjs
@@ -7,6 +7,11 @@ const STAGING_THOUGHT_BASE = "https://staging.thought-inshell-art.pages.dev";
 const SEPOLIA_CHAIN_ID = "0xaa36a7";
 const ATTEMPT_DELAYS_MS = [0, 1_000, 3_000, 6_000];
 const REQUEST_TIMEOUT_MS = 12_000;
+const PUB_BOUNDARY_SMOKE_PATHS = [
+  "/llms.txt",
+  "/pub.manifest.json",
+  "/pub/contract/pub-path-boundary.json",
+];
 
 function parseArgs(argv) {
   const args = {
@@ -73,6 +78,27 @@ async function fetchJsonWithTimeout(url, init) {
       throw new Error(`${url} returned HTTP ${response.status}: ${JSON.stringify(payload).slice(0, 240)}`);
     }
     return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchTextWithTimeout(url, init) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        accept: "application/json, text/plain, */*;q=0.1",
+        ...(init?.headers ?? {}),
+      },
+    });
+    return {
+      response,
+      text: await response.text(),
+    };
   } finally {
     clearTimeout(timer);
   }
@@ -147,6 +173,60 @@ async function checkOpsStatus(base, label) {
   });
 }
 
+function isDevAppShellResponse(response, text) {
+  const contentType = response.headers.get("content-type") ?? "";
+  return (
+    contentType.includes("text/html") &&
+    (
+      text.includes('<div id="root"></div>') ||
+      text.includes("Inshell / PATH") ||
+      text.includes("THOUGHT creation, minting, and gallery for Inshell.") ||
+      /\/assets\/index-[A-Za-z0-9_-]+\.js/.test(text)
+    )
+  );
+}
+
+async function checkPubBoundarySmoke(base) {
+  for (const path of PUB_BOUNDARY_SMOKE_PATHS) {
+    await retry(`home PUB boundary ${path}`, async () => {
+      const { response, text } = await fetchTextWithTimeout(urlFor(base, path), {
+        method: "GET",
+      });
+      if (!response.ok) {
+        throw new Error(`${path} returned HTTP ${response.status}`);
+      }
+      if (isDevAppShellResponse(response, text)) {
+        throw new Error(`${path} is being served by the DEV app shell`);
+      }
+      const contentType = response.headers.get("content-type") ?? "";
+      if (path === "/llms.txt" && !contentType.includes("text/plain")) {
+        throw new Error(`${path} returned unexpected content-type ${contentType || "(missing)"}`);
+      }
+      if ((path === "/pub.manifest.json" || path === "/pub/contract/pub-path-boundary.json") && response.ok) {
+        let payload;
+        try {
+          payload = JSON.parse(text);
+        } catch {
+          throw new Error(`${path} returned HTTP ${response.status} but not JSON`);
+        }
+        if (path === "/pub/contract/pub-path-boundary.json") {
+          if (
+            payload?.schemaVersion !== 1 ||
+            payload?.origin !== "https://inshell.art" ||
+            payload?.owner !== "PUB" ||
+            !Array.isArray(payload?.paths?.exact) ||
+            !Array.isArray(payload?.paths?.prefixes)
+          ) {
+            throw new Error(`${path} returned an invalid PUB boundary contract`);
+          }
+        } else if (payload?.schemaVersion !== 1 || !Array.isArray(payload?.files)) {
+          throw new Error(`${path} returned an invalid PUB manifest`);
+        }
+      }
+    });
+  }
+}
+
 async function checkThoughtPreview(base) {
   await retry("thought /api/thought-preview", async () => {
     const payload = await fetchJsonWithTimeout(urlFor(base, "/api/thought-preview"), {
@@ -161,6 +241,7 @@ async function checkThoughtPreview(base) {
 
 async function checkHome(base) {
   await checkOpsStatus(base, "home /api/ops/status");
+  await checkPubBoundarySmoke(base);
   await checkRpcChainId(base, "/api/path-rpc", "home /api/path-rpc");
   await checkGetArrayField(base, "/api/pulse-auction", "bids", "home /api/pulse-auction");
   await checkGetArrayField(base, "/api/path-tokens", "items", "home /api/path-tokens");

--- a/scripts/validate-production-surface.ts
+++ b/scripts/validate-production-surface.ts
@@ -35,6 +35,7 @@ const DEPLOY_WORKFLOW_SNIPPETS = [
   "VITE_THOUGHT_EXPLORER_BASE_URL",
   "VITE_WALLETCONNECT_PROJECT_ID",
   "check:deployment",
+  "pub-boundary:check",
   "Smoke home API routes",
   "Smoke THOUGHT API routes",
   "smoke:api-routes",
@@ -177,6 +178,10 @@ function checkPackageScripts() {
   if (!smokeApiRoutes.includes("smoke-cloudflare-api-routes.mjs")) {
     fail("package.json is missing smoke:api-routes coverage for smoke-cloudflare-api-routes.mjs");
   }
+  const pubBoundaryCheck = String(rootPkg?.scripts?.["pub-boundary:check"] ?? "");
+  if (!pubBoundaryCheck.includes("check-pub-boundary.mjs")) {
+    fail("package.json is missing pub-boundary:check coverage for check-pub-boundary.mjs");
+  }
   const webAnalyticsTokenCheck = String(rootPkg?.scripts?.["check:web-analytics-token"] ?? "");
   if (!webAnalyticsTokenCheck.includes("check-cloudflare-web-analytics-token.mjs")) {
     fail("package.json is missing check:web-analytics-token coverage for check-cloudflare-web-analytics-token.mjs");
@@ -210,6 +215,10 @@ function checkPackageScripts() {
     "/api/pulse-auction",
     "/api/path-tokens",
     "/api/thought-gallery",
+    "/llms.txt",
+    "/pub.manifest.json",
+    "/pub/contract/pub-path-boundary.json",
+    "checkPubBoundarySmoke",
     "staging.inshell-art.pages.dev",
     "staging.thought-inshell-art.pages.dev",
   ]) {
@@ -543,6 +552,14 @@ function checkCloudflareRpcProxy() {
     "PUBLIC_FEED_SEPOLIA_RSS_URL",
     "PUBLIC_FEED_BASE_URL",
     "APP_SHELL_CACHE_CONTROL",
+    "PUB_UPSTREAM_DEFAULT",
+    "https://inshell-pub.pages.dev",
+    "isPubReservedPathname",
+    "isPubRouteHost",
+    "proxyPubArtifact",
+    "pubMethodNotAllowed",
+    "pub-proxy",
+    "x-inshell-dev-path-boundary",
     "temporarySepoliaHostRedirect",
     "sepolia.inshell.art",
     "getPublicFeedArtifactUrl",


### PR DESCRIPTION
## Summary\n- route PUB-reserved shared-origin paths through the DEV Pages middleware to https://inshell-pub.pages.dev\n- add PUB boundary contract validation to CI/deploy workflows\n- extend smoke and middleware tests for PUB path proxying and method safety\n\n## Validation\n- pnpm run pub-boundary:check\n- pnpm tsx scripts/validate-production-surface.ts\n- pnpm run lint\n- pnpm run type-check\n- pnpm run test:unit\n- pnpm run build:home\n- pnpm run build:thought\n- gitleaks detect --no-git --redact --no-banner\n- deploy-pages staging home run 27867263482\n- staging PUB path smoke passed for /llms.txt, /pub.manifest.json, /pub/contract/pub-path-boundary.json\n