### PR TITLE
Promote anonymous analytics visit model

### DIFF
--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -39,6 +39,7 @@ import {
   PUBLIC_NETWORK_CONFIG,
   SURFACE_TERMINOLOGY,
   resolveWalletChainRpcUrls,
+  trackInshellAnonymousAnalytics,
 } from "@inshell/shared";
 import HeaderWalletCTA from "@/components/HeaderWalletCTA";
 import { useWallet } from "@inshell/wallet";
@@ -113,6 +114,28 @@ function isWalletRpcBusyMessage(message: string): boolean {
   return /rpc endpoint returned too many errors|too many errors|too many requests|rate limit|429|502|503|504/i.test(
     message
   );
+}
+
+function trackPathMintAnalytics(
+  eventType: "mint_started" | "mint_succeeded" | "mint_failed",
+  metadata: Record<string, unknown>
+) {
+  trackInshellAnonymousAnalytics({
+    eventType,
+    contentType: "path",
+    metadata,
+  });
+}
+
+function mintAnalyticsErrorCategory(error: unknown) {
+  const message = walletErrorMessage(error);
+  const lower = message.toLowerCase();
+  if (isWalletCancellationError(error)) return "wallet_rejected";
+  if (isWalletRpcBusyMessage(message)) return "wallet_busy";
+  if (isWalletReadOnlyRpcMessage(message) || lower.includes("rpc")) return "rpc";
+  if (lower.includes("network") || lower.includes("fetch")) return "network";
+  if (lower.includes("timeout")) return "timeout";
+  return "unknown";
 }
 
 type PreflightResult = {
@@ -4572,6 +4595,11 @@ export default function AuctionCanvas({
       setTxPhase(phase);
       setTxState("awaiting_signature");
       setTxError(null);
+      if (phase === "bid") {
+        trackPathMintAnalytics("mint_started", {
+          mintStage: "wallet_signature",
+        });
+      }
       const res = await call();
       const hash =
         res?.transaction_hash ??
@@ -4584,6 +4612,11 @@ export default function AuctionCanvas({
       setTxHash(hash);
       setLastTxHash(hash);
       setTxState("submitted");
+      if (phase === "bid") {
+        trackPathMintAnalytics("mint_started", {
+          mintStage: "submitted",
+        });
+      }
       showToast({ kind: "info", text: `Submitted: ${shortHash(hash)}.` });
       const waitProvider =
         provider ?? (getDefaultProvider() as ProviderInterface);
@@ -4615,6 +4648,9 @@ export default function AuctionCanvas({
         text: phase === "bid" ? "Settlement confirmed. Loading sale event." : "Confirmed.",
       });
       if (phase === "bid") {
+        trackPathMintAnalytics("mint_succeeded", {
+          mintStage: "confirmed",
+        });
         trackSubmittedBid(hash);
       }
       txIdleTimerRef.current = window.setTimeout(() => {
@@ -4637,6 +4673,14 @@ export default function AuctionCanvas({
       }
       if (!walletCancelled) {
         console.error("mint failed", err);
+      }
+      if (phase === "bid") {
+        const errorCode = walletErrorCode(err);
+        trackPathMintAnalytics("mint_failed", {
+          mintStage: walletCancelled ? "wallet_signature" : "transaction",
+          errorCategory: mintAnalyticsErrorCategory(err),
+          errorCode: errorCode == null ? undefined : String(errorCode),
+        });
       }
       return false;
     } finally {

--- a/apps/home/tests/anonymousAnalytics.test.ts
+++ b/apps/home/tests/anonymousAnalytics.test.ts
@@ -72,6 +72,7 @@ describe("Inshell anonymous analytics client", () => {
     });
     expect(payload.visitorId).toBe("12345678-1234-4234-9234-123456789abc");
     expect(payload.sessionId).toBe("12345678-1234-4234-9234-123456789abc");
+    expect(payload.visitId).toBe("12345678-1234-4234-9234-123456789abc");
   });
 
   test("exposes a manual tracker for typed action events", async () => {
@@ -122,6 +123,72 @@ describe("Inshell anonymous analytics client", () => {
         errorCategory: "wallet_rejected",
       },
     });
+  });
+
+  test("splits same-tab activity into visits after 30 minutes of inactivity", async () => {
+    const ids = [
+      "visitor_11111111",
+      "session_11111111",
+      "visit_morning_11111111",
+      "event_page_11111111",
+      "event_scroll_11111111",
+      "visit_night_11111111",
+      "event_cta_11111111",
+    ];
+    const dateNow = jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+    (globalThis.crypto.randomUUID as jest.Mock).mockImplementation(() => ids.shift() ?? "extra_11111111");
+    const fetchMock = jest.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(
+      installInshellAnonymousAnalytics({
+        hostname: "inshell.art",
+        window,
+        document,
+        navigator: testNavigator,
+        location: {
+          href: "https://inshell.art/path/25",
+          hostname: "inshell.art",
+          pathname: "/path/25",
+          search: "",
+          hash: "",
+          origin: "https://inshell.art",
+        },
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    dateNow.mockReturnValue(1_000_000 + 29 * 60 * 1000);
+    expect(trackInshellAnonymousAnalytics({
+      eventType: "scroll_depth",
+      metadata: { scrollPercent: 50 },
+    })).toBe(true);
+    await Promise.resolve();
+
+    dateNow.mockReturnValue(1_000_000 + 60 * 60 * 1000 + 1_000);
+    expect(trackInshellAnonymousAnalytics({
+      eventType: "cta_click",
+      metadata: { ctaId: "mint-primary" },
+    })).toBe(true);
+    await Promise.resolve();
+
+    const payloads = fetchMock.mock.calls.map(([, init]) => JSON.parse(String((init as globalThis.RequestInit).body)));
+    expect(payloads).toHaveLength(3);
+    expect(payloads.map((item) => item.visitorId)).toEqual([
+      "visitor_11111111",
+      "visitor_11111111",
+      "visitor_11111111",
+    ]);
+    expect(payloads.map((item) => item.sessionId)).toEqual([
+      "session_11111111",
+      "session_11111111",
+      "session_11111111",
+    ]);
+    expect(payloads.map((item) => item.visitId)).toEqual([
+      "visit_morning_11111111",
+      "visit_morning_11111111",
+      "visit_night_11111111",
+    ]);
   });
 
   test("does not install on local hosts or when explicitly disabled", () => {

--- a/apps/home/tests/anonymousAnalytics.test.ts
+++ b/apps/home/tests/anonymousAnalytics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { installInshellAnonymousAnalytics } from "@inshell/shared";
+import { installInshellAnonymousAnalytics, trackInshellAnonymousAnalytics } from "@inshell/shared";
 
 const originalFetch = globalThis.fetch;
 const originalCrypto = globalThis.crypto;
@@ -30,6 +30,8 @@ describe("Inshell anonymous analytics client", () => {
       value: originalCrypto,
     });
     delete (window as any).__INSHELL_ANON_ANALYTICS_INSTALLED__;
+    delete (window as any).__INSHELL_ANON_ANALYTICS_FETCH_PATCHED__;
+    delete (window as any).inshellAnalytics;
     jest.restoreAllMocks();
   });
 
@@ -63,11 +65,63 @@ describe("Inshell anonymous analytics client", () => {
       version: 1,
       eventType: "pageview",
       path: "/path/25",
+      contentType: "path",
+      contentId: "25",
       title: "$PATH",
       automation: false,
     });
     expect(payload.visitorId).toBe("12345678-1234-4234-9234-123456789abc");
     expect(payload.sessionId).toBe("12345678-1234-4234-9234-123456789abc");
+  });
+
+  test("exposes a manual tracker for typed action events", async () => {
+    const fetchMock = jest.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(
+      installInshellAnonymousAnalytics({
+        hostname: "thought.inshell.art",
+        window,
+        document,
+        navigator: testNavigator,
+        location: {
+          href: "https://thought.inshell.art/thought/17",
+          hostname: "thought.inshell.art",
+          pathname: "/thought/17",
+          search: "",
+          hash: "",
+          origin: "https://thought.inshell.art",
+        },
+      }),
+    ).toBe(true);
+
+    fetchMock.mockClear();
+    expect(
+      trackInshellAnonymousAnalytics({
+        eventType: "wallet_connect_failed",
+        contentType: "thought",
+        metadata: {
+          walletKind: "injected",
+          walletStage: "request_accounts",
+          errorCategory: "wallet_rejected",
+        },
+      }),
+    ).toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, globalThis.RequestInit];
+    const payload = JSON.parse(String(init.body));
+    expect(payload).toMatchObject({
+      eventType: "wallet_connect_failed",
+      path: "/thought/17",
+      contentType: "thought",
+      contentId: "17",
+      metadata: {
+        walletKind: "injected",
+        walletStage: "request_accounts",
+        errorCategory: "wallet_rejected",
+      },
+    });
   });
 
   test("does not install on local hosts or when explicitly disabled", () => {

--- a/apps/home/tests/anonymousAnalyticsFunction.test.ts
+++ b/apps/home/tests/anonymousAnalyticsFunction.test.ts
@@ -50,6 +50,7 @@ type AnalyticsRow = {
   event_type: string;
   visitor_hash: string;
   session_hash: string;
+  visit_hash: string | null;
   surface: string;
   hostname: string;
   path: string;
@@ -94,6 +95,7 @@ function createAnalyticsD1Mock() {
             eventCount: rows.length,
             uniqueVisitors: new Set(rows.map((row) => row.visitor_hash)).size,
             sessions: new Set(rows.map((row) => row.session_hash)).size,
+            visits: new Set(rows.map((row) => row.visit_hash ?? row.session_hash)).size,
           };
         }
         if (/count\(\*\)\s+as\s+pageViews/i.test(query)) {
@@ -102,6 +104,7 @@ function createAnalyticsD1Mock() {
             pageViews: rows.length,
             uniqueVisitors: new Set(rows.map((row) => row.visitor_hash)).size,
             sessions: new Set(rows.map((row) => row.session_hash)).size,
+            visits: new Set(rows.map((row) => row.visit_hash ?? row.session_hash)).size,
             automationEvents: rows.reduce((total, row) => total + row.automation, 0),
           };
         }
@@ -110,15 +113,42 @@ function createAnalyticsD1Mock() {
           const byVisitor = new Map<string, Set<string>>();
           for (const row of rows) {
             if (!byVisitor.has(row.visitor_hash)) byVisitor.set(row.visitor_hash, new Set());
-            byVisitor.get(row.visitor_hash)?.add(row.session_hash);
+            byVisitor.get(row.visitor_hash)?.add(row.visit_hash ?? row.session_hash);
           }
           return {
-            returningVisitors: [...byVisitor.values()].filter((sessionSet) => sessionSet.size > 1).length,
+            returningVisitors: [...byVisitor.values()].filter((visitSet) => visitSet.size > 1).length,
           };
         }
         return null;
       }),
       all: jest.fn(async () => {
+        if (/pragma\s+table_info/i.test(query)) {
+          return {
+            results: [
+              "event_id",
+              "event_type",
+              "visitor_hash",
+              "session_hash",
+              "visit_hash",
+              "surface",
+              "hostname",
+              "path",
+              "content_type",
+              "content_id",
+              "referrer_host",
+              "referrer_path",
+              "occurred_at",
+              "received_at",
+              "device_class",
+              "viewport_width",
+              "viewport_height",
+              "timezone_offset",
+              "language",
+              "automation",
+              "metadata_json",
+            ].map((name) => ({ name })),
+          };
+        }
         if (/where\s+visitor_hash\s*=\s*\?1/i.test(query)) {
           const visitorHash = String(bound[0] ?? "");
           const since = String(bound[1] ?? "");
@@ -130,6 +160,7 @@ function createAnalyticsD1Mock() {
               .map((event) => ({
                 eventType: event.event_type,
                 sessionHash: event.session_hash,
+                visitHash: event.visit_hash ?? event.session_hash,
                 surface: event.surface,
                 hostname: event.hostname,
                 path: event.path,
@@ -162,6 +193,7 @@ function createAnalyticsD1Mock() {
                 eventCount: visitorRows.length,
                 pageViews: visitorRows.filter((row) => row.event_type === "pageview").length,
                 sessions: new Set(visitorRows.map((row) => row.session_hash)).size,
+                visits: new Set(visitorRows.map((row) => row.visit_hash ?? row.session_hash)).size,
                 firstSeenAt: visitorRows.map((row) => row.received_at).sort()[0] ?? null,
                 lastSeenAt: visitorRows.map((row) => row.received_at).sort().at(-1) ?? null,
                 automationEvents: visitorRows.reduce((total, row) => total + row.automation, 0),
@@ -198,22 +230,23 @@ function createAnalyticsD1Mock() {
             event_type: String(bound[1]),
             visitor_hash: String(bound[2]),
             session_hash: String(bound[3]),
-            surface: String(bound[4]),
-            hostname: String(bound[5]),
-            path: String(bound[6]),
-            content_type: bound[7] == null ? null : String(bound[7]),
-            content_id: bound[8] == null ? null : String(bound[8]),
-            referrer_host: bound[9] == null ? null : String(bound[9]),
-            referrer_path: bound[10] == null ? null : String(bound[10]),
-            occurred_at: String(bound[11]),
-            received_at: String(bound[12]),
-            device_class: bound[13] == null ? null : String(bound[13]),
-            viewport_width: bound[14] == null ? null : Number(bound[14]),
-            viewport_height: bound[15] == null ? null : Number(bound[15]),
-            timezone_offset: bound[16] == null ? null : Number(bound[16]),
-            language: bound[17] == null ? null : String(bound[17]),
-            automation: Number(bound[18] ?? 0),
-            metadata_json: bound[19] == null ? null : String(bound[19]),
+            visit_hash: bound[4] == null ? null : String(bound[4]),
+            surface: String(bound[5]),
+            hostname: String(bound[6]),
+            path: String(bound[7]),
+            content_type: bound[8] == null ? null : String(bound[8]),
+            content_id: bound[9] == null ? null : String(bound[9]),
+            referrer_host: bound[10] == null ? null : String(bound[10]),
+            referrer_path: bound[11] == null ? null : String(bound[11]),
+            occurred_at: String(bound[12]),
+            received_at: String(bound[13]),
+            device_class: bound[14] == null ? null : String(bound[14]),
+            viewport_width: bound[15] == null ? null : Number(bound[15]),
+            viewport_height: bound[16] == null ? null : Number(bound[16]),
+            timezone_offset: bound[17] == null ? null : Number(bound[17]),
+            language: bound[18] == null ? null : String(bound[18]),
+            automation: Number(bound[19] ?? 0),
+            metadata_json: bound[20] == null ? null : String(bound[20]),
           });
         }
         if (/insert\s+into\s+inshell_anon_analytics_visitors/i.test(query)) {
@@ -267,6 +300,7 @@ function payload(overrides: Record<string, unknown> = {}) {
     eventId: "event_12345678",
     visitorId: "visitor_12345678",
     sessionId: "session_12345678",
+    visitId: "visit_12345678",
     eventType: "pageview",
     path: "/path/25?discard=yes",
     occurredAt: new Date().toISOString(),
@@ -292,8 +326,8 @@ describe("anonymous analytics Pages functions", () => {
               ? new Uint8Array(data)
               : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
             const out = new Uint8Array(32);
-            for (let index = 0; index < out.length; index += 1) {
-              out[index] = input[index % input.length] ^ index;
+            for (let index = 0; index < input.length; index += 1) {
+              out[index % out.length] = (out[index % out.length] + input[index] + index) % 256;
             }
             return out.buffer;
           },
@@ -331,6 +365,27 @@ describe("anonymous analytics Pages functions", () => {
     expect(event.surface).toBe("home");
     expect(event.visitor_hash).not.toBe("visitor_12345678");
     expect(event.session_hash).not.toBe("session_12345678");
+    expect(event.visit_hash).not.toBe("visit_12345678");
+    expect(event.visit_hash).toBeTruthy();
+  });
+
+  test("falls back to a hashed session id for legacy clients without visitId", async () => {
+    const d1 = createAnalyticsD1Mock();
+    const response = await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({ eventId: "event_legacy_12345678", visitId: undefined }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      stored: true,
+    });
+    const event = d1.events.get("event_legacy_12345678");
+    expect(event?.visit_hash).toBe(event?.session_hash);
+    expect(event?.visit_hash).not.toBe("session_12345678");
   });
 
   test("filters typed event metadata through a privacy allowlist", async () => {
@@ -416,6 +471,7 @@ describe("anonymous analytics Pages functions", () => {
         pageViews: 1,
         uniqueVisitors: 1,
         sessions: 1,
+        visits: 1,
       },
       hostScope: {
         name: "production",
@@ -474,7 +530,8 @@ describe("anonymous analytics Pages functions", () => {
         "https://inshell.art/api/analytics/event",
         payload({
           eventId: "event_return_12345678",
-          sessionId: "return_session_12345678",
+          sessionId: "session_12345678",
+          visitId: "visit_return_12345678",
           path: "/gallery",
         }),
       ),
@@ -511,7 +568,8 @@ describe("anonymous analytics Pages functions", () => {
           visitorRank: 1,
           eventCount: 4,
           pageViews: 2,
-          sessions: 2,
+          sessions: 1,
+          visitCount: 2,
           returning: true,
           source: {
             referrerHost: "example.com",
@@ -529,6 +587,11 @@ describe("anonymous analytics Pages functions", () => {
       "wallet_connect_failed",
       "pageview",
     ]);
+    expect(body.visitors[0].timeline.map((event: any) => event.visitRank)).toEqual([1, 1, 1, 2]);
+    expect(body.visitors[0].visits).toHaveLength(2);
+    expect(body.visitors[0].visits.map((visit: any) => visit.visitRank)).toEqual([1, 2]);
+    expect(body.visitors[0].visits.map((visit: any) => visit.eventCount)).toEqual([3, 1]);
+    expect(body.visitors[0].visits[1].source.firstPath).toBe("/gallery");
     expect(body.visitors[0].timeline[1].metadata).toEqual({ scrollPercent: 75 });
     expect(body.visitors[0].timeline[2].metadata).toEqual({
       walletKind: "injected",
@@ -538,6 +601,8 @@ describe("anonymous analytics Pages functions", () => {
     const serialized = JSON.stringify(body);
     expect(serialized).not.toContain("visitor_12345678");
     expect(serialized).not.toContain("session_12345678");
+    expect(serialized).not.toContain("visit_12345678");
+    expect(serialized).not.toContain("visit_return_12345678");
     expect(serialized).not.toContain("walletAddress");
     expect(serialized).not.toContain("private prompt");
     expect(serialized).not.toContain("staging-only");
@@ -562,12 +627,15 @@ describe("anonymous analytics Pages functions", () => {
       dbBinding: "INSHELL_CHAIN_DATA_DB",
       rawIpStored: false,
       rawUserAgentStored: false,
+      rawVisitIdStored: false,
       rawWalletAddressStored: false,
       metadataAllowlist: true,
+      visitTimeoutMinutes: 30,
       statusSource: "d1",
       eventCount24h: 1,
       uniqueVisitors24h: 1,
       sessions24h: 1,
+      visits24h: 1,
     });
   });
 });

--- a/apps/home/tests/anonymousAnalyticsFunction.test.ts
+++ b/apps/home/tests/anonymousAnalyticsFunction.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import { onRequestPost as onAnalyticsEventPost } from "../../../functions/api/analytics/event";
 import { onRequestGet as onAnalyticsSummaryGet } from "../../../functions/api/analytics/summary";
+import { onRequestGet as onAnalyticsVisitorsGet } from "../../../functions/api/analytics/visitors";
 import {
   analyticsHostScopeForHostname,
   readAnalyticsStatus,
@@ -52,8 +53,19 @@ type AnalyticsRow = {
   surface: string;
   hostname: string;
   path: string;
+  content_type: string | null;
+  content_id: string | null;
+  referrer_host: string | null;
+  referrer_path: string | null;
+  occurred_at: string;
   received_at: string;
+  device_class: string | null;
+  viewport_width: number | null;
+  viewport_height: number | null;
+  timezone_offset: number | null;
+  language: string | null;
   automation: number;
+  metadata_json: string | null;
 };
 
 function createAnalyticsD1Mock() {
@@ -85,7 +97,7 @@ function createAnalyticsD1Mock() {
           };
         }
         if (/count\(\*\)\s+as\s+pageViews/i.test(query)) {
-          const rows = rowsSince(bound, String(bound[0] ?? ""));
+          const rows = rowsSince(bound, String(bound[0] ?? ""), true);
           return {
             pageViews: rows.length,
             uniqueVisitors: new Set(rows.map((row) => row.visitor_hash)).size,
@@ -94,7 +106,7 @@ function createAnalyticsD1Mock() {
           };
         }
         if (/returningVisitors/i.test(query)) {
-          const rows = rowsSince(bound, String(bound[0] ?? ""));
+          const rows = rowsSince(bound, String(bound[0] ?? ""), true);
           const byVisitor = new Map<string, Set<string>>();
           for (const row of rows) {
             if (!byVisitor.has(row.visitor_hash)) byVisitor.set(row.visitor_hash, new Set());
@@ -107,7 +119,57 @@ function createAnalyticsD1Mock() {
         return null;
       }),
       all: jest.fn(async () => {
-        const rows = rowsSince(bound, String(bound[0] ?? ""));
+        if (/where\s+visitor_hash\s*=\s*\?1/i.test(query)) {
+          const visitorHash = String(bound[0] ?? "");
+          const since = String(bound[1] ?? "");
+          const hostnames = bound.slice(2, -1).map(String);
+          return {
+            results: rowsForHostnames(hostnames)
+              .filter((event) => event.visitor_hash === visitorHash && event.received_at >= since)
+              .sort((a, b) => a.received_at.localeCompare(b.received_at))
+              .map((event) => ({
+                eventType: event.event_type,
+                sessionHash: event.session_hash,
+                surface: event.surface,
+                hostname: event.hostname,
+                path: event.path,
+                contentType: event.content_type,
+                contentId: event.content_id,
+                referrerHost: event.referrer_host,
+                referrerPath: event.referrer_path,
+                occurredAt: event.occurred_at,
+                receivedAt: event.received_at,
+                deviceClass: event.device_class,
+                viewportWidth: event.viewport_width,
+                viewportHeight: event.viewport_height,
+                timezoneOffset: event.timezone_offset,
+                language: event.language,
+                automation: event.automation,
+                metadataJson: event.metadata_json,
+              })),
+          };
+        }
+        if (/group\s+by\s+visitor_hash/i.test(query)) {
+          const rows = rowsSince(bound, String(bound[0] ?? ""), false);
+          const grouped = new Map<string, AnalyticsRow[]>();
+          for (const row of rows) {
+            grouped.set(row.visitor_hash, [...(grouped.get(row.visitor_hash) ?? []), row]);
+          }
+          return {
+            results: [...grouped.entries()]
+              .map(([visitorHash, visitorRows]) => ({
+                visitorHash,
+                eventCount: visitorRows.length,
+                pageViews: visitorRows.filter((row) => row.event_type === "pageview").length,
+                sessions: new Set(visitorRows.map((row) => row.session_hash)).size,
+                firstSeenAt: visitorRows.map((row) => row.received_at).sort()[0] ?? null,
+                lastSeenAt: visitorRows.map((row) => row.received_at).sort().at(-1) ?? null,
+                automationEvents: visitorRows.reduce((total, row) => total + row.automation, 0),
+              }))
+              .sort((a, b) => b.eventCount - a.eventCount || String(b.lastSeenAt).localeCompare(String(a.lastSeenAt))),
+          };
+        }
+        const rows = rowsSince(bound, String(bound[0] ?? ""), /event_type\s*=\s*'pageview'/i.test(query));
         const field = /group\s+by\s+surface/i.test(query)
           ? "surface"
           : /group\s+by\s+hostname/i.test(query)
@@ -139,8 +201,19 @@ function createAnalyticsD1Mock() {
             surface: String(bound[4]),
             hostname: String(bound[5]),
             path: String(bound[6]),
-            received_at: String(bound[10]),
-            automation: Number(bound[16] ?? 0),
+            content_type: bound[7] == null ? null : String(bound[7]),
+            content_id: bound[8] == null ? null : String(bound[8]),
+            referrer_host: bound[9] == null ? null : String(bound[9]),
+            referrer_path: bound[10] == null ? null : String(bound[10]),
+            occurred_at: String(bound[11]),
+            received_at: String(bound[12]),
+            device_class: bound[13] == null ? null : String(bound[13]),
+            viewport_width: bound[14] == null ? null : Number(bound[14]),
+            viewport_height: bound[15] == null ? null : Number(bound[15]),
+            timezone_offset: bound[16] == null ? null : Number(bound[16]),
+            language: bound[17] == null ? null : String(bound[17]),
+            automation: Number(bound[18] ?? 0),
+            metadata_json: bound[19] == null ? null : String(bound[19]),
           });
         }
         if (/insert\s+into\s+inshell_anon_analytics_visitors/i.test(query)) {
@@ -157,10 +230,11 @@ function createAnalyticsD1Mock() {
     return statement;
   });
 
-  function rowsSince(boundValues: unknown[], since: string) {
+  function rowsSince(boundValues: unknown[], since: string, pageviewsOnly = false) {
     const hostnames = boundValues.slice(1).map(String);
     return rowsForHostnames(hostnames).filter((event) => {
       if (event.received_at < since) return false;
+      if (pageviewsOnly && event.event_type !== "pageview") return false;
       return true;
     });
   }
@@ -252,9 +326,42 @@ describe("anonymous analytics Pages functions", () => {
     });
     const event = [...d1.events.values()][0];
     expect(event.path).toBe("/path/25");
+    expect(event.content_type).toBe("path");
+    expect(event.content_id).toBe("25");
     expect(event.surface).toBe("home");
     expect(event.visitor_hash).not.toBe("visitor_12345678");
     expect(event.session_hash).not.toBe("session_12345678");
+  });
+
+  test("filters typed event metadata through a privacy allowlist", async () => {
+    const d1 = createAnalyticsD1Mock();
+    const response = await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({
+          eventId: "event_cta_12345678",
+          eventType: "cta_click",
+          path: "/",
+          contentType: "home",
+          metadata: {
+            ctaId: "mint-primary",
+            walletAddress: "0x1234567890123456789012345678901234567890",
+            prompt: "private prompt text",
+            scrollPercent: 100,
+          },
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      stored: true,
+    });
+    const event = d1.events.get("event_cta_12345678");
+    expect(event?.metadata_json).toBe(JSON.stringify({ ctaId: "mint-primary" }));
+    expect(event?.metadata_json).not.toContain("walletAddress");
+    expect(event?.metadata_json).not.toContain("private prompt");
   });
 
   test("treats duplicate event ids as idempotent", async () => {
@@ -317,6 +424,125 @@ describe("anonymous analytics Pages functions", () => {
     });
   });
 
+  test("returns privacy-safe visitor timelines behind bearer auth", async () => {
+    const d1 = createAnalyticsD1Mock();
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({
+          eventId: "event_path_page_12345678",
+          path: "/path/25",
+          referrer: "https://example.com/source",
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({
+          eventId: "event_scroll_12345678",
+          eventType: "scroll_depth",
+          path: "/path/25",
+          metadata: {
+            scrollPercent: 75,
+            walletAddress: "0x1234567890123456789012345678901234567890",
+          },
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({
+          eventId: "event_wallet_fail_12345678",
+          eventType: "wallet_connect_failed",
+          path: "/path/25",
+          metadata: {
+            walletKind: "injected",
+            walletStage: "request_accounts",
+            errorCategory: "wallet_rejected",
+            prompt: "private prompt",
+          },
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({
+          eventId: "event_return_12345678",
+          sessionId: "return_session_12345678",
+          path: "/gallery",
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://staging.inshell-art.pages.dev/api/analytics/event",
+        payload({
+          eventId: "event_staging_only_12345678",
+          path: "/staging-only",
+        }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+
+    const unauthorized = await onAnalyticsVisitorsGet({
+      request: analyticsRequest("https://inshell.art/api/analytics/visitors?days=1"),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db, INSHELL_INDEXER_REFRESH_TOKEN: "secret" },
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const response = await onAnalyticsVisitorsGet({
+      request: analyticsRequest("https://inshell.art/api/analytics/visitors?days=1", undefined, "secret"),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db, INSHELL_INDEXER_REFRESH_TOKEN: "secret" },
+    });
+    const body = await response.json() as any;
+
+    expect(body).toMatchObject({
+      ok: true,
+      hostScope: { name: "production" },
+      visitors: [
+        {
+          visitorRank: 1,
+          eventCount: 4,
+          pageViews: 2,
+          sessions: 2,
+          returning: true,
+          source: {
+            referrerHost: "example.com",
+            referrerPath: null,
+            firstPath: "/path/25",
+            firstContentType: "path",
+            firstContentId: "25",
+          },
+        },
+      ],
+    });
+    expect(body.visitors[0].timeline.map((event: any) => event.eventType)).toEqual([
+      "pageview",
+      "scroll_depth",
+      "wallet_connect_failed",
+      "pageview",
+    ]);
+    expect(body.visitors[0].timeline[1].metadata).toEqual({ scrollPercent: 75 });
+    expect(body.visitors[0].timeline[2].metadata).toEqual({
+      walletKind: "injected",
+      walletStage: "request_accounts",
+      errorCategory: "wallet_rejected",
+    });
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("visitor_12345678");
+    expect(serialized).not.toContain("session_12345678");
+    expect(serialized).not.toContain("walletAddress");
+    expect(serialized).not.toContain("private prompt");
+    expect(serialized).not.toContain("staging-only");
+  });
+
   test("reports OPS-safe status without exposing identifiers", async () => {
     const d1 = createAnalyticsD1Mock();
     await onAnalyticsEventPost({
@@ -336,6 +562,8 @@ describe("anonymous analytics Pages functions", () => {
       dbBinding: "INSHELL_CHAIN_DATA_DB",
       rawIpStored: false,
       rawUserAgentStored: false,
+      rawWalletAddressStored: false,
+      metadataAllowlist: true,
       statusSource: "d1",
       eventCount24h: 1,
       uniqueVisitors24h: 1,

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -37,6 +37,7 @@ import {
   maybeInstallCloudflareWebAnalytics,
   resolveWalletChainRpcUrls,
   shouldShowPreviewWatermark,
+  trackInshellAnonymousAnalytics,
   type PublicLaunchMode,
 } from "@inshell/shared";
 import thoughtInstructions from "../THOUGHT.md?raw";
@@ -1629,6 +1630,56 @@ let mintSheetPrimaryAction: MintSheetAction = "none";
 let mintSheetSecondaryAction: MintSheetAction = "none";
 let mintSheetTertiaryAction: MintSheetAction = "none";
 let lastMintSheetFocusRefreshAt = 0;
+
+type ThoughtAnalyticsEventType =
+  | "wallet_connect_started"
+  | "wallet_connect_succeeded"
+  | "wallet_connect_failed"
+  | "mint_started"
+  | "mint_succeeded"
+  | "mint_failed";
+
+const trackThoughtAnalytics = (
+  eventType: ThoughtAnalyticsEventType,
+  metadata: Record<string, unknown>,
+) => {
+  trackInshellAnonymousAnalytics({
+    eventType,
+    contentType: "thought",
+    metadata,
+  });
+};
+
+const thoughtAnalyticsErrorCategory = (error: unknown) => {
+  const message = String(
+    (error as { shortMessage?: unknown; message?: unknown })?.shortMessage ??
+      (error as Error)?.message ??
+      error ??
+      "",
+  ).toLowerCase();
+  const code = Number((error as { code?: unknown })?.code);
+  if (
+    code === 4001 ||
+    message.includes("rejected") ||
+    message.includes("denied") ||
+    message.includes("cancel")
+  ) return "wallet_rejected";
+  if (
+    code === -32002 ||
+    message.includes("already processing") ||
+    message.includes("already pending")
+  ) return "wallet_busy";
+  if (message.includes("wallet did not expose") || message.includes("no supported wallet")) {
+    return "wallet_missing";
+  }
+  if (message.includes("not submitted") || message.includes("timed out") || message.includes("timeout")) {
+    return "timeout";
+  }
+  if (message.includes("rpc") || message.includes("eth_sendrawtransaction")) return "rpc";
+  if (message.includes("network") || message.includes("fetch")) return "network";
+  return "unknown";
+};
+
 const cliEntries: CliEntry[] = [];
 const cliCommandHistory: string[] = [];
 let cliCommandInFlight = false;
@@ -4676,8 +4727,17 @@ const bindWalletProviderEvents = () => {
 };
 
 const requestWalletConnect = async () => {
+  trackThoughtAnalytics("wallet_connect_started", {
+    walletKind: "injected",
+    walletStage: "request_accounts",
+  });
   const ethereum = getEthereumProvider();
   if (!ethereum) {
+    trackThoughtAnalytics("wallet_connect_failed", {
+      walletKind: "injected",
+      walletStage: "request_accounts",
+      errorCategory: "wallet_missing",
+    });
     setWarning("No supported wallet found.", { level: "warn" });
     setStatus("");
     return;
@@ -4722,7 +4782,16 @@ const requestWalletConnect = async () => {
 
     syncInterface();
     setStatus("wallet connected.", { flashMs: NOTICE_FLASH_MS });
+    trackThoughtAnalytics("wallet_connect_succeeded", {
+      walletKind: "injected",
+      walletStage: "connected",
+    });
   } catch (error) {
+    trackThoughtAnalytics("wallet_connect_failed", {
+      walletKind: "injected",
+      walletStage: "request_accounts",
+      errorCategory: thoughtAnalyticsErrorCategory(error),
+    });
     const message = error instanceof Error ? error.message : "wallet connect failed.";
     setWarning(message);
     setStatus("");
@@ -5265,6 +5334,9 @@ const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliRe
     clearThoughtGalleryCache();
     await refreshMintPreflight();
     syncInterface();
+    trackThoughtAnalytics("mint_succeeded", {
+      mintStage: "confirmed",
+    });
 
     if (shouldAppendCliResult) {
       const consumedPathId = selectedCliPathId();
@@ -5289,6 +5361,10 @@ const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliRe
     );
     syncInterface();
     setStatus("");
+    trackThoughtAnalytics("mint_failed", {
+      mintStage: "confirmation",
+      errorCategory: thoughtAnalyticsErrorCategory(error),
+    });
 
     if (shouldAppendCliResult) {
       appendCliError([message, "use: current"]);
@@ -5329,11 +5405,18 @@ const registerSubmittedMintTx = async (
   walletState.txHash = tx.hash;
   mintFlowData.txHash = tx.hash;
   setStatus("");
+  trackThoughtAnalytics("mint_started", {
+    mintStage: "submitted",
+  });
 
   if (nonceGap) {
     const message = `transaction queued with nonce ${nonceGap.actual}; chain expects ${nonceGap.expected}.`;
     setMintFlowError(message, "mint");
     syncInterface();
+    trackThoughtAnalytics("mint_failed", {
+      mintStage: "submitted",
+      errorCategory: "rpc",
+    });
 
     if (shouldAppendCliResult) {
       appendCliError([
@@ -5404,10 +5487,17 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
   if (mintFlowData.deadline <= BigInt(Math.floor(Date.now() / 1000))) {
     setMintFlowError("authorization expired.", "signature");
     syncInterface();
+    trackThoughtAnalytics("mint_failed", {
+      mintStage: "signature",
+      errorCategory: "timeout",
+    });
     return;
   }
 
   let txTimedOut = false;
+  trackThoughtAnalytics("mint_started", {
+    mintStage: "wallet_signature",
+  });
 
   try {
     await refreshWalletChainRpc();
@@ -5470,6 +5560,10 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
     setMintFlowError(message, message.includes("expired") ? "signature" : "mint");
     syncInterface();
     setStatus("");
+    trackThoughtAnalytics("mint_failed", {
+      mintStage: txTimedOut ? "wallet_signature" : "transaction",
+      errorCategory: thoughtAnalyticsErrorCategory(error),
+    });
     return null;
   }
 };

--- a/functions/api/analytics/store.ts
+++ b/functions/api/analytics/store.ts
@@ -737,7 +737,6 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_session ON ${EVENT_TABLE} (session_hash, received_at)`,
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_path ON ${EVENT_TABLE} (path, received_at)`,
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_event_type ON ${EVENT_TABLE} (event_type, received_at)`,
-    `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_content ON ${EVENT_TABLE} (content_type, content_id, received_at)`,
     `CREATE TABLE IF NOT EXISTS ${VISITOR_TABLE} (` +
       "visitor_hash TEXT PRIMARY KEY,first_seen_at TEXT NOT NULL,last_seen_at TEXT NOT NULL,event_count INTEGER NOT NULL DEFAULT 0)",
     `CREATE TABLE IF NOT EXISTS ${SESSION_TABLE} (` +
@@ -757,6 +756,9 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
       if (!isDuplicateColumnError(error)) throw error;
     }
   }
+  await db
+    .prepare(`CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_content ON ${EVENT_TABLE} (content_type, content_id, received_at)`)
+    .run();
   ensuredTables.add(db as object);
 }
 

--- a/functions/api/analytics/store.ts
+++ b/functions/api/analytics/store.ts
@@ -9,6 +9,8 @@ type AnalyticsEventPayload = {
   sessionId?: unknown;
   eventType?: unknown;
   path?: unknown;
+  contentType?: unknown;
+  contentId?: unknown;
   title?: unknown;
   referrer?: unknown;
   occurredAt?: unknown;
@@ -18,12 +20,45 @@ type AnalyticsEventPayload = {
   timezoneOffset?: unknown;
   language?: unknown;
   automation?: unknown;
+  metadata?: unknown;
 };
+
+const ANALYTICS_EVENT_TYPES = [
+  "pageview",
+  "page_visible_duration",
+  "scroll_depth",
+  "cta_click",
+  "wallet_connect_started",
+  "wallet_connect_succeeded",
+  "wallet_connect_failed",
+  "mint_started",
+  "mint_succeeded",
+  "mint_failed",
+  "api_error",
+  "frontend_error",
+  "external_link_click",
+] as const;
+
+type AnalyticsEventType = typeof ANALYTICS_EVENT_TYPES[number];
+
+const ANALYTICS_CONTENT_TYPES = [
+  "home",
+  "path",
+  "thought",
+  "gallery",
+  "pulse",
+  "verify",
+  "unknown",
+] as const;
+
+type AnalyticsContentType = typeof ANALYTICS_CONTENT_TYPES[number];
+type AnalyticsMetadata = Record<string, string | number | boolean | null>;
 
 export type AnalyticsStatus = {
   enabled: boolean;
   route: string;
   summaryRoute: string;
+  visitorRoute: string;
   identity: "anonymous-browser-session";
   hostScope: AnalyticsHostScope["name"];
   countedHosts: string[];
@@ -31,6 +66,10 @@ export type AnalyticsStatus = {
   dbBinding: "INSHELL_ANALYTICS_DB" | "INSHELL_CHAIN_DATA_DB" | null;
   rawIpStored: false;
   rawUserAgentStored: false;
+  rawWalletAddressStored: false;
+  rawMetadataStored: false;
+  metadataAllowlist: true;
+  supportedEventTypes: AnalyticsEventType[];
   statusSource: "d1" | "empty" | "unavailable" | "error";
   statusError: string | null;
   lastEventAt: string | null;
@@ -74,6 +113,56 @@ export type AnalyticsSummary = {
   }>;
 };
 
+export type AnalyticsVisitors = {
+  ok: true;
+  generatedAt: string;
+  hostScope: {
+    name: AnalyticsHostScope["name"];
+    hostnames: string[];
+  };
+  window: {
+    days: number;
+    since: string;
+  };
+  visitors: Array<{
+    visitorRank: number;
+    firstSeenAt: string | null;
+    lastSeenAt: string | null;
+    eventCount: number;
+    pageViews: number;
+    sessions: number;
+    returning: boolean;
+    automationEvents: number;
+    source: {
+      referrerHost: string | null;
+      referrerPath: string | null;
+      firstPath: string | null;
+      firstContentType: AnalyticsContentType | null;
+      firstContentId: string | null;
+    };
+    timeline: Array<{
+      eventType: AnalyticsEventType;
+      occurredAt: string;
+      receivedAt: string;
+      sessionRank: number;
+      surface: string;
+      hostname: string;
+      path: string;
+      contentType: AnalyticsContentType;
+      contentId: string | null;
+      referrerHost: string | null;
+      referrerPath: string | null;
+      deviceClass: string | null;
+      viewportWidth: number | null;
+      viewportHeight: number | null;
+      timezoneOffset: number | null;
+      language: string | null;
+      automation: boolean;
+      metadata: AnalyticsMetadata;
+    }>;
+  }>;
+};
+
 export type AnalyticsHostScope = {
   name: "production" | "preview" | "staging" | "host";
   hostnames: string[];
@@ -84,10 +173,15 @@ const VISITOR_TABLE = "inshell_anon_analytics_visitors";
 const SESSION_TABLE = "inshell_anon_analytics_sessions";
 const MAX_BODY_BYTES = 4096;
 const MAX_PATH_LENGTH = 256;
+const MAX_CONTENT_ID_LENGTH = 64;
 const MAX_LANGUAGE_LENGTH = 32;
 const MAX_REFERRER_HOST_LENGTH = 120;
 const MAX_REFERRER_PATH_LENGTH = 256;
+const MAX_METADATA_JSON_LENGTH = 1024;
 const HASH_PREFIX = "inshell-anon-analytics:v1:";
+const EVENT_TYPE_SET = new Set<string>(ANALYTICS_EVENT_TYPES);
+const CONTENT_TYPE_SET = new Set<string>(ANALYTICS_CONTENT_TYPES);
+const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
 
 const PRODUCTION_HOSTS = ["inshell.art", "thought.inshell.art", "gallery.inshell.art"];
 const PREVIEW_HOSTS = ["preview.inshell.art", "thought.preview.inshell.art", "gallery.preview.inshell.art"];
@@ -236,9 +330,9 @@ export async function recordAnalyticsEvent(
   await db
     .prepare(
       `INSERT INTO ${EVENT_TABLE} (` +
-        "event_id,event_type,visitor_hash,session_hash,surface,hostname,path,referrer_host,referrer_path," +
+        "event_id,event_type,visitor_hash,session_hash,surface,hostname,path,content_type,content_id,referrer_host,referrer_path," +
         "occurred_at,received_at,device_class,viewport_width,viewport_height,timezone_offset,language,automation" +
-        ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)",
+        ",metadata_json) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
     )
     .bind(
       normalized.eventId,
@@ -248,6 +342,8 @@ export async function recordAnalyticsEvent(
       normalized.surface,
       hostname,
       normalized.path,
+      normalized.contentType,
+      normalized.contentId,
       normalized.referrerHost,
       normalized.referrerPath,
       normalized.occurredAt,
@@ -258,6 +354,7 @@ export async function recordAnalyticsEvent(
       normalized.timezoneOffset,
       normalized.language,
       normalized.automation ? 1 : 0,
+      normalized.metadataJson,
     )
     .run();
 
@@ -273,10 +370,11 @@ export async function recordAnalyticsEvent(
   await db
     .prepare(
       `INSERT INTO ${SESSION_TABLE} (session_hash,visitor_hash,started_at,last_seen_at,pageview_count) ` +
-        "VALUES (?1,?2,?3,?4,1) " +
-        "ON CONFLICT(session_hash) DO UPDATE SET last_seen_at=excluded.last_seen_at,pageview_count=pageview_count+1",
+        "VALUES (?1,?2,?3,?4,?5) " +
+        "ON CONFLICT(session_hash) DO UPDATE SET last_seen_at=excluded.last_seen_at," +
+        "pageview_count=pageview_count+excluded.pageview_count",
     )
-    .bind(sessionHash, visitorHash, receivedAt, receivedAt)
+    .bind(sessionHash, visitorHash, receivedAt, receivedAt, normalized.eventType === "pageview" ? 1 : 0)
     .run();
 
   return {
@@ -299,6 +397,7 @@ export async function readAnalyticsStatus(
     enabled: isAnalyticsEnabled(env),
     route: "/api/analytics/event",
     summaryRoute: "/api/analytics/summary",
+    visitorRoute: "/api/analytics/visitors",
     identity: "anonymous-browser-session",
     hostScope: hostScope.name,
     countedHosts: hostScope.hostnames,
@@ -306,6 +405,10 @@ export async function readAnalyticsStatus(
     dbBinding: binding,
     rawIpStored: false,
     rawUserAgentStored: false,
+    rawWalletAddressStored: false,
+    rawMetadataStored: false,
+    metadataAllowlist: true,
+    supportedEventTypes: [...ANALYTICS_EVENT_TYPES],
     statusSource: db ? "empty" : "unavailable",
     statusError: null,
     lastEventAt: null,
@@ -410,6 +513,87 @@ export async function readAnalyticsSummary(
   };
 }
 
+export async function readAnalyticsVisitors(
+  env: ChainCacheEnv,
+  days: number,
+  hostScope: AnalyticsHostScope = {
+    name: "production",
+    hostnames: PRODUCTION_HOSTS,
+  },
+  visitorRank?: number,
+): Promise<AnalyticsVisitors> {
+  const { db } = resolveAnalyticsDb(env);
+  if (!db) throw new Error("analytics D1 binding is not configured");
+  const safeDays = Math.min(30, Math.max(1, Math.trunc(days || 1)));
+  const since = new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000).toISOString();
+  const rank = Number.isFinite(visitorRank) && visitorRank != null
+    ? Math.min(50, Math.max(1, Math.trunc(visitorRank)))
+    : null;
+  const visitorLimit = rank ?? 10;
+  const filter = hostFilter(hostScope, 2);
+  const limitParam = 2 + filter.values.length;
+  const visitorResult = await db
+    .prepare(
+      `SELECT visitor_hash AS visitorHash,COUNT(*) AS eventCount,` +
+        `SUM(CASE WHEN event_type = 'pageview' THEN 1 ELSE 0 END) AS pageViews,` +
+        `COUNT(DISTINCT session_hash) AS sessions,MIN(received_at) AS firstSeenAt,` +
+        `MAX(received_at) AS lastSeenAt,SUM(automation) AS automationEvents ` +
+        `FROM ${EVENT_TABLE} WHERE received_at >= ?1 AND ${filter.sql} ` +
+        `GROUP BY visitor_hash ORDER BY eventCount DESC,lastSeenAt DESC LIMIT ?${limitParam}`,
+    )
+    .bind(since, ...filter.values, visitorLimit)
+    .all?.<{
+      visitorHash: string;
+      eventCount: number;
+      pageViews: number | null;
+      sessions: number;
+      firstSeenAt: string | null;
+      lastSeenAt: string | null;
+      automationEvents: number | null;
+    }>();
+  const rankedVisitors = (visitorResult?.results ?? []).map((row, index) => ({ ...row, rank: index + 1 }));
+  const selectedVisitors = rank
+    ? rankedVisitors.filter((row) => row.rank === rank)
+    : rankedVisitors;
+
+  return {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    hostScope: {
+      name: hostScope.name,
+      hostnames: hostScope.hostnames,
+    },
+    window: {
+      days: safeDays,
+      since,
+    },
+    visitors: await Promise.all(
+      selectedVisitors.map(async (visitor) => {
+        const timeline = await readVisitorTimeline(db, visitor.visitorHash, since, hostScope);
+        const firstContent = timeline.find((event) => event.eventType === "pageview") ?? timeline[0] ?? null;
+        return {
+          visitorRank: visitor.rank,
+          firstSeenAt: visitor.firstSeenAt ?? null,
+          lastSeenAt: visitor.lastSeenAt ?? null,
+          eventCount: Number(visitor.eventCount ?? 0),
+          pageViews: Number(visitor.pageViews ?? 0),
+          sessions: Number(visitor.sessions ?? 0),
+          returning: Number(visitor.sessions ?? 0) > 1,
+          automationEvents: Number(visitor.automationEvents ?? 0),
+          source: {
+            referrerHost: firstContent?.referrerHost ?? null,
+            referrerPath: firstContent?.referrerPath ?? null,
+            firstPath: firstContent?.path ?? null,
+            firstContentType: firstContent?.contentType ?? null,
+            firstContentId: firstContent?.contentId ?? null,
+          },
+          timeline,
+        };
+      }),
+    ),
+  };
+}
+
 async function readPathRows(
   db: D1DatabaseLike,
   since: string,
@@ -471,18 +655,89 @@ async function readGroupedRows(
   }));
 }
 
+async function readVisitorTimeline(
+  db: D1DatabaseLike,
+  visitorHash: string,
+  since: string,
+  hostScope: AnalyticsHostScope,
+): Promise<AnalyticsVisitors["visitors"][number]["timeline"]> {
+  const filter = hostFilter(hostScope, 3);
+  const limitParam = 3 + filter.values.length;
+  const result = await db
+    .prepare(
+      `SELECT event_type AS eventType,session_hash AS sessionHash,surface,hostname,path,` +
+        `content_type AS contentType,content_id AS contentId,referrer_host AS referrerHost,` +
+        `referrer_path AS referrerPath,occurred_at AS occurredAt,received_at AS receivedAt,` +
+        `device_class AS deviceClass,viewport_width AS viewportWidth,viewport_height AS viewportHeight,` +
+        `timezone_offset AS timezoneOffset,language,automation,metadata_json AS metadataJson ` +
+        `FROM ${EVENT_TABLE} WHERE visitor_hash = ?1 AND received_at >= ?2 AND ${filter.sql} ` +
+        `ORDER BY received_at ASC LIMIT ?${limitParam}`,
+    )
+    .bind(visitorHash, since, ...filter.values, 200)
+    .all?.<{
+      eventType: AnalyticsEventType;
+      sessionHash: string;
+      surface: string;
+      hostname: string;
+      path: string;
+      contentType: AnalyticsContentType | null;
+      contentId: string | null;
+      referrerHost: string | null;
+      referrerPath: string | null;
+      occurredAt: string;
+      receivedAt: string;
+      deviceClass: string | null;
+      viewportWidth: number | null;
+      viewportHeight: number | null;
+      timezoneOffset: number | null;
+      language: string | null;
+      automation: number | null;
+      metadataJson: string | null;
+    }>();
+  const sessionRanks = new Map<string, number>();
+  return (result?.results ?? []).map((row) => {
+    const sessionHashValue = String(row.sessionHash ?? "");
+    if (!sessionRanks.has(sessionHashValue)) {
+      sessionRanks.set(sessionHashValue, sessionRanks.size + 1);
+    }
+    return {
+      eventType: EVENT_TYPE_SET.has(row.eventType) ? row.eventType : "pageview",
+      occurredAt: row.occurredAt,
+      receivedAt: row.receivedAt,
+      sessionRank: sessionRanks.get(sessionHashValue) ?? 1,
+      surface: row.surface,
+      hostname: row.hostname,
+      path: row.path,
+      contentType: CONTENT_TYPE_SET.has(String(row.contentType)) ? (row.contentType as AnalyticsContentType) : "unknown",
+      contentId: row.contentId ?? null,
+      referrerHost: row.referrerHost ?? null,
+      referrerPath: row.referrerPath ?? null,
+      deviceClass: row.deviceClass ?? null,
+      viewportWidth: numberOrNull(row.viewportWidth),
+      viewportHeight: numberOrNull(row.viewportHeight),
+      timezoneOffset: numberOrNull(row.timezoneOffset),
+      language: row.language ?? null,
+      automation: Number(row.automation ?? 0) === 1,
+      metadata: parseMetadata(row.metadataJson),
+    };
+  });
+}
+
 async function ensureAnalyticsTables(db: D1DatabaseLike) {
   if (ensuredTables.has(db as object)) return;
   for (const query of [
     `CREATE TABLE IF NOT EXISTS ${EVENT_TABLE} (` +
       "event_id TEXT PRIMARY KEY,event_type TEXT NOT NULL,visitor_hash TEXT NOT NULL,session_hash TEXT NOT NULL," +
-      "surface TEXT NOT NULL,hostname TEXT NOT NULL,path TEXT NOT NULL,referrer_host TEXT,referrer_path TEXT," +
+      "surface TEXT NOT NULL,hostname TEXT NOT NULL,path TEXT NOT NULL,content_type TEXT,content_id TEXT," +
+      "referrer_host TEXT,referrer_path TEXT," +
       "occurred_at TEXT NOT NULL,received_at TEXT NOT NULL,device_class TEXT,viewport_width INTEGER,viewport_height INTEGER," +
-      "timezone_offset INTEGER,language TEXT,automation INTEGER NOT NULL DEFAULT 0)",
+      "timezone_offset INTEGER,language TEXT,automation INTEGER NOT NULL DEFAULT 0,metadata_json TEXT)",
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_received ON ${EVENT_TABLE} (received_at)`,
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_visitor ON ${EVENT_TABLE} (visitor_hash, received_at)`,
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_session ON ${EVENT_TABLE} (session_hash, received_at)`,
     `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_path ON ${EVENT_TABLE} (path, received_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_event_type ON ${EVENT_TABLE} (event_type, received_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_content ON ${EVENT_TABLE} (content_type, content_id, received_at)`,
     `CREATE TABLE IF NOT EXISTS ${VISITOR_TABLE} (` +
       "visitor_hash TEXT PRIMARY KEY,first_seen_at TEXT NOT NULL,last_seen_at TEXT NOT NULL,event_count INTEGER NOT NULL DEFAULT 0)",
     `CREATE TABLE IF NOT EXISTS ${SESSION_TABLE} (` +
@@ -490,6 +745,17 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
       "pageview_count INTEGER NOT NULL DEFAULT 0)",
   ]) {
     await db.prepare(query).run();
+  }
+  for (const query of [
+    `ALTER TABLE ${EVENT_TABLE} ADD COLUMN content_type TEXT`,
+    `ALTER TABLE ${EVENT_TABLE} ADD COLUMN content_id TEXT`,
+    `ALTER TABLE ${EVENT_TABLE} ADD COLUMN metadata_json TEXT`,
+  ]) {
+    try {
+      await db.prepare(query).run();
+    } catch (error) {
+      if (!isDuplicateColumnError(error)) throw error;
+    }
   }
   ensuredTables.add(db as object);
 }
@@ -499,8 +765,11 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
   const eventId = normalizedId(payload.eventId, "eventId");
   const visitorId = normalizedId(payload.visitorId, "visitorId");
   const sessionId = normalizedId(payload.sessionId, "sessionId");
-  const eventType = payload.eventType === "pageview" ? "pageview" : "";
-  if (!eventType) throw new AnalyticsInputError("eventType must be pageview");
+  const eventType = normalizeEventType(payload.eventType);
+  const path = normalizePath(payload.path);
+  const contentType = normalizeContentType(payload.contentType, path);
+  const contentId = normalizeContentId(payload.contentId, path, contentType);
+  const metadata = normalizeEventMetadata(eventType, payload.metadata);
   return {
     eventId,
     visitorId,
@@ -508,7 +777,9 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
     eventType,
     surface: surfaceForHost(hostname),
     hostname,
-    path: normalizePath(payload.path),
+    path,
+    contentType,
+    contentId,
     ...normalizeReferrer(payload.referrer),
     occurredAt: normalizeOccurredAt(payload.occurredAt),
     deviceClass: normalizeDeviceClass(payload.deviceClass),
@@ -517,7 +788,15 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
     timezoneOffset: normalizeInteger(payload.timezoneOffset, -1440, 1440),
     language: normalizeLanguage(payload.language),
     automation: payload.automation === true,
+    metadataJson: metadataToJson(metadata),
   };
+}
+
+function normalizeEventType(value: unknown): AnalyticsEventType {
+  if (typeof value !== "string" || !EVENT_TYPE_SET.has(value)) {
+    throw new AnalyticsInputError("eventType is not supported");
+  }
+  return value as AnalyticsEventType;
 }
 
 function normalizedId(value: unknown, label: string) {
@@ -538,6 +817,41 @@ function normalizePath(value: unknown) {
   } catch {
     return "/";
   }
+}
+
+function normalizeContentType(value: unknown, path: string): AnalyticsContentType {
+  if (typeof value === "string" && CONTENT_TYPE_SET.has(value)) {
+    return value as AnalyticsContentType;
+  }
+  return contentTypeForPath(path);
+}
+
+function normalizeContentId(
+  value: unknown,
+  path: string,
+  contentType: AnalyticsContentType,
+) {
+  if (typeof value === "string" || typeof value === "number") {
+    const normalized = normalizeToken(String(value), MAX_CONTENT_ID_LENGTH);
+    return normalized || null;
+  }
+  return contentIdForPath(path, contentType);
+}
+
+function contentTypeForPath(path: string): AnalyticsContentType {
+  if (path === "/" || path === "/home") return "home";
+  if (path === "/verify" || path.startsWith("/verify/")) return "verify";
+  if (path === "/gallery" || path.startsWith("/gallery/")) return "gallery";
+  if (path === "/thought" || path.startsWith("/thought/")) return "thought";
+  if (path === "/pulse" || path.startsWith("/pulse/")) return "pulse";
+  if (path === "/path" || path.startsWith("/path/")) return "path";
+  return "unknown";
+}
+
+function contentIdForPath(path: string, contentType: AnalyticsContentType) {
+  if (contentType !== "path" && contentType !== "thought" && contentType !== "gallery") return null;
+  const match = path.match(/\/(?:path|thought|gallery)\/([A-Za-z0-9_-]{1,64})(?:\/|$)/i);
+  return match ? normalizeToken(match[1], MAX_CONTENT_ID_LENGTH) : null;
 }
 
 function normalizeReferrer(value: unknown) {
@@ -582,6 +896,136 @@ function normalizeLanguage(value: unknown) {
   return /^[A-Za-z0-9-]+$/.test(trimmed) ? trimmed : null;
 }
 
+function normalizeEventMetadata(eventType: AnalyticsEventType, value: unknown): AnalyticsMetadata {
+  const input = isRecord(value) ? value : {};
+  const output: AnalyticsMetadata = {};
+  const addToken = (key: string, maxLength = 80) => {
+    const normalized = normalizeToken(input[key], maxLength);
+    if (normalized) output[key] = normalized;
+  };
+  const addErrorFields = () => {
+    const category = normalizeErrorCategory(input.errorCategory);
+    if (category) output.errorCategory = category;
+    const code = normalizeToken(input.errorCode, 48);
+    if (code) output.errorCode = code;
+  };
+
+  switch (eventType) {
+    case "page_visible_duration": {
+      const duration = normalizeDurationBucket(input.durationMs);
+      if (duration != null) output.durationMs = duration;
+      break;
+    }
+    case "scroll_depth": {
+      const scrollPercent = normalizeScrollBucket(input.scrollPercent);
+      if (scrollPercent != null) output.scrollPercent = scrollPercent;
+      break;
+    }
+    case "cta_click":
+      addToken("ctaId");
+      break;
+    case "external_link_click":
+      addToken("hrefHost", MAX_REFERRER_HOST_LENGTH);
+      output.hrefHost = typeof output.hrefHost === "string"
+        ? normalizeHostname(output.hrefHost).slice(0, MAX_REFERRER_HOST_LENGTH)
+        : output.hrefHost;
+      output.hrefPath = normalizePath(input.hrefPath);
+      addToken("ctaId");
+      break;
+    case "api_error": {
+      output.endpoint = normalizePath(input.endpoint);
+      const status = normalizeInteger(input.status, 100, 599);
+      if (status != null) output.status = status;
+      addErrorFields();
+      break;
+    }
+    case "frontend_error":
+      addErrorFields();
+      break;
+    case "wallet_connect_started":
+    case "wallet_connect_succeeded":
+    case "wallet_connect_failed":
+      addToken("walletKind", 32);
+      addToken("walletStage", 32);
+      if (eventType === "wallet_connect_failed") addErrorFields();
+      break;
+    case "mint_started":
+    case "mint_succeeded":
+    case "mint_failed":
+      addToken("mintStage", 32);
+      if (eventType === "mint_failed") addErrorFields();
+      break;
+    case "pageview":
+      break;
+  }
+
+  return output;
+}
+
+function normalizeDurationBucket(value: unknown) {
+  const numeric = typeof value === "number" ? Math.trunc(value) : Number.NaN;
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return DURATION_BUCKETS_MS.find((bucket) => numeric <= bucket) ?? 600_000;
+}
+
+function normalizeScrollBucket(value: unknown) {
+  const numeric = typeof value === "number" ? Math.trunc(value) : Number.NaN;
+  return [25, 50, 75, 100].includes(numeric) ? numeric : null;
+}
+
+function normalizeErrorCategory(value: unknown) {
+  if (typeof value !== "string") return "";
+  const normalized = normalizeToken(value, 32);
+  return [
+    "http",
+    "network",
+    "timeout",
+    "rpc",
+    "wallet_rejected",
+    "wallet_busy",
+    "wallet_missing",
+    "runtime",
+    "promise",
+    "unknown",
+  ].includes(normalized) ? normalized : "unknown";
+}
+
+function metadataToJson(metadata: AnalyticsMetadata) {
+  const json = JSON.stringify(metadata);
+  return json.length <= MAX_METADATA_JSON_LENGTH ? json : "{}";
+}
+
+function parseMetadata(value: unknown): AnalyticsMetadata {
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (!isRecord(parsed)) return {};
+    const output: AnalyticsMetadata = {};
+    for (const [key, item] of Object.entries(parsed)) {
+      if (typeof item === "string" || typeof item === "number" || typeof item === "boolean" || item === null) {
+        output[key] = item;
+      }
+    }
+    return output;
+  } catch {
+    return {};
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToken(value: unknown, maxLength: number) {
+  if (typeof value !== "string" && typeof value !== "number") return "";
+  return String(value).trim().replace(/[^A-Za-z0-9_.:/#-]+/g, "_").slice(0, maxLength);
+}
+
+function numberOrNull(value: unknown) {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
 function normalizeHostname(value: string) {
   return value.trim().toLowerCase().replace(/\.$/, "");
 }
@@ -616,4 +1060,9 @@ async function hashIdentifier(value: string) {
 function isMissingAnalyticsTableError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return message.toLowerCase().includes("no such table");
+}
+
+function isDuplicateColumnError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes("duplicate column");
 }

--- a/functions/api/analytics/store.ts
+++ b/functions/api/analytics/store.ts
@@ -7,6 +7,7 @@ type AnalyticsEventPayload = {
   eventId?: unknown;
   visitorId?: unknown;
   sessionId?: unknown;
+  visitId?: unknown;
   eventType?: unknown;
   path?: unknown;
   contentType?: unknown;
@@ -54,6 +55,46 @@ const ANALYTICS_CONTENT_TYPES = [
 type AnalyticsContentType = typeof ANALYTICS_CONTENT_TYPES[number];
 type AnalyticsMetadata = Record<string, string | number | boolean | null>;
 
+type AnalyticsVisitorTimelineEvent = {
+  eventType: AnalyticsEventType;
+  occurredAt: string;
+  receivedAt: string;
+  sessionRank: number;
+  visitRank: number;
+  surface: string;
+  hostname: string;
+  path: string;
+  contentType: AnalyticsContentType;
+  contentId: string | null;
+  referrerHost: string | null;
+  referrerPath: string | null;
+  deviceClass: string | null;
+  viewportWidth: number | null;
+  viewportHeight: number | null;
+  timezoneOffset: number | null;
+  language: string | null;
+  automation: boolean;
+  metadata: AnalyticsMetadata;
+};
+
+type AnalyticsVisitorSource = {
+  referrerHost: string | null;
+  referrerPath: string | null;
+  firstPath: string | null;
+  firstContentType: AnalyticsContentType | null;
+  firstContentId: string | null;
+};
+
+type AnalyticsVisitorVisit = {
+  visitRank: number;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+  eventCount: number;
+  pageViews: number;
+  source: AnalyticsVisitorSource;
+  timeline: AnalyticsVisitorTimelineEvent[];
+};
+
 export type AnalyticsStatus = {
   enabled: boolean;
   route: string;
@@ -66,9 +107,11 @@ export type AnalyticsStatus = {
   dbBinding: "INSHELL_ANALYTICS_DB" | "INSHELL_CHAIN_DATA_DB" | null;
   rawIpStored: false;
   rawUserAgentStored: false;
+  rawVisitIdStored: false;
   rawWalletAddressStored: false;
   rawMetadataStored: false;
   metadataAllowlist: true;
+  visitTimeoutMinutes: 30;
   supportedEventTypes: AnalyticsEventType[];
   statusSource: "d1" | "empty" | "unavailable" | "error";
   statusError: string | null;
@@ -76,6 +119,7 @@ export type AnalyticsStatus = {
   eventCount24h: number;
   uniqueVisitors24h: number;
   sessions24h: number;
+  visits24h: number;
 };
 
 export type AnalyticsSummary = {
@@ -93,6 +137,7 @@ export type AnalyticsSummary = {
     pageViews: number;
     uniqueVisitors: number;
     sessions: number;
+    visits: number;
     returningVisitors: number;
     automationEvents: number;
   };
@@ -131,35 +176,12 @@ export type AnalyticsVisitors = {
     eventCount: number;
     pageViews: number;
     sessions: number;
+    visitCount: number;
     returning: boolean;
     automationEvents: number;
-    source: {
-      referrerHost: string | null;
-      referrerPath: string | null;
-      firstPath: string | null;
-      firstContentType: AnalyticsContentType | null;
-      firstContentId: string | null;
-    };
-    timeline: Array<{
-      eventType: AnalyticsEventType;
-      occurredAt: string;
-      receivedAt: string;
-      sessionRank: number;
-      surface: string;
-      hostname: string;
-      path: string;
-      contentType: AnalyticsContentType;
-      contentId: string | null;
-      referrerHost: string | null;
-      referrerPath: string | null;
-      deviceClass: string | null;
-      viewportWidth: number | null;
-      viewportHeight: number | null;
-      timezoneOffset: number | null;
-      language: string | null;
-      automation: boolean;
-      metadata: AnalyticsMetadata;
-    }>;
+    source: AnalyticsVisitorSource;
+    visits: AnalyticsVisitorVisit[];
+    timeline: AnalyticsVisitorTimelineEvent[];
   }>;
 };
 
@@ -179,6 +201,7 @@ const MAX_REFERRER_HOST_LENGTH = 120;
 const MAX_REFERRER_PATH_LENGTH = 256;
 const MAX_METADATA_JSON_LENGTH = 1024;
 const HASH_PREFIX = "inshell-anon-analytics:v1:";
+const VISIT_TIMEOUT_MINUTES = 30;
 const EVENT_TYPE_SET = new Set<string>(ANALYTICS_EVENT_TYPES);
 const CONTENT_TYPE_SET = new Set<string>(ANALYTICS_CONTENT_TYPES);
 const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
@@ -325,20 +348,22 @@ export async function recordAnalyticsEvent(
 
   const visitorHash = await hashIdentifier(normalized.visitorId);
   const sessionHash = await hashIdentifier(normalized.sessionId);
+  const visitHash = await hashIdentifier(normalized.visitId);
   const receivedAt = new Date().toISOString();
 
   await db
     .prepare(
       `INSERT INTO ${EVENT_TABLE} (` +
-        "event_id,event_type,visitor_hash,session_hash,surface,hostname,path,content_type,content_id,referrer_host,referrer_path," +
+        "event_id,event_type,visitor_hash,session_hash,visit_hash,surface,hostname,path,content_type,content_id,referrer_host,referrer_path," +
         "occurred_at,received_at,device_class,viewport_width,viewport_height,timezone_offset,language,automation" +
-        ",metadata_json) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
+        ",metadata_json) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
     )
     .bind(
       normalized.eventId,
       normalized.eventType,
       visitorHash,
       sessionHash,
+      visitHash,
       normalized.surface,
       hostname,
       normalized.path,
@@ -405,9 +430,11 @@ export async function readAnalyticsStatus(
     dbBinding: binding,
     rawIpStored: false,
     rawUserAgentStored: false,
+    rawVisitIdStored: false,
     rawWalletAddressStored: false,
     rawMetadataStored: false,
     metadataAllowlist: true,
+    visitTimeoutMinutes: VISIT_TIMEOUT_MINUTES,
     supportedEventTypes: [...ANALYTICS_EVENT_TYPES],
     statusSource: db ? "empty" : "unavailable",
     statusError: null,
@@ -415,12 +442,14 @@ export async function readAnalyticsStatus(
     eventCount24h: 0,
     uniqueVisitors24h: 0,
     sessions24h: 0,
+    visits24h: 0,
   };
   if (!db) return base;
 
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const filter = hostFilter(hostScope, 1);
   try {
+    const visitHashSql = await visitHashExpression(db);
     const last = await db
       .prepare(`SELECT MAX(received_at) AS lastEventAt FROM ${EVENT_TABLE} WHERE ${filter.sql}`)
       .bind(...filter.values)
@@ -428,11 +457,12 @@ export async function readAnalyticsStatus(
     const totals = await db
       .prepare(
         `SELECT COUNT(*) AS eventCount, COUNT(DISTINCT visitor_hash) AS uniqueVisitors, ` +
-          `COUNT(DISTINCT session_hash) AS sessions FROM ${EVENT_TABLE} WHERE received_at >= ?1 ` +
+          `COUNT(DISTINCT session_hash) AS sessions, COUNT(DISTINCT ${visitHashSql}) AS visits ` +
+          `FROM ${EVENT_TABLE} WHERE received_at >= ?1 ` +
           `AND ${hostFilter(hostScope, 2).sql}`,
       )
       .bind(since, ...hostScope.hostnames)
-      .first<{ eventCount: number; uniqueVisitors: number; sessions: number }>();
+      .first<{ eventCount: number; uniqueVisitors: number; sessions: number; visits: number }>();
     return {
       ...base,
       statusSource: last?.lastEventAt ? "d1" : "empty",
@@ -440,6 +470,7 @@ export async function readAnalyticsStatus(
       eventCount24h: Number(totals?.eventCount ?? 0),
       uniqueVisitors24h: Number(totals?.uniqueVisitors ?? 0),
       sessions24h: Number(totals?.sessions ?? 0),
+      visits24h: Number(totals?.visits ?? 0),
     };
   } catch (error) {
     if (isMissingAnalyticsTableError(error)) return base;
@@ -463,11 +494,13 @@ export async function readAnalyticsSummary(
   if (!db) throw new Error("analytics D1 binding is not configured");
   const safeDays = Math.min(90, Math.max(1, Math.trunc(days || 7)));
   const since = new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000).toISOString();
+  const visitHashSql = await visitHashExpression(db);
 
   const totals = await db
     .prepare(
       `SELECT COUNT(*) AS pageViews, COUNT(DISTINCT visitor_hash) AS uniqueVisitors, ` +
-        `COUNT(DISTINCT session_hash) AS sessions, SUM(automation) AS automationEvents ` +
+        `COUNT(DISTINCT session_hash) AS sessions, COUNT(DISTINCT ${visitHashSql}) AS visits, ` +
+        `SUM(automation) AS automationEvents ` +
         `FROM ${EVENT_TABLE} WHERE event_type = 'pageview' AND received_at >= ?1 ` +
         `AND ${hostFilter(hostScope, 2).sql}`,
     )
@@ -476,6 +509,7 @@ export async function readAnalyticsSummary(
       pageViews: number;
       uniqueVisitors: number;
       sessions: number;
+      visits: number;
       automationEvents: number | null;
     }>();
   const returning = await db
@@ -483,7 +517,7 @@ export async function readAnalyticsSummary(
       `SELECT COUNT(*) AS returningVisitors FROM (` +
         `SELECT visitor_hash FROM ${EVENT_TABLE} WHERE event_type = 'pageview' AND received_at >= ?1 ` +
         `AND ${hostFilter(hostScope, 2).sql} ` +
-        `GROUP BY visitor_hash HAVING COUNT(DISTINCT session_hash) > 1` +
+        `GROUP BY visitor_hash HAVING COUNT(DISTINCT ${visitHashSql}) > 1` +
         `)`,
     )
     .bind(since, ...hostScope.hostnames)
@@ -504,6 +538,7 @@ export async function readAnalyticsSummary(
       pageViews: Number(totals?.pageViews ?? 0),
       uniqueVisitors: Number(totals?.uniqueVisitors ?? 0),
       sessions: Number(totals?.sessions ?? 0),
+      visits: Number(totals?.visits ?? 0),
       returningVisitors: Number(returning?.returningVisitors ?? 0),
       automationEvents: Number(totals?.automationEvents ?? 0),
     },
@@ -532,11 +567,13 @@ export async function readAnalyticsVisitors(
   const visitorLimit = rank ?? 10;
   const filter = hostFilter(hostScope, 2);
   const limitParam = 2 + filter.values.length;
+  const visitHashSql = await visitHashExpression(db);
   const visitorResult = await db
     .prepare(
       `SELECT visitor_hash AS visitorHash,COUNT(*) AS eventCount,` +
         `SUM(CASE WHEN event_type = 'pageview' THEN 1 ELSE 0 END) AS pageViews,` +
-        `COUNT(DISTINCT session_hash) AS sessions,MIN(received_at) AS firstSeenAt,` +
+        `COUNT(DISTINCT session_hash) AS sessions,COUNT(DISTINCT ${visitHashSql}) AS visits,` +
+        `MIN(received_at) AS firstSeenAt,` +
         `MAX(received_at) AS lastSeenAt,SUM(automation) AS automationEvents ` +
         `FROM ${EVENT_TABLE} WHERE received_at >= ?1 AND ${filter.sql} ` +
         `GROUP BY visitor_hash ORDER BY eventCount DESC,lastSeenAt DESC LIMIT ?${limitParam}`,
@@ -547,6 +584,7 @@ export async function readAnalyticsVisitors(
       eventCount: number;
       pageViews: number | null;
       sessions: number;
+      visits: number;
       firstSeenAt: string | null;
       lastSeenAt: string | null;
       automationEvents: number | null;
@@ -569,8 +607,8 @@ export async function readAnalyticsVisitors(
     },
     visitors: await Promise.all(
       selectedVisitors.map(async (visitor) => {
-        const timeline = await readVisitorTimeline(db, visitor.visitorHash, since, hostScope);
-        const firstContent = timeline.find((event) => event.eventType === "pageview") ?? timeline[0] ?? null;
+        const timeline = await readVisitorTimeline(db, visitor.visitorHash, since, hostScope, visitHashSql);
+        const visitCount = Number(visitor.visits ?? 0);
         return {
           visitorRank: visitor.rank,
           firstSeenAt: visitor.firstSeenAt ?? null,
@@ -578,15 +616,11 @@ export async function readAnalyticsVisitors(
           eventCount: Number(visitor.eventCount ?? 0),
           pageViews: Number(visitor.pageViews ?? 0),
           sessions: Number(visitor.sessions ?? 0),
-          returning: Number(visitor.sessions ?? 0) > 1,
+          visitCount,
+          returning: visitCount > 1,
           automationEvents: Number(visitor.automationEvents ?? 0),
-          source: {
-            referrerHost: firstContent?.referrerHost ?? null,
-            referrerPath: firstContent?.referrerPath ?? null,
-            firstPath: firstContent?.path ?? null,
-            firstContentType: firstContent?.contentType ?? null,
-            firstContentId: firstContent?.contentId ?? null,
-          },
+          source: sourceForTimeline(timeline),
+          visits: groupTimelineByVisit(timeline),
           timeline,
         };
       }),
@@ -660,12 +694,13 @@ async function readVisitorTimeline(
   visitorHash: string,
   since: string,
   hostScope: AnalyticsHostScope,
+  visitHashSql: string,
 ): Promise<AnalyticsVisitors["visitors"][number]["timeline"]> {
   const filter = hostFilter(hostScope, 3);
   const limitParam = 3 + filter.values.length;
   const result = await db
     .prepare(
-      `SELECT event_type AS eventType,session_hash AS sessionHash,surface,hostname,path,` +
+      `SELECT event_type AS eventType,session_hash AS sessionHash,${visitHashSql} AS visitHash,surface,hostname,path,` +
         `content_type AS contentType,content_id AS contentId,referrer_host AS referrerHost,` +
         `referrer_path AS referrerPath,occurred_at AS occurredAt,received_at AS receivedAt,` +
         `device_class AS deviceClass,viewport_width AS viewportWidth,viewport_height AS viewportHeight,` +
@@ -677,6 +712,7 @@ async function readVisitorTimeline(
     .all?.<{
       eventType: AnalyticsEventType;
       sessionHash: string;
+      visitHash: string;
       surface: string;
       hostname: string;
       path: string;
@@ -695,16 +731,22 @@ async function readVisitorTimeline(
       metadataJson: string | null;
     }>();
   const sessionRanks = new Map<string, number>();
+  const visitRanks = new Map<string, number>();
   return (result?.results ?? []).map((row) => {
     const sessionHashValue = String(row.sessionHash ?? "");
     if (!sessionRanks.has(sessionHashValue)) {
       sessionRanks.set(sessionHashValue, sessionRanks.size + 1);
+    }
+    const visitHashValue = String(row.visitHash ?? sessionHashValue);
+    if (!visitRanks.has(visitHashValue)) {
+      visitRanks.set(visitHashValue, visitRanks.size + 1);
     }
     return {
       eventType: EVENT_TYPE_SET.has(row.eventType) ? row.eventType : "pageview",
       occurredAt: row.occurredAt,
       receivedAt: row.receivedAt,
       sessionRank: sessionRanks.get(sessionHashValue) ?? 1,
+      visitRank: visitRanks.get(visitHashValue) ?? 1,
       surface: row.surface,
       hostname: row.hostname,
       path: row.path,
@@ -723,11 +765,43 @@ async function readVisitorTimeline(
   });
 }
 
+function sourceForTimeline(timeline: AnalyticsVisitorTimelineEvent[]): AnalyticsVisitorSource {
+  const firstContent = timeline.find((event) => event.eventType === "pageview") ?? timeline[0] ?? null;
+  return {
+    referrerHost: firstContent?.referrerHost ?? null,
+    referrerPath: firstContent?.referrerPath ?? null,
+    firstPath: firstContent?.path ?? null,
+    firstContentType: firstContent?.contentType ?? null,
+    firstContentId: firstContent?.contentId ?? null,
+  };
+}
+
+function groupTimelineByVisit(timeline: AnalyticsVisitorTimelineEvent[]): AnalyticsVisitorVisit[] {
+  const grouped = new Map<number, AnalyticsVisitorTimelineEvent[]>();
+  for (const event of timeline) {
+    grouped.set(event.visitRank, [...(grouped.get(event.visitRank) ?? []), event]);
+  }
+  return [...grouped.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([visitRank, events]) => {
+      const pageViews = events.filter((event) => event.eventType === "pageview").length;
+      return {
+        visitRank,
+        firstSeenAt: events[0]?.receivedAt ?? null,
+        lastSeenAt: events.at(-1)?.receivedAt ?? null,
+        eventCount: events.length,
+        pageViews,
+        source: sourceForTimeline(events),
+        timeline: events,
+      };
+    });
+}
+
 async function ensureAnalyticsTables(db: D1DatabaseLike) {
   if (ensuredTables.has(db as object)) return;
   for (const query of [
     `CREATE TABLE IF NOT EXISTS ${EVENT_TABLE} (` +
-      "event_id TEXT PRIMARY KEY,event_type TEXT NOT NULL,visitor_hash TEXT NOT NULL,session_hash TEXT NOT NULL," +
+      "event_id TEXT PRIMARY KEY,event_type TEXT NOT NULL,visitor_hash TEXT NOT NULL,session_hash TEXT NOT NULL,visit_hash TEXT," +
       "surface TEXT NOT NULL,hostname TEXT NOT NULL,path TEXT NOT NULL,content_type TEXT,content_id TEXT," +
       "referrer_host TEXT,referrer_path TEXT," +
       "occurred_at TEXT NOT NULL,received_at TEXT NOT NULL,device_class TEXT,viewport_width INTEGER,viewport_height INTEGER," +
@@ -749,6 +823,7 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
     `ALTER TABLE ${EVENT_TABLE} ADD COLUMN content_type TEXT`,
     `ALTER TABLE ${EVENT_TABLE} ADD COLUMN content_id TEXT`,
     `ALTER TABLE ${EVENT_TABLE} ADD COLUMN metadata_json TEXT`,
+    `ALTER TABLE ${EVENT_TABLE} ADD COLUMN visit_hash TEXT`,
   ]) {
     try {
       await db.prepare(query).run();
@@ -759,6 +834,9 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
   await db
     .prepare(`CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_content ON ${EVENT_TABLE} (content_type, content_id, received_at)`)
     .run();
+  await db
+    .prepare(`CREATE INDEX IF NOT EXISTS idx_${EVENT_TABLE}_visit ON ${EVENT_TABLE} (visitor_hash, visit_hash, received_at)`)
+    .run();
   ensuredTables.add(db as object);
 }
 
@@ -767,6 +845,7 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
   const eventId = normalizedId(payload.eventId, "eventId");
   const visitorId = normalizedId(payload.visitorId, "visitorId");
   const sessionId = normalizedId(payload.sessionId, "sessionId");
+  const visitId = normalizedOptionalId(payload.visitId, "visitId") ?? sessionId;
   const eventType = normalizeEventType(payload.eventType);
   const path = normalizePath(payload.path);
   const contentType = normalizeContentType(payload.contentType, path);
@@ -776,6 +855,7 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
     eventId,
     visitorId,
     sessionId,
+    visitId,
     eventType,
     surface: surfaceForHost(hostname),
     hostname,
@@ -808,6 +888,11 @@ function normalizedId(value: unknown, label: string) {
     throw new AnalyticsInputError(`${label} is invalid`);
   }
   return trimmed;
+}
+
+function normalizedOptionalId(value: unknown, label: string) {
+  if (value == null) return null;
+  return normalizedId(value, label);
 }
 
 function normalizePath(value: unknown) {
@@ -1051,6 +1136,23 @@ function hostFilter(hostScope: AnalyticsHostScope, firstParamIndex: number) {
     sql: `hostname IN (${hostScope.hostnames.map((_, index) => `?${firstParamIndex + index}`).join(",")})`,
     values: hostScope.hostnames,
   };
+}
+
+async function visitHashExpression(db: D1DatabaseLike) {
+  return await analyticsEventColumnExists(db, "visit_hash")
+    ? "COALESCE(visit_hash, session_hash)"
+    : "session_hash";
+}
+
+async function analyticsEventColumnExists(db: D1DatabaseLike, columnName: string) {
+  try {
+    const result = await db
+      .prepare(`PRAGMA table_info(${EVENT_TABLE})`)
+      .all?.<{ name: string }>();
+    return (result?.results ?? []).some((row) => row.name === columnName);
+  } catch {
+    return false;
+  }
 }
 
 async function hashIdentifier(value: string) {

--- a/functions/api/analytics/visitors.ts
+++ b/functions/api/analytics/visitors.ts
@@ -1,0 +1,47 @@
+import type { PagesContextLike } from "../chain-cache";
+import {
+  analyticsHostScopeForHostname,
+  analyticsJson,
+  analyticsOptions,
+  isAnalyticsReadAuthorized,
+  readAnalyticsVisitors,
+} from "./store";
+
+export const onRequestOptions = analyticsOptions;
+
+export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
+  if (!isAnalyticsReadAuthorized(ctx.request, ctx.env)) {
+    return analyticsJson(401, {
+      ok: false,
+      error: "Unauthorized.",
+    });
+  }
+
+  try {
+    const url = new globalThis.URL(ctx.request.url);
+    const days = Number.parseInt(url.searchParams.get("days") ?? "1", 10);
+    const visitorRankRaw = url.searchParams.get("visitorRank");
+    const visitorRank = visitorRankRaw == null ? undefined : Number.parseInt(visitorRankRaw, 10);
+    return analyticsJson(
+      200,
+      await readAnalyticsVisitors(
+        ctx.env,
+        days,
+        analyticsHostScopeForHostname(url.hostname),
+        visitorRank,
+      ),
+    );
+  } catch {
+    return analyticsJson(503, {
+      ok: false,
+      error: "Analytics visitors unavailable.",
+    });
+  }
+}
+
+export async function onRequestPost(): Promise<Response> {
+  return analyticsJson(405, {
+    ok: false,
+    error: "Use GET for analytics visitors.",
+  });
+}

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -59,8 +59,10 @@ const ROUTES = {
     privacy: {
       rawIpStored: false,
       rawUserAgentStored: false,
+      rawVisitIdStored: false,
       rawWalletAddressStored: false,
       metadataAllowlist: true,
+      visitTimeoutMinutes: 30,
     },
   },
   publicFeed: [

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -52,8 +52,16 @@ const ROUTES = {
   analytics: {
     eventRoute: "/api/analytics/event",
     summaryRoute: "/api/analytics/summary",
+    visitorRoute: "/api/analytics/visitors",
     summaryAuth: "bearer-token-required",
+    visitorAuth: "bearer-token-required",
     identity: "anonymous-browser-session",
+    privacy: {
+      rawIpStored: false,
+      rawUserAgentStored: false,
+      rawWalletAddressStored: false,
+      metadataAllowlist: true,
+    },
   },
   publicFeed: [
     "/rss.xml",
@@ -183,7 +191,7 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
       devOwns: [
         "Pages API route behavior",
         "chain_snapshots table schema and read/write code",
-        "anonymous analytics event and summary route behavior",
+        "anonymous analytics event, summary, and visitor timeline route behavior",
         "RPC route selection contract",
         "frontend read behavior and diagnostics headers",
       ],

--- a/packages/shared/src/anonymousAnalytics.ts
+++ b/packages/shared/src/anonymousAnalytics.ts
@@ -52,7 +52,9 @@ type AnalyticsWindow = globalThis.Window & {
 
 const VISITOR_STORAGE_KEY = "inshell.analytics.visitor.v1";
 const SESSION_STORAGE_KEY = "inshell.analytics.session.v1";
+const VISIT_STORAGE_KEY = "inshell.analytics.visit.v1";
 const DEFAULT_ENDPOINT = "/api/analytics/event";
+const VISIT_TIMEOUT_MS = 30 * 60 * 1000;
 const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
 
 const ALLOWED_HOSTS = new Set([
@@ -93,6 +95,8 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
   let emittedScrollBuckets = new Set<number>();
 
   const track = (input: AnonymousAnalyticsTrackInput) => {
+    const visit = readOrCreateVisitState(windowRef, Date.now());
+    const visitId = visit?.id ?? sessionId;
     const path = normalizePath(input.path ?? locationRef.pathname);
     const content = contentForPath(path, input.contentType, input.contentId);
     sendAnalyticsEvent(endpoint, {
@@ -100,6 +104,7 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
       eventId: createId(),
       visitorId,
       sessionId,
+      visitId,
       eventType: input.eventType,
       path,
       contentType: content.contentType,
@@ -114,7 +119,9 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
       language: navigatorRef.language || "",
       automation: navigatorRef.webdriver === true,
       metadata: input.metadata ?? {},
-    }, navigatorRef);
+    }, navigatorRef, () => {
+      updateVisitActivity(windowRef, visitId, Date.now());
+    });
     return true;
   };
 
@@ -183,11 +190,13 @@ function sendAnalyticsEvent(
   endpoint: string,
   payload: Record<string, unknown>,
   navigatorRef: globalThis.Navigator,
+  onAccepted?: () => void,
 ) {
   const body = JSON.stringify(payload);
   if (typeof navigatorRef.sendBeacon === "function") {
     try {
       if (navigatorRef.sendBeacon(endpoint, new globalThis.Blob([body], { type: "application/json" }))) {
+        onAccepted?.();
         return;
       }
     } catch {
@@ -201,6 +210,8 @@ function sendAnalyticsEvent(
     },
     body,
     keepalive: true,
+  }).then((response) => {
+    if (response.ok) onAccepted?.();
   }).catch(() => undefined);
 }
 
@@ -348,6 +359,54 @@ function readOrCreateWindowStorageId(
     return created;
   } catch {
     return "";
+  }
+}
+
+function readOrCreateVisitState(windowRef: globalThis.Window, now: number) {
+  try {
+    const raw = windowRef.localStorage.getItem(VISIT_STORAGE_KEY);
+    const existing = parseVisitState(raw);
+    if (existing && now - existing.lastActivityAt <= VISIT_TIMEOUT_MS) {
+      return existing;
+    }
+    const created = { id: createId(), lastActivityAt: now };
+    writeVisitState(windowRef, created);
+    return created;
+  } catch {
+    return null;
+  }
+}
+
+function updateVisitActivity(windowRef: globalThis.Window, id: string, now: number) {
+  writeVisitState(windowRef, { id, lastActivityAt: now });
+}
+
+function parseVisitState(raw: string | null) {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { id?: unknown; lastActivityAt?: unknown };
+    if (typeof parsed.id !== "string" || !/^[A-Za-z0-9_-]{8,96}$/.test(parsed.id)) return null;
+    if (typeof parsed.lastActivityAt !== "number" || !Number.isFinite(parsed.lastActivityAt)) return null;
+    return {
+      id: parsed.id,
+      lastActivityAt: parsed.lastActivityAt,
+    };
+  } catch {
+    if (/^[A-Za-z0-9_-]{8,96}$/.test(raw)) {
+      return { id: raw, lastActivityAt: 0 };
+    }
+    return null;
+  }
+}
+
+function writeVisitState(
+  windowRef: globalThis.Window,
+  state: { id: string; lastActivityAt: number },
+) {
+  try {
+    windowRef.localStorage.setItem(VISIT_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Analytics must not affect the application when browser storage is unavailable.
   }
 }
 

--- a/packages/shared/src/anonymousAnalytics.ts
+++ b/packages/shared/src/anonymousAnalytics.ts
@@ -1,3 +1,37 @@
+/* global Element, HTMLAnchorElement, RequestInfo, RequestInit, URL, performance */
+
+export type AnonymousAnalyticsEventType =
+  | "pageview"
+  | "page_visible_duration"
+  | "scroll_depth"
+  | "cta_click"
+  | "wallet_connect_started"
+  | "wallet_connect_succeeded"
+  | "wallet_connect_failed"
+  | "mint_started"
+  | "mint_succeeded"
+  | "mint_failed"
+  | "api_error"
+  | "frontend_error"
+  | "external_link_click";
+
+export type AnonymousAnalyticsContentType =
+  | "home"
+  | "path"
+  | "thought"
+  | "gallery"
+  | "pulse"
+  | "verify"
+  | "unknown";
+
+export type AnonymousAnalyticsTrackInput = {
+  eventType: AnonymousAnalyticsEventType;
+  path?: string;
+  contentType?: AnonymousAnalyticsContentType;
+  contentId?: string | number | null;
+  metadata?: Record<string, unknown>;
+};
+
 export type AnonymousAnalyticsOptions = {
   env?: Readonly<Record<string, unknown>>;
   endpoint?: string;
@@ -10,11 +44,16 @@ export type AnonymousAnalyticsOptions = {
 
 type AnalyticsWindow = globalThis.Window & {
   __INSHELL_ANON_ANALYTICS_INSTALLED__?: boolean;
+  __INSHELL_ANON_ANALYTICS_FETCH_PATCHED__?: boolean;
+  inshellAnalytics?: {
+    track: (input: AnonymousAnalyticsTrackInput) => boolean;
+  };
 };
 
 const VISITOR_STORAGE_KEY = "inshell.analytics.visitor.v1";
 const SESSION_STORAGE_KEY = "inshell.analytics.session.v1";
 const DEFAULT_ENDPOINT = "/api/analytics/event";
+const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
 
 const ALLOWED_HOSTS = new Set([
   "inshell.art",
@@ -50,19 +89,22 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
   analyticsWindow.__INSHELL_ANON_ANALYTICS_INSTALLED__ = true;
   const endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
   let lastLocationKey = "";
+  let pageVisibleSinceMs = nowMs();
+  let emittedScrollBuckets = new Set<number>();
 
-  const sendCurrentPageView = () => {
-    const locationKey = `${locationRef.pathname}${locationRef.search}${locationRef.hash}`;
-    if (locationKey === lastLocationKey) return;
-    lastLocationKey = locationKey;
+  const track = (input: AnonymousAnalyticsTrackInput) => {
+    const path = normalizePath(input.path ?? locationRef.pathname);
+    const content = contentForPath(path, input.contentType, input.contentId);
     sendAnalyticsEvent(endpoint, {
       version: 1,
       eventId: createId(),
       visitorId,
       sessionId,
-      eventType: "pageview",
-      path: locationRef.pathname,
-      title: documentRef.title,
+      eventType: input.eventType,
+      path,
+      contentType: content.contentType,
+      contentId: content.contentId,
+      title: input.eventType === "pageview" ? documentRef.title : undefined,
       referrer: documentRef.referrer || "",
       occurredAt: new Date().toISOString(),
       deviceClass: deviceClassFor(windowRef, navigatorRef),
@@ -71,14 +113,70 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
       timezoneOffset: new Date().getTimezoneOffset(),
       language: navigatorRef.language || "",
       automation: navigatorRef.webdriver === true,
+      metadata: input.metadata ?? {},
     }, navigatorRef);
+    return true;
+  };
+
+  analyticsWindow.inshellAnalytics = { track };
+
+  const sendVisibleDuration = () => {
+    const elapsedMs = nowMs() - pageVisibleSinceMs;
+    if (elapsedMs < 1_000) return;
+    track({
+      eventType: "page_visible_duration",
+      metadata: {
+        durationMs: bucketDurationMs(elapsedMs),
+      },
+    });
+    pageVisibleSinceMs = nowMs();
+  };
+
+  const sendCurrentPageView = () => {
+    const locationKey = `${locationRef.pathname}${locationRef.search}${locationRef.hash}`;
+    if (locationKey === lastLocationKey) return;
+    if (lastLocationKey) sendVisibleDuration();
+    lastLocationKey = locationKey;
+    emittedScrollBuckets = new Set<number>();
+    pageVisibleSinceMs = nowMs();
+    track({ eventType: "pageview" });
+    maybeSendScrollDepth(windowRef, documentRef, emittedScrollBuckets, track);
   };
 
   patchHistory(windowRef, sendCurrentPageView);
+  patchFetch(windowRef, endpoint, track);
   windowRef.addEventListener("popstate", sendCurrentPageView);
   windowRef.addEventListener("hashchange", sendCurrentPageView);
+  windowRef.addEventListener("scroll", () => {
+    maybeSendScrollDepth(windowRef, documentRef, emittedScrollBuckets, track);
+  }, { passive: true });
+  documentRef.addEventListener("click", (event) => {
+    trackClickEvent(event, windowRef, track);
+  }, { capture: true });
+  windowRef.addEventListener("error", () => {
+    track({
+      eventType: "frontend_error",
+      metadata: { errorCategory: "runtime" },
+    });
+  });
+  windowRef.addEventListener("unhandledrejection", () => {
+    track({
+      eventType: "frontend_error",
+      metadata: { errorCategory: "promise" },
+    });
+  });
+  documentRef.addEventListener("visibilitychange", () => {
+    if (documentRef.visibilityState === "hidden") sendVisibleDuration();
+    if (documentRef.visibilityState === "visible") pageVisibleSinceMs = nowMs();
+  });
+  windowRef.addEventListener("pagehide", sendVisibleDuration);
   sendCurrentPageView();
   return true;
+}
+
+export function trackInshellAnonymousAnalytics(input: AnonymousAnalyticsTrackInput): boolean {
+  const api = typeof window === "undefined" ? null : (window as AnalyticsWindow).inshellAnalytics;
+  return api?.track(input) ?? false;
 }
 
 function sendAnalyticsEvent(
@@ -121,6 +219,121 @@ function patchHistory(windowRef: globalThis.Window, callback: () => void) {
   }
 }
 
+function patchFetch(
+  windowRef: globalThis.Window,
+  analyticsEndpoint: string,
+  track: (input: AnonymousAnalyticsTrackInput) => boolean,
+) {
+  const analyticsWindow = windowRef as AnalyticsWindow;
+  if (analyticsWindow.__INSHELL_ANON_ANALYTICS_FETCH_PATCHED__) return;
+  if (typeof windowRef.fetch !== "function") return;
+  analyticsWindow.__INSHELL_ANON_ANALYTICS_FETCH_PATCHED__ = true;
+  const originalFetch = windowRef.fetch.bind(windowRef);
+  windowRef.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const endpointPath = requestPath(input, windowRef.location.origin);
+    try {
+      const response = await originalFetch(input, init);
+      if (endpointPath && isTrackedApiPath(endpointPath, analyticsEndpoint) && !response.ok) {
+        track({
+          eventType: "api_error",
+          path: endpointPath,
+          metadata: {
+            endpoint: endpointPath,
+            status: response.status,
+            errorCategory: "http",
+          },
+        });
+      }
+      return response;
+    } catch (error) {
+      if (endpointPath && isTrackedApiPath(endpointPath, analyticsEndpoint)) {
+        track({
+          eventType: "api_error",
+          path: endpointPath,
+          metadata: {
+            endpoint: endpointPath,
+            errorCategory: categorizeError(error),
+          },
+        });
+      }
+      throw error;
+    }
+  }) as typeof fetch;
+}
+
+function trackClickEvent(
+  event: globalThis.Event,
+  windowRef: globalThis.Window,
+  track: (input: AnonymousAnalyticsTrackInput) => boolean,
+) {
+  const target = event.target instanceof Element ? event.target : null;
+  const clickable = target?.closest("a,button,[role='button'],[data-analytics-cta],[data-inshell-analytics]");
+  if (!clickable) return;
+  const ctaId = ctaIdForElement(clickable);
+  if (ctaId) {
+    track({
+      eventType: "cta_click",
+      metadata: { ctaId },
+    });
+  }
+  if (clickable instanceof HTMLAnchorElement && clickable.href) {
+    const link = safeUrl(clickable.href, windowRef.location.href);
+    if (link && link.hostname.toLowerCase() !== windowRef.location.hostname.toLowerCase()) {
+      track({
+        eventType: "external_link_click",
+        metadata: {
+          hrefHost: link.hostname.toLowerCase(),
+          hrefPath: normalizePath(link.pathname),
+          ctaId: ctaId || undefined,
+        },
+      });
+    }
+  }
+}
+
+function ctaIdForElement(element: Element) {
+  const dataId =
+    element.getAttribute("data-analytics-cta") ||
+    element.getAttribute("data-inshell-analytics") ||
+    element.getAttribute("data-analytics-id");
+  const id = dataId || element.id;
+  if (id) return sanitizeToken(id, 80);
+  if (element instanceof HTMLAnchorElement) {
+    const href = safeUrl(element.href, typeof window === "undefined" ? "https://inshell.art" : window.location.href);
+    if (href) return sanitizeToken(`link:${normalizePath(href.pathname)}`, 80);
+  }
+  return "";
+}
+
+function maybeSendScrollDepth(
+  windowRef: globalThis.Window,
+  documentRef: globalThis.Document,
+  emittedBuckets: Set<number>,
+  track: (input: AnonymousAnalyticsTrackInput) => boolean,
+) {
+  const root = documentRef.documentElement;
+  const body = documentRef.body;
+  const scrollTop = Math.max(0, windowRef.scrollY || root.scrollTop || body?.scrollTop || 0);
+  const viewportHeight = Math.max(1, windowRef.innerHeight || root.clientHeight || 1);
+  const scrollHeight = Math.max(
+    root.scrollHeight || 0,
+    body?.scrollHeight || 0,
+    viewportHeight,
+  );
+  const scrollable = Math.max(1, scrollHeight - viewportHeight);
+  const percent = Math.min(100, Math.max(0, Math.round(((scrollTop + viewportHeight) / scrollHeight) * 100)));
+  if (scrollable <= 1) return;
+  for (const bucket of [25, 50, 75, 100]) {
+    if (percent >= bucket && !emittedBuckets.has(bucket)) {
+      emittedBuckets.add(bucket);
+      track({
+        eventType: "scroll_depth",
+        metadata: { scrollPercent: bucket },
+      });
+    }
+  }
+}
+
 function readOrCreateWindowStorageId(
   windowRef: globalThis.Window,
   storageName: "localStorage" | "sessionStorage",
@@ -154,6 +367,90 @@ function createId() {
     }
   }
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function requestPath(input: RequestInfo | URL, origin: string) {
+  const raw = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+  const parsed = safeUrl(raw, origin);
+  return parsed ? normalizePath(parsed.pathname) : "";
+}
+
+function isTrackedApiPath(path: string, analyticsEndpoint: string) {
+  const analyticsPath = normalizePath(analyticsEndpoint);
+  return path.startsWith("/api/") && path !== analyticsPath;
+}
+
+function safeUrl(value: string, base: string) {
+  try {
+    return new URL(value, base);
+  } catch {
+    return null;
+  }
+}
+
+function contentForPath(
+  path: string,
+  providedType?: AnonymousAnalyticsContentType,
+  providedId?: string | number | null,
+) {
+  const contentType = providedType ?? contentTypeForPath(path);
+  const contentId = providedId == null ? contentIdForPath(path, contentType) : sanitizeToken(String(providedId), 64);
+  return { contentType, contentId };
+}
+
+function contentTypeForPath(path: string): AnonymousAnalyticsContentType {
+  if (path === "/" || path === "/home") return "home";
+  if (path === "/verify" || path.startsWith("/verify/")) return "verify";
+  if (path === "/gallery" || path.startsWith("/gallery/")) return "gallery";
+  if (path === "/thought" || path.startsWith("/thought/")) return "thought";
+  if (path === "/pulse" || path.startsWith("/pulse/")) return "pulse";
+  if (path === "/path" || path.startsWith("/path/")) return "path";
+  return "unknown";
+}
+
+function contentIdForPath(path: string, contentType: AnonymousAnalyticsContentType) {
+  if (contentType !== "path" && contentType !== "thought" && contentType !== "gallery") return null;
+  const match = path.match(/\/(?:path|thought|gallery)\/([A-Za-z0-9_-]{1,64})(?:\/|$)/i);
+  return match ? sanitizeToken(match[1], 64) : null;
+}
+
+function normalizePath(value: unknown) {
+  const raw = typeof value === "string" ? value.trim() : "/";
+  if (!raw) return "/";
+  try {
+    const parsed = new URL(raw, "https://inshell.art");
+    return parsed.pathname.replace(/\/{2,}/g, "/").slice(0, 256) || "/";
+  } catch {
+    return "/";
+  }
+}
+
+function bucketDurationMs(value: number) {
+  const duration = Math.max(0, Math.min(600_000, Math.trunc(value)));
+  return DURATION_BUCKETS_MS.find((bucket) => duration <= bucket) ?? 600_000;
+}
+
+function categorizeError(error: unknown) {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error ?? "").toLowerCase();
+  if (message.includes("timeout")) return "timeout";
+  if (message.includes("network") || message.includes("fetch")) return "network";
+  if (message.includes("rpc")) return "rpc";
+  return "unknown";
+}
+
+function sanitizeToken(value: string, maxLength: number) {
+  return value.trim().replace(/[^A-Za-z0-9_.:/#-]+/g, "_").slice(0, maxLength);
+}
+
+function nowMs() {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
 }
 
 function normalizeHostname(value: string | null | undefined) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,15 @@
 export type SurfaceId = "path" | "thought";
 
-export { installInshellAnonymousAnalytics } from "./anonymousAnalytics";
-export type { AnonymousAnalyticsOptions } from "./anonymousAnalytics";
+export {
+  installInshellAnonymousAnalytics,
+  trackInshellAnonymousAnalytics,
+} from "./anonymousAnalytics";
+export type {
+  AnonymousAnalyticsContentType,
+  AnonymousAnalyticsEventType,
+  AnonymousAnalyticsOptions,
+  AnonymousAnalyticsTrackInput,
+} from "./anonymousAnalytics";
 
 export type PublicLaunchMode = "local" | "sepolia_invite" | "production";
 

--- a/packages/wallet/src/index.tsx
+++ b/packages/wallet/src/index.tsx
@@ -328,6 +328,54 @@ function chainLabel(chainId: number | null): { name: string; network: string } {
   return { name: "Unknown", network: "unknown" };
 }
 
+type WalletAnalyticsEventType =
+  | "wallet_connect_started"
+  | "wallet_connect_succeeded"
+  | "wallet_connect_failed";
+
+function trackWalletAnalytics(
+  eventType: WalletAnalyticsEventType,
+  metadata: Record<string, unknown>
+) {
+  try {
+    const analytics = typeof window === "undefined"
+      ? null
+      : (window as any).inshellAnalytics;
+    analytics?.track?.({
+      eventType,
+      metadata,
+    });
+  } catch {
+    /* analytics must never affect wallet flow */
+  }
+}
+
+function walletAnalyticsErrorCategory(error: unknown) {
+  const msg = String((error as any)?.message ?? error ?? "").toLowerCase();
+  const code = Number((error as any)?.code);
+  if (
+    code === 4001 ||
+    msg.includes("user rejected") ||
+    msg.includes("user reject") ||
+    msg.includes("user denied") ||
+    msg.includes("user cancelled") ||
+    msg.includes("user canceled")
+  ) return "wallet_rejected";
+  if (
+    code === -32002 ||
+    msg.includes("already processing") ||
+    msg.includes("already pending")
+  ) return "wallet_busy";
+  if (
+    msg.includes("no eip-1193 injected wallet found") ||
+    msg.includes("missing vite_walletconnect_project_id") ||
+    msg.includes("walletconnect v2 provider is unavailable")
+  ) return "wallet_missing";
+  if (msg.includes("rpc")) return "rpc";
+  if (msg.includes("network")) return "network";
+  return "unknown";
+}
+
 function walletConnectMetadata() {
   const hostname =
     typeof window === "undefined" ? "" : window.location.hostname.toLowerCase();
@@ -494,6 +542,10 @@ export function WalletProvider({ children }: WalletProviderProps) {
 
   const connectEip1193 = useCallback(async () => {
     setConnectStatus("connecting");
+    trackWalletAnalytics("wallet_connect_started", {
+      walletKind: "injected",
+      walletStage: "request_accounts",
+    });
     try {
       const discovered = await discoverEip6963Providers();
       const merged = mergeProviderDetails(evmProviders, discovered);
@@ -512,16 +564,29 @@ export function WalletProvider({ children }: WalletProviderProps) {
         setWalletConnectProvider(null);
       }
       setConnectedState(detail.provider, connected, detail.info.name || "Injected");
+      trackWalletAnalytics("wallet_connect_succeeded", {
+        walletKind: "injected",
+        walletStage: "connected",
+      });
       return connected;
     } catch (error) {
       setConnectError(error);
       setConnectStatus("error");
+      trackWalletAnalytics("wallet_connect_failed", {
+        walletKind: "injected",
+        walletStage: "request_accounts",
+        errorCategory: walletAnalyticsErrorCategory(error),
+      });
       throw error;
     }
   }, [evmProviders, setConnectedState, walletConnectProvider]);
 
   const connectWalletConnectV2 = useCallback(async () => {
     setConnectStatus("connecting");
+    trackWalletAnalytics("wallet_connect_started", {
+      walletKind: "walletconnect",
+      walletStage: "request_accounts",
+    });
     try {
       const projectIdRaw = getEnv("VITE_WALLETCONNECT_PROJECT_ID");
       if (typeof projectIdRaw !== "string" || !projectIdRaw.trim()) {
@@ -553,10 +618,19 @@ export function WalletProvider({ children }: WalletProviderProps) {
       };
       setWalletConnectProvider(wcProvider);
       setConnectedState(wcProvider, connected, "WalletConnect v2");
+      trackWalletAnalytics("wallet_connect_succeeded", {
+        walletKind: "walletconnect",
+        walletStage: "connected",
+      });
       return connected;
     } catch (error) {
       setConnectError(error);
       setConnectStatus("error");
+      trackWalletAnalytics("wallet_connect_failed", {
+        walletKind: "walletconnect",
+        walletStage: "request_accounts",
+        errorCategory: walletAnalyticsErrorCategory(error),
+      });
       throw error;
     }
   }, [setConnectedState]);
@@ -608,6 +682,10 @@ export function WalletProvider({ children }: WalletProviderProps) {
       }
       if (connector?.detail) {
         setConnectStatus("connecting");
+        trackWalletAnalytics("wallet_connect_started", {
+          walletKind: "injected",
+          walletStage: "request_accounts",
+        });
         try {
           const connected = await connectEip1193Provider(connector.detail);
           setConnectedState(
@@ -615,10 +693,19 @@ export function WalletProvider({ children }: WalletProviderProps) {
             connected,
             connector.detail.info.name || "Injected"
           );
+          trackWalletAnalytics("wallet_connect_succeeded", {
+            walletKind: "injected",
+            walletStage: "connected",
+          });
           return connected;
         } catch (error) {
           setConnectError(error);
           setConnectStatus("error");
+          trackWalletAnalytics("wallet_connect_failed", {
+            walletKind: "injected",
+            walletStage: "request_accounts",
+            errorCategory: walletAnalyticsErrorCategory(error),
+          });
           throw error;
         }
       }

--- a/scripts/smoke-cloudflare-api-routes.mjs
+++ b/scripts/smoke-cloudflare-api-routes.mjs
@@ -173,8 +173,10 @@ async function checkOpsStatus(base, label) {
       payload?.anonymousAnalytics?.identity !== "anonymous-browser-session" ||
       payload?.anonymousAnalytics?.rawIpStored !== false ||
       payload?.anonymousAnalytics?.rawUserAgentStored !== false ||
+      payload?.anonymousAnalytics?.rawVisitIdStored !== false ||
       payload?.anonymousAnalytics?.rawWalletAddressStored !== false ||
-      payload?.anonymousAnalytics?.metadataAllowlist !== true
+      payload?.anonymousAnalytics?.metadataAllowlist !== true ||
+      payload?.anonymousAnalytics?.visitTimeoutMinutes !== 30
     ) {
       throw new Error("expected anonymous analytics route contract and privacy flags");
     }

--- a/scripts/smoke-cloudflare-api-routes.mjs
+++ b/scripts/smoke-cloudflare-api-routes.mjs
@@ -169,9 +169,12 @@ async function checkOpsStatus(base, label) {
     }
     if (
       payload?.routes?.analytics?.eventRoute !== "/api/analytics/event" ||
+      payload?.routes?.analytics?.visitorRoute !== "/api/analytics/visitors" ||
       payload?.anonymousAnalytics?.identity !== "anonymous-browser-session" ||
       payload?.anonymousAnalytics?.rawIpStored !== false ||
-      payload?.anonymousAnalytics?.rawUserAgentStored !== false
+      payload?.anonymousAnalytics?.rawUserAgentStored !== false ||
+      payload?.anonymousAnalytics?.rawWalletAddressStored !== false ||
+      payload?.anonymousAnalytics?.metadataAllowlist !== true
     ) {
       throw new Error("expected anonymous analytics route contract and privacy flags");
     }

--- a/scripts/validate-production-surface.ts
+++ b/scripts/validate-production-surface.ts
@@ -216,6 +216,7 @@ function checkPackageScripts() {
     "/api/path-tokens",
     "/api/thought-gallery",
     "/api/analytics/event",
+    "/api/analytics/visitors",
     "anonymousAnalytics",
     "anonymous-browser-session",
     "/llms.txt",


### PR DESCRIPTION
## Summary
- add richer anonymous analytics event capture and OPS visitor timeline route
- persist analytics events with D1-backed privacy-safe hashed identities
- add logical visitId splitting after 30 minutes of inactivity
- expose OPS status flags for analytics privacy and visit counting

## Verification
- pnpm run lint
- pnpm run type-check
- pnpm run test:unit
- pnpm run test:thought-runtime
- pnpm run check:deployment
- pnpm run pub-boundary:check
- pnpm run build:home
- pnpm run build:thought
- git diff --check
- gitleaks detect --no-git --redact --no-banner
- staging smoke: node scripts/smoke-cloudflare-api-routes.mjs --home-base https://staging.inshell-art.pages.dev --thought-base https://staging.thought-inshell-art.pages.dev
- live staging synthetic visitor check confirmed one visitor, one session, two visits, and no raw IDs exposed

Operator approved production merge in Codex.