### PR TITLE
Promote gallery canonicalization

### DIFF
--- a/apps/home/src/components/Footer/Footer.tsx
+++ b/apps/home/src/components/Footer/Footer.tsx
@@ -77,9 +77,9 @@ function isLocalBrowserHost(): boolean {
 }
 
 function defaultGalleryUrl(): string {
-  if (isPreviewDeployment()) return "https://gallery.preview.inshell.art/";
+  if (isPreviewDeployment()) return "https://preview.inshell.art/gallery";
   if (isLocalBrowserHost()) return "http://127.0.0.1:5174/gallery";
-  return "https://gallery.inshell.art/";
+  return "https://inshell.art/gallery";
 }
 
 function resolveGalleryUrl(): string {

--- a/apps/home/src/components/ThoughtDetailPage.tsx
+++ b/apps/home/src/components/ThoughtDetailPage.tsx
@@ -59,9 +59,9 @@ function isLocalBrowserHost(): boolean {
 }
 
 function defaultGalleryUrl(): string {
-  if (isPreviewDeployment()) return "https://gallery.preview.inshell.art/";
+  if (isPreviewDeployment()) return "https://preview.inshell.art/gallery";
   if (isLocalBrowserHost()) return "http://127.0.0.1:5174/gallery";
-  return "https://gallery.inshell.art/";
+  return "https://inshell.art/gallery";
 }
 
 function galleryUrl(): string {

--- a/apps/home/src/components/VerifyPage.tsx
+++ b/apps/home/src/components/VerifyPage.tsx
@@ -193,7 +193,7 @@ export default function VerifyPage() {
               { id: "path-domain", label: "$PATH", value: "https://inshell.art" },
               { id: "path-route", label: "$PATH route", value: "https://inshell.art/path" },
               { id: "thought-domain", label: "THOUGHT", value: "https://thought.inshell.art" },
-              { id: "gallery-domain", label: "gallery", value: "https://gallery.inshell.art" },
+              { id: "gallery-domain", label: "gallery", value: "https://inshell.art/gallery" },
               { id: "network", label: "network", value: PUBLIC_NETWORK_CONFIG.environmentLabel },
               { id: "chain", label: "chain", value: PUBLIC_NETWORK_CONFIG.chainLabel },
               { id: "chain-id", label: "chain id", value: String(chainId) },
@@ -208,9 +208,9 @@ export default function VerifyPage() {
             rows={[
               { id: "origin-main", label: "inshell.art", value: "main Inshell surface" },
               { id: "origin-path", label: "inshell.art/path", value: "PATH / Pulse surface" },
+              { id: "origin-gallery", label: "inshell.art/gallery", value: "public gallery" },
               { id: "origin-verify", label: "inshell.art/verify", value: "verification room" },
               { id: "origin-thought", label: "thought.inshell.art", value: "THOUGHT movement app" },
-              { id: "origin-gallery", label: "gallery.inshell.art", value: "public gallery" },
               { id: "origin-preview", label: "preview.inshell.art", value: "preview / staging surface" },
             ]}
           />

--- a/apps/home/tests/App.test.tsx
+++ b/apps/home/tests/App.test.tsx
@@ -202,12 +202,12 @@ function expectedDefaultGalleryUrl() {
     return new globalThis.URL(configured).toString();
   }
   if (String(env.VITE_DEPLOY_ENV ?? "").toLowerCase() === "preview") {
-    return "https://gallery.preview.inshell.art/";
+    return "https://preview.inshell.art/gallery";
   }
   const hostname = window.location.hostname.toLowerCase();
   return hostname === "localhost" || hostname === "127.0.0.1"
     ? "http://127.0.0.1:5174/gallery"
-    : "https://gallery.inshell.art/";
+    : "https://inshell.art/gallery";
 }
 
 describe("App Component", () => {
@@ -641,7 +641,7 @@ describe("App Component", () => {
     expect(screen.getByText("https://inshell.art")).toBeInTheDocument();
     expect(screen.getByText("https://inshell.art/path")).toBeInTheDocument();
     expect(screen.getByText("https://thought.inshell.art")).toBeInTheDocument();
-    expect(screen.getByText("https://gallery.inshell.art")).toBeInTheDocument();
+    expect(screen.getByText("https://inshell.art/gallery")).toBeInTheDocument();
     expect(screen.getByText("official origins")).toBeInTheDocument();
     expect(screen.getByText("inshell.art/verify")).toBeInTheDocument();
     expect(screen.getByText("preview / staging surface")).toBeInTheDocument();
@@ -1137,14 +1137,14 @@ describe("App Component", () => {
 
   test("footer gallery uses configured gallery URL", () => {
     (globalThis as any).__VITE_ENV__ = {
-      VITE_GALLERY_URL: "https://gallery.preview.inshell.art/",
+      VITE_GALLERY_URL: "https://preview.inshell.art/gallery",
     };
 
     render(<App />);
 
     expect(screen.getByLabelText("Open gallery")).toHaveAttribute(
       "href",
-      "https://gallery.preview.inshell.art/",
+      "https://preview.inshell.art/gallery",
     );
   });
 
@@ -1186,7 +1186,7 @@ describe("App Component", () => {
 
     expect(screen.getByLabelText("Open gallery")).toHaveAttribute(
       "href",
-      "https://gallery.preview.inshell.art/",
+      "https://preview.inshell.art/gallery",
     );
   });
 

--- a/apps/home/tests/anonymousAnalyticsFunction.test.ts
+++ b/apps/home/tests/anonymousAnalyticsFunction.test.ts
@@ -450,9 +450,20 @@ describe("anonymous analytics Pages functions", () => {
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
     await onAnalyticsEventPost({
-      request: analyticsRequest("https://gallery.inshell.art/api/analytics/event", payload({ path: "/gallery" })),
+      request: analyticsRequest(
+        "https://gallery.inshell.art/api/analytics/event",
+        payload({ eventId: "event_legacy_gallery_12345678", path: "/legacy-gallery" }),
+      ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
+    await onAnalyticsEventPost({
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({ eventId: "event_canonical_gallery_12345678", path: "/gallery" }),
+      ),
+      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+    });
+    expect(d1.events.get("event_legacy_gallery_12345678")?.hostname).toBe("gallery.inshell.art");
 
     const unauthorized = await onAnalyticsSummaryGet({
       request: analyticsRequest("https://gallery.inshell.art/api/analytics/summary?days=1"),

--- a/apps/home/tests/cloudflareWebAnalytics.test.ts
+++ b/apps/home/tests/cloudflareWebAnalytics.test.ts
@@ -37,6 +37,7 @@ describe("Cloudflare Web Analytics install policy", () => {
 
   test("does not install on preview, ops, pages.dev, or local hosts", () => {
     const blockedHosts = [
+      "gallery.inshell.art",
       "preview.inshell.art",
       "thought.preview.inshell.art",
       "gallery.preview.inshell.art",
@@ -70,7 +71,7 @@ describe("Cloudflare Web Analytics install policy", () => {
     (globalThis as any).__INSHELL_VITE_ENV__ = env;
 
     expect(
-      maybeInstallCloudflareWebAnalytics({ document, hostname: "gallery.inshell.art" }),
+      maybeInstallCloudflareWebAnalytics({ document, hostname: "thought.inshell.art" }),
     ).toBe(true);
 
     expect(

--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -141,6 +141,66 @@ describe("Pages middleware canonical routes", () => {
     expect(ctx.assetsFetch).not.toHaveBeenCalled();
   });
 
+  test("permanently redirects gallery root to the canonical root gallery route", async () => {
+    const ctx = middlewareContext("https://gallery.inshell.art/");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("https://inshell.art/gallery");
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("preserves safe query strings on gallery host redirects", async () => {
+    const ctx = middlewareContext("https://gallery.inshell.art/thought/9?ref=x");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("https://inshell.art/thought/9?ref=x");
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("permanently redirects preview gallery host to the preview root gallery route", async () => {
+    const ctx = middlewareContext("https://gallery.preview.inshell.art/");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("https://preview.inshell.art/gallery");
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("does not redirect legacy gallery analytics API traffic", async () => {
+    const ctx = middlewareContext("https://gallery.inshell.art/api/analytics/event", { method: "POST" });
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(ctx.next).toHaveBeenCalledTimes(1);
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("does not redirect standalone THOUGHT host root to gallery", async () => {
+    const ctx = middlewareContext("https://thought.inshell.art/");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
+    expect(ctx.next).not.toHaveBeenCalled();
+  });
+
+  test("serves canonical root gallery route through the root app shell", async () => {
+    const ctx = middlewareContext("https://inshell.art/gallery");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
+    expect(response.headers.get("clear-site-data")).toBeNull();
+    expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
+    expect(ctx.next).not.toHaveBeenCalled();
+  });
+
   test("routes PUB reserved paths to the PUB upstream before the app shell", async () => {
     const fetchMock = jest.fn(
       async () =>

--- a/apps/thought/index.html
+++ b/apps/thought/index.html
@@ -341,7 +341,7 @@
 
           <div hidden>
             <a id="thought-instructions-link" href="#" target="_blank" rel="noopener noreferrer">THOUGHT.md</a>
-            <a id="thought-gallery-link" href="https://gallery.inshell.art/">gallery</a>
+            <a id="thought-gallery-link" href="https://inshell.art/gallery">gallery</a>
           </div>
         </div>
       </div>
@@ -597,7 +597,7 @@
           <h1 id="thought-detail-title" class="thought-detail__title">THOUGHT #<span id="thought-detail-token-id">-</span></h1>
         </div>
         <nav class="thought-detail__links" aria-label="THOUGHT detail links">
-          <a id="thought-detail-gallery-link" class="thought-detail__link" href="https://gallery.inshell.art/">[ gallery ]</a>
+          <a id="thought-detail-gallery-link" class="thought-detail__link" href="https://inshell.art/gallery">[ gallery ]</a>
           <a id="thought-detail-create-link" class="thought-detail__link" href="https://thought.inshell.art/">[ create yours ]</a>
         </nav>
       </header>

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -863,8 +863,8 @@ const GALLERY_URL =
   (LOCAL_BROWSER_HOSTS.has(window.location.hostname)
     ? ""
     : IS_PREVIEW_DEPLOYMENT
-      ? "https://gallery.preview.inshell.art/"
-      : "https://gallery.inshell.art/");
+      ? "https://preview.inshell.art/gallery"
+      : "https://inshell.art/gallery");
 const THOUGHT_APP_URL =
   readConfiguredUrl("VITE_THOUGHT_URL") ||
   (LOCAL_BROWSER_HOSTS.has(window.location.hostname)

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -27,9 +27,13 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   }
 
   const pathname = normalizePathname(url.pathname);
+  const galleryRedirect = canonicalGalleryHostRedirect(ctx.request, url, pathname);
   const sepoliaRedirect = temporarySepoliaHostRedirect(url);
   const thoughtRedirect = canonicalThoughtRedirect(url, pathname);
 
+  if (galleryRedirect) {
+    return galleryRedirect;
+  }
   if (sepoliaRedirect) {
     return sepoliaRedirect;
   }
@@ -192,6 +196,43 @@ function temporarySepoliaHostRedirect(url: UrlInstance) {
   const target = new globalThis.URL(url.pathname, "https://inshell.art");
   target.search = url.search;
   return Response.redirect(target.toString(), 302);
+}
+
+function canonicalGalleryHostRedirect(request: Request, url: UrlInstance, pathname: string) {
+  const hostname = url.hostname.toLowerCase();
+  if (!isCanonicalGalleryRedirectHost(hostname)) return null;
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  if (isApiPathname(pathname) || isLikelyStaticAssetPathname(url.pathname)) return null;
+
+  const target = new globalThis.URL(
+    canonicalGalleryPathname(pathname),
+    hostname === "gallery.preview.inshell.art"
+      ? "https://preview.inshell.art"
+      : "https://inshell.art",
+  );
+  target.search = url.search;
+  return Response.redirect(target.toString(), 308);
+}
+
+function isCanonicalGalleryRedirectHost(hostname: string) {
+  return hostname === "gallery.inshell.art" || hostname === "gallery.preview.inshell.art";
+}
+
+function isApiPathname(pathname: string) {
+  return pathname === "/api" || pathname.startsWith("/api/");
+}
+
+function isLikelyStaticAssetPathname(pathname: string) {
+  return (
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/") ||
+    /\.(?:css|js|mjs|map|png|jpg|jpeg|gif|svg|webp|ico|woff2?|ttf|otf|json|txt|xml)$/i.test(pathname)
+  );
+}
+
+function canonicalGalleryPathname(pathname: string) {
+  if (pathname === "/" || pathname === "/gallery") return "/gallery";
+  return isAppShellRoute(pathname) ? pathname : "/gallery";
 }
 
 function normalizePathname(pathname: string) {

--- a/functions/api/analytics/store.ts
+++ b/functions/api/analytics/store.ts
@@ -206,14 +206,16 @@ const EVENT_TYPE_SET = new Set<string>(ANALYTICS_EVENT_TYPES);
 const CONTENT_TYPE_SET = new Set<string>(ANALYTICS_CONTENT_TYPES);
 const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
 
-const PRODUCTION_HOSTS = ["inshell.art", "thought.inshell.art", "gallery.inshell.art"];
-const PREVIEW_HOSTS = ["preview.inshell.art", "thought.preview.inshell.art", "gallery.preview.inshell.art"];
+const PRODUCTION_HOSTS = ["inshell.art", "thought.inshell.art"];
+const PREVIEW_HOSTS = ["preview.inshell.art", "thought.preview.inshell.art"];
 const STAGING_HOSTS = ["staging.inshell-art.pages.dev", "staging.thought-inshell-art.pages.dev"];
+const LEGACY_GALLERY_HOSTS = ["gallery.inshell.art", "gallery.preview.inshell.art"];
 
 const ALLOWED_HOSTS = new Set([
   ...PRODUCTION_HOSTS,
   ...PREVIEW_HOSTS,
   ...STAGING_HOSTS,
+  ...LEGACY_GALLERY_HOSTS,
   "inshell-art.pages.dev",
   "thought-inshell-art.pages.dev",
 ]);
@@ -275,7 +277,13 @@ export function analyticsHostScopeForHostname(hostname: string): AnalyticsHostSc
   if (PRODUCTION_HOSTS.includes(normalized)) {
     return { name: "production", hostnames: PRODUCTION_HOSTS };
   }
+  if (normalized === "gallery.inshell.art") {
+    return { name: "production", hostnames: PRODUCTION_HOSTS };
+  }
   if (PREVIEW_HOSTS.includes(normalized)) {
+    return { name: "preview", hostnames: PREVIEW_HOSTS };
+  }
+  if (normalized === "gallery.preview.inshell.art") {
     return { name: "preview", hostnames: PREVIEW_HOSTS };
   }
   if (

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -130,9 +130,9 @@ export const SURFACE_DEPLOYMENT_MANIFEST = {
     gallery: {
       id: "gallery",
       product: "Gallery",
-      domain: "https://gallery.inshell.art",
+      domain: "https://inshell.art",
       role: "Public gallery for movement works.",
-      canonicalPath: "/",
+      canonicalPath: "/gallery",
     },
   },
   contractIds: {
@@ -425,7 +425,6 @@ export const CLOUDFLARE_WEB_ANALYTICS_SCRIPT_ID = "inshell-cloudflare-web-analyt
 export const CLOUDFLARE_WEB_ANALYTICS_ALLOWED_HOSTS = [
   "inshell.art",
   "thought.inshell.art",
-  "gallery.inshell.art",
 ] as const;
 
 function normalizeHostname(value: string | null | undefined): string {


### PR DESCRIPTION
Summary:
- Canonicalize gallery hosts to the main /gallery route with 308 navigation redirects.
- Keep legacy gallery analytics beacons accepted while excluding gallery hosts from normal counted production/preview scopes.
- Update canonical gallery links and verification copy to inshell.art/gallery.

Checks:
- pnpm run lint
- pnpm run type-check
- pnpm run test:unit
- pnpm run check:deployment
- pnpm run pub-boundary:check
- pnpm run build:home
- pnpm run build:thought
- gitleaks detect --no-git --redact --no-banner

Staging:
- staging.inshell-art.pages.dev/api/ops/status reports commit 7c498875c335132eebdfaf42581f206a1c9e2955
- staging.inshell-art.pages.dev/gallery returns 200

Note:
- custom preview hosts are still behind Cloudflare Access, so unauthenticated curl reaches Access before Pages middleware.