### PR TITLE
Promote shared-cookie analytics identity

### DIFF
--- a/apps/home/tests/anonymousAnalytics.test.ts
+++ b/apps/home/tests/anonymousAnalytics.test.ts
@@ -60,6 +60,7 @@ describe("Inshell anonymous analytics client", () => {
     const [, init] = fetchMock.mock.calls[0] as [string, globalThis.RequestInit];
     expect(init.method).toBe("POST");
     expect(init.keepalive).toBe(true);
+    expect(init.credentials).toBe("same-origin");
     const payload = JSON.parse(String(init.body));
     expect(payload).toMatchObject({
       version: 1,
@@ -70,9 +71,9 @@ describe("Inshell anonymous analytics client", () => {
       title: "$PATH",
       automation: false,
     });
-    expect(payload.visitorId).toBe("12345678-1234-4234-9234-123456789abc");
-    expect(payload.sessionId).toBe("12345678-1234-4234-9234-123456789abc");
-    expect(payload.visitId).toBe("12345678-1234-4234-9234-123456789abc");
+    expect(payload.visitorId).toBeUndefined();
+    expect(payload.sessionId).toBeUndefined();
+    expect(payload.visitId).toBeUndefined();
   });
 
   test("exposes a manual tracker for typed action events", async () => {
@@ -142,17 +143,17 @@ describe("Inshell anonymous analytics client", () => {
 
     expect(
       installInshellAnonymousAnalytics({
-        hostname: "inshell.art",
+        hostname: "staging.inshell-art.pages.dev",
         window,
         document,
         navigator: testNavigator,
         location: {
-          href: "https://inshell.art/path/25",
-          hostname: "inshell.art",
+          href: "https://staging.inshell-art.pages.dev/path/25",
+          hostname: "staging.inshell-art.pages.dev",
           pathname: "/path/25",
           search: "",
           hash: "",
-          origin: "https://inshell.art",
+          origin: "https://staging.inshell-art.pages.dev",
         },
       }),
     ).toBe(true);

--- a/apps/home/tests/anonymousAnalyticsFunction.test.ts
+++ b/apps/home/tests/anonymousAnalyticsFunction.test.ts
@@ -12,20 +12,44 @@ const originalResponse = globalThis.Response;
 const originalHeaders = globalThis.Headers;
 
 class TestHeaders {
-  private readonly values = new Map<string, string>();
+  private readonly values = new Map<string, string[]>();
 
-  constructor(init?: Record<string, string>) {
-    for (const [key, value] of Object.entries(init ?? {})) {
+  constructor(init?: Record<string, string> | Iterable<[string, string]> | { forEach: (callback: (value: string, key: string) => void) => void }) {
+    if (!init) return;
+    if (typeof (init as { forEach?: unknown }).forEach === "function") {
+      (init as { forEach: (callback: (value: string, key: string) => void) => void }).forEach((value, key) => {
+        this.append(key, value);
+      });
+      return;
+    }
+    if (Symbol.iterator in Object(init)) {
+      for (const [key, value] of init as Iterable<[string, string]>) {
+        this.append(key, value);
+      }
+      return;
+    }
+    for (const [key, value] of Object.entries(init)) {
       this.set(key, value);
     }
   }
 
   set(key: string, value: string) {
-    this.values.set(key.toLowerCase(), value);
+    this.values.set(key.toLowerCase(), [value]);
+  }
+
+  append(key: string, value: string) {
+    const normalized = key.toLowerCase();
+    this.values.set(normalized, [...(this.values.get(normalized) ?? []), value]);
   }
 
   get(key: string) {
-    return this.values.get(key.toLowerCase()) ?? null;
+    return this.values.get(key.toLowerCase())?.join("\n") ?? null;
+  }
+
+  forEach(callback: (value: string, key: string) => void) {
+    for (const [key, values] of this.values.entries()) {
+      callback(values.join("\n"), key);
+    }
   }
 }
 
@@ -34,7 +58,7 @@ class TestResponse {
   readonly headers: TestHeaders;
   private readonly bodyText: string;
 
-  constructor(body?: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+  constructor(body?: unknown, init?: { status?: number; headers?: ConstructorParameters<typeof TestHeaders>[0] }) {
     this.status = init?.status ?? 200;
     this.headers = new TestHeaders(init?.headers);
     this.bodyText = typeof body === "string" ? body : "";
@@ -286,10 +310,17 @@ function createAnalyticsD1Mock() {
   };
 }
 
-function analyticsRequest(url: string, payload?: unknown, token?: string): Request {
+function analyticsRequest(
+  url: string,
+  payload?: unknown,
+  token?: string,
+  headersInit: Record<string, string> = {},
+): Request {
+  const headers = new Headers(headersInit);
+  if (token) headers.set("authorization", `Bearer ${token}`);
   return {
     url,
-    headers: new Headers(token ? { authorization: `Bearer ${token}` } : undefined),
+    headers,
     text: async () => JSON.stringify(payload ?? {}),
   } as Request;
 }
@@ -311,6 +342,18 @@ function payload(overrides: Record<string, unknown> = {}) {
     automation: false,
     ...overrides,
   };
+}
+
+function sharedCookieHeader(
+  visitor = "shared_visitor_12345678",
+  session = "shared_session_12345678",
+  visit = "shared_visit_12345678",
+) {
+  return `${[
+    `inshell_anon_visitor=${visitor}`,
+    `inshell_anon_session=${session}`,
+    `inshell_anon_visit=${visit}`,
+  ].join("; ")}`;
 }
 
 describe("anonymous analytics Pages functions", () => {
@@ -346,18 +389,32 @@ describe("anonymous analytics Pages functions", () => {
     jest.restoreAllMocks();
   });
 
-  test("records pageviews without storing raw visitor or session ids", async () => {
+  test("records shared-cookie pageviews without storing raw visitor or session ids", async () => {
     const d1 = createAnalyticsD1Mock();
     const response = await onAnalyticsEventPost({
-      request: analyticsRequest("https://inshell.art/api/analytics/event", payload()),
+      request: analyticsRequest(
+        "https://inshell.art/api/analytics/event",
+        payload({ visitorId: undefined, sessionId: undefined, visitId: undefined }),
+      ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
 
-    await expect(response.json()).resolves.toMatchObject({
+    const body = await response.json() as any;
+    expect(body).toMatchObject({
       ok: true,
       stored: true,
       duplicate: false,
     });
+    expect(body.setCookies).toBeUndefined();
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("inshell_anon_visitor=");
+    expect(setCookie).toContain("Max-Age=31536000");
+    expect(setCookie).toContain("inshell_anon_session=");
+    expect(setCookie).toContain("inshell_anon_visit=");
+    expect(setCookie).toContain("Max-Age=1800");
+    expect(setCookie).toContain("Domain=.inshell.art");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
     const event = [...d1.events.values()][0];
     expect(event.path).toBe("/path/25");
     expect(event.content_type).toBe("path");
@@ -373,7 +430,7 @@ describe("anonymous analytics Pages functions", () => {
     const d1 = createAnalyticsD1Mock();
     const response = await onAnalyticsEventPost({
       request: analyticsRequest(
-        "https://inshell.art/api/analytics/event",
+        "https://staging.inshell-art.pages.dev/api/analytics/event",
         payload({ eventId: "event_legacy_12345678", visitId: undefined }),
       ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
@@ -493,6 +550,16 @@ describe("anonymous analytics Pages functions", () => {
 
   test("returns privacy-safe visitor timelines behind bearer auth", async () => {
     const d1 = createAnalyticsD1Mock();
+    const firstVisitCookie = sharedCookieHeader(
+      "journey_visitor_12345678",
+      "journey_session_12345678",
+      "journey_visit_one_12345678",
+    );
+    const secondVisitCookie = sharedCookieHeader(
+      "journey_visitor_12345678",
+      "journey_session_12345678",
+      "journey_visit_two_12345678",
+    );
     await onAnalyticsEventPost({
       request: analyticsRequest(
         "https://inshell.art/api/analytics/event",
@@ -501,6 +568,8 @@ describe("anonymous analytics Pages functions", () => {
           path: "/path/25",
           referrer: "https://example.com/source",
         }),
+        undefined,
+        { cookie: firstVisitCookie },
       ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
@@ -516,16 +585,18 @@ describe("anonymous analytics Pages functions", () => {
             walletAddress: "0x1234567890123456789012345678901234567890",
           },
         }),
+        undefined,
+        { cookie: firstVisitCookie },
       ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
     await onAnalyticsEventPost({
       request: analyticsRequest(
-        "https://inshell.art/api/analytics/event",
+        "https://thought.inshell.art/api/analytics/event",
         payload({
           eventId: "event_wallet_fail_12345678",
           eventType: "wallet_connect_failed",
-          path: "/path/25",
+          path: "/thought/17",
           metadata: {
             walletKind: "injected",
             walletStage: "request_accounts",
@@ -533,6 +604,8 @@ describe("anonymous analytics Pages functions", () => {
             prompt: "private prompt",
           },
         }),
+        undefined,
+        { cookie: firstVisitCookie },
       ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
@@ -541,10 +614,10 @@ describe("anonymous analytics Pages functions", () => {
         "https://inshell.art/api/analytics/event",
         payload({
           eventId: "event_return_12345678",
-          sessionId: "session_12345678",
-          visitId: "visit_return_12345678",
           path: "/gallery",
         }),
+        undefined,
+        { cookie: secondVisitCookie },
       ),
       env: { INSHELL_CHAIN_DATA_DB: d1.db },
     });
@@ -577,6 +650,7 @@ describe("anonymous analytics Pages functions", () => {
       visitors: [
         {
           visitorRank: 1,
+          visitorKey: expect.stringMatching(/^v_[a-f0-9]{12}$/),
           eventCount: 4,
           pageViews: 2,
           sessions: 1,
@@ -598,6 +672,12 @@ describe("anonymous analytics Pages functions", () => {
       "wallet_connect_failed",
       "pageview",
     ]);
+    expect(body.visitors[0].timeline.map((event: any) => event.hostname)).toEqual([
+      "inshell.art",
+      "inshell.art",
+      "thought.inshell.art",
+      "inshell.art",
+    ]);
     expect(body.visitors[0].timeline.map((event: any) => event.visitRank)).toEqual([1, 1, 1, 2]);
     expect(body.visitors[0].visits).toHaveLength(2);
     expect(body.visitors[0].visits.map((visit: any) => visit.visitRank)).toEqual([1, 2]);
@@ -613,7 +693,10 @@ describe("anonymous analytics Pages functions", () => {
     expect(serialized).not.toContain("visitor_12345678");
     expect(serialized).not.toContain("session_12345678");
     expect(serialized).not.toContain("visit_12345678");
-    expect(serialized).not.toContain("visit_return_12345678");
+    expect(serialized).not.toContain("journey_visitor_12345678");
+    expect(serialized).not.toContain("journey_session_12345678");
+    expect(serialized).not.toContain("journey_visit_one_12345678");
+    expect(serialized).not.toContain("journey_visit_two_12345678");
     expect(serialized).not.toContain("walletAddress");
     expect(serialized).not.toContain("private prompt");
     expect(serialized).not.toContain("staging-only");
@@ -633,11 +716,15 @@ describe("anonymous analytics Pages functions", () => {
       ),
     ).resolves.toMatchObject({
       enabled: true,
+      identityMode: "shared_cookie",
+      sharedCookieDomain: ".inshell.art",
       hostScope: "production",
       dbBound: true,
       dbBinding: "INSHELL_CHAIN_DATA_DB",
       rawIpStored: false,
       rawUserAgentStored: false,
+      rawVisitorIdStored: false,
+      rawSessionIdStored: false,
       rawVisitIdStored: false,
       rawWalletAddressStored: false,
       metadataAllowlist: true,

--- a/functions/api/analytics/event.ts
+++ b/functions/api/analytics/event.ts
@@ -13,7 +13,8 @@ export async function onRequestPost(ctx: PagesContextLike): Promise<Response> {
   try {
     const payload = await readAnalyticsRequest(ctx.request);
     const result = await recordAnalyticsEvent(ctx.env, ctx.request, payload);
-    return analyticsJson(200, result);
+    const { setCookies, ...body } = result;
+    return analyticsJson(200, body, { setCookies });
   } catch (error) {
     if (error instanceof AnalyticsInputError) {
       return analyticsJson(error.status, {

--- a/functions/api/analytics/store.ts
+++ b/functions/api/analytics/store.ts
@@ -101,12 +101,16 @@ export type AnalyticsStatus = {
   summaryRoute: string;
   visitorRoute: string;
   identity: "anonymous-browser-session";
+  identityMode: "shared_cookie";
+  sharedCookieDomain: ".inshell.art";
   hostScope: AnalyticsHostScope["name"];
   countedHosts: string[];
   dbBound: boolean;
   dbBinding: "INSHELL_ANALYTICS_DB" | "INSHELL_CHAIN_DATA_DB" | null;
   rawIpStored: false;
   rawUserAgentStored: false;
+  rawVisitorIdStored: false;
+  rawSessionIdStored: false;
   rawVisitIdStored: false;
   rawWalletAddressStored: false;
   rawMetadataStored: false;
@@ -171,6 +175,7 @@ export type AnalyticsVisitors = {
   };
   visitors: Array<{
     visitorRank: number;
+    visitorKey: string;
     firstSeenAt: string | null;
     lastSeenAt: string | null;
     eventCount: number;
@@ -202,6 +207,12 @@ const MAX_REFERRER_PATH_LENGTH = 256;
 const MAX_METADATA_JSON_LENGTH = 1024;
 const HASH_PREFIX = "inshell-anon-analytics:v1:";
 const VISIT_TIMEOUT_MINUTES = 30;
+const SHARED_COOKIE_DOMAIN = ".inshell.art";
+const SHARED_VISITOR_COOKIE = "inshell_anon_visitor";
+const SHARED_SESSION_COOKIE = "inshell_anon_session";
+const SHARED_VISIT_COOKIE = "inshell_anon_visit";
+const SHARED_VISITOR_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+const SHARED_VISIT_MAX_AGE_SECONDS = VISIT_TIMEOUT_MINUTES * 60;
 const EVENT_TYPE_SET = new Set<string>(ANALYTICS_EVENT_TYPES);
 const CONTENT_TYPE_SET = new Set<string>(ANALYTICS_CONTENT_TYPES);
 const DURATION_BUCKETS_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000];
@@ -222,18 +233,26 @@ const ALLOWED_HOSTS = new Set([
 
 const ensuredTables = new WeakSet<object>();
 
-export function analyticsJson(status: number, body: unknown): Response {
+export function analyticsJson(
+  status: number,
+  body: unknown,
+  options: { setCookies?: string[] } = {},
+): Response {
+  const headers = new Headers({
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET, POST, OPTIONS",
+    "access-control-allow-headers": "content-type, authorization, x-inshell-analytics-token",
+    "access-control-max-age": "86400",
+    "x-content-type-options": "nosniff",
+  });
+  for (const cookie of options.setCookies ?? []) {
+    headers.append("set-cookie", cookie);
+  }
   return new Response(JSON.stringify(body), {
     status,
-    headers: {
-      "content-type": "application/json; charset=utf-8",
-      "cache-control": "no-store",
-      "access-control-allow-origin": "*",
-      "access-control-allow-methods": "GET, POST, OPTIONS",
-      "access-control-allow-headers": "content-type, authorization, x-inshell-analytics-token",
-      "access-control-max-age": "86400",
-      "x-content-type-options": "nosniff",
-    },
+    headers,
   });
 }
 
@@ -338,7 +357,8 @@ export async function recordAnalyticsEvent(
     throw new AnalyticsInputError("analytics host is not allowed", 403);
   }
 
-  const normalized = normalizeAnalyticsEvent(payload, hostname);
+  const identity = resolveAnalyticsIdentity(request, payload, hostname);
+  const normalized = normalizeAnalyticsEvent(payload, hostname, identity);
   await ensureAnalyticsTables(db);
 
   const existing = await db
@@ -351,6 +371,7 @@ export async function recordAnalyticsEvent(
       stored: false,
       duplicate: true,
       eventId: normalized.eventId,
+      setCookies: identity.setCookies,
     };
   }
 
@@ -415,6 +436,7 @@ export async function recordAnalyticsEvent(
     stored: true,
     duplicate: false,
     eventId: normalized.eventId,
+    setCookies: identity.setCookies,
   };
 }
 
@@ -432,12 +454,16 @@ export async function readAnalyticsStatus(
     summaryRoute: "/api/analytics/summary",
     visitorRoute: "/api/analytics/visitors",
     identity: "anonymous-browser-session",
+    identityMode: "shared_cookie",
+    sharedCookieDomain: SHARED_COOKIE_DOMAIN,
     hostScope: hostScope.name,
     countedHosts: hostScope.hostnames,
     dbBound: Boolean(db),
     dbBinding: binding,
     rawIpStored: false,
     rawUserAgentStored: false,
+    rawVisitorIdStored: false,
+    rawSessionIdStored: false,
     rawVisitIdStored: false,
     rawWalletAddressStored: false,
     rawMetadataStored: false,
@@ -619,6 +645,7 @@ export async function readAnalyticsVisitors(
         const visitCount = Number(visitor.visits ?? 0);
         return {
           visitorRank: visitor.rank,
+          visitorKey: visitorKeyForHash(visitor.visitorHash),
           firstSeenAt: visitor.firstSeenAt ?? null,
           lastSeenAt: visitor.lastSeenAt ?? null,
           eventCount: Number(visitor.eventCount ?? 0),
@@ -848,12 +875,60 @@ async function ensureAnalyticsTables(db: D1DatabaseLike) {
   ensuredTables.add(db as object);
 }
 
-function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: string) {
+type AnalyticsIdentity = {
+  visitorId: string;
+  sessionId: string;
+  visitId: string;
+  setCookies: string[];
+};
+
+function resolveAnalyticsIdentity(
+  request: Request,
+  payload: AnalyticsEventPayload,
+  hostname: string,
+): AnalyticsIdentity {
+  const cookieDomain = sharedCookieDomainForHostname(hostname);
+  if (!cookieDomain) {
+    const visitorId = normalizedId(payload.visitorId, "visitorId");
+    const sessionId = normalizedId(payload.sessionId, "sessionId");
+    return {
+      visitorId,
+      sessionId,
+      visitId: normalizedOptionalId(payload.visitId, "visitId") ?? sessionId,
+      setCookies: [],
+    };
+  }
+
+  const cookies = parseCookieHeader(request.headers.get("cookie") ?? "");
+  const visitorId = normalizedCookieId(cookies.get(SHARED_VISITOR_COOKIE)) ?? createSharedCookieId();
+  const sessionId = normalizedCookieId(cookies.get(SHARED_SESSION_COOKIE)) ?? createSharedCookieId();
+  const visitId = normalizedCookieId(cookies.get(SHARED_VISIT_COOKIE)) ?? createSharedCookieId();
+
+  return {
+    visitorId,
+    sessionId,
+    visitId,
+    setCookies: [
+      sharedCookie(SHARED_VISITOR_COOKIE, visitorId, {
+        domain: cookieDomain,
+        maxAge: SHARED_VISITOR_MAX_AGE_SECONDS,
+      }),
+      sharedCookie(SHARED_SESSION_COOKIE, sessionId, { domain: cookieDomain }),
+      sharedCookie(SHARED_VISIT_COOKIE, visitId, {
+        domain: cookieDomain,
+        maxAge: SHARED_VISIT_MAX_AGE_SECONDS,
+      }),
+    ],
+  };
+}
+
+function normalizeAnalyticsEvent(
+  payload: AnalyticsEventPayload,
+  hostname: string,
+  identity: AnalyticsIdentity,
+) {
   if (payload.version !== 1) throw new AnalyticsInputError("version must be 1");
   const eventId = normalizedId(payload.eventId, "eventId");
-  const visitorId = normalizedId(payload.visitorId, "visitorId");
-  const sessionId = normalizedId(payload.sessionId, "sessionId");
-  const visitId = normalizedOptionalId(payload.visitId, "visitId") ?? sessionId;
   const eventType = normalizeEventType(payload.eventType);
   const path = normalizePath(payload.path);
   const contentType = normalizeContentType(payload.contentType, path);
@@ -861,9 +936,9 @@ function normalizeAnalyticsEvent(payload: AnalyticsEventPayload, hostname: strin
   const metadata = normalizeEventMetadata(eventType, payload.metadata);
   return {
     eventId,
-    visitorId,
-    sessionId,
-    visitId,
+    visitorId: identity.visitorId,
+    sessionId: identity.sessionId,
+    visitId: identity.visitId,
     eventType,
     surface: surfaceForHost(hostname),
     hostname,
@@ -901,6 +976,52 @@ function normalizedId(value: unknown, label: string) {
 function normalizedOptionalId(value: unknown, label: string) {
   if (value == null) return null;
   return normalizedId(value, label);
+}
+
+function sharedCookieDomainForHostname(hostname: string): ".inshell.art" | null {
+  return hostname === "inshell.art" || hostname.endsWith(".inshell.art")
+    ? SHARED_COOKIE_DOMAIN
+    : null;
+}
+
+function parseCookieHeader(header: string) {
+  const cookies = new Map<string, string>();
+  for (const part of header.split(";")) {
+    const separatorIndex = part.indexOf("=");
+    if (separatorIndex <= 0) continue;
+    const key = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+    if (!key) continue;
+    try {
+      cookies.set(key, decodeURIComponent(value));
+    } catch {
+      cookies.set(key, value);
+    }
+  }
+  return cookies;
+}
+
+function normalizedCookieId(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return /^[A-Za-z0-9_-][A-Za-z0-9_-]{7,95}$/.test(trimmed) ? trimmed : null;
+}
+
+function sharedCookie(
+  name: string,
+  value: string,
+  options: { domain: ".inshell.art"; maxAge?: number },
+) {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    `Domain=${options.domain}`,
+    "Path=/",
+    "Secure",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (options.maxAge != null) parts.push(`Max-Age=${Math.trunc(options.maxAge)}`);
+  return parts.join("; ");
 }
 
 function normalizePath(value: unknown) {
@@ -1121,6 +1242,10 @@ function numberOrNull(value: unknown) {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
+function visitorKeyForHash(visitorHash: string) {
+  return `v_${visitorHash.slice(0, 12)}`;
+}
+
 function normalizeHostname(value: string) {
   return value.trim().toLowerCase().replace(/\.$/, "");
 }
@@ -1167,6 +1292,21 @@ async function hashIdentifier(value: string) {
   const bytes = new TextEncoder().encode(`${HASH_PREFIX}${value}`);
   const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function createSharedCookieId() {
+  if (typeof globalThis.crypto.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof globalThis.crypto.getRandomValues === "function") {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function isMissingAnalyticsTableError(error: unknown) {

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -56,9 +56,13 @@ const ROUTES = {
     summaryAuth: "bearer-token-required",
     visitorAuth: "bearer-token-required",
     identity: "anonymous-browser-session",
+    identityMode: "shared_cookie",
+    sharedCookieDomain: ".inshell.art",
     privacy: {
       rawIpStored: false,
       rawUserAgentStored: false,
+      rawVisitorIdStored: false,
+      rawSessionIdStored: false,
       rawVisitIdStored: false,
       rawWalletAddressStored: false,
       metadataAllowlist: true,

--- a/packages/shared/src/anonymousAnalytics.ts
+++ b/packages/shared/src/anonymousAnalytics.ts
@@ -84,9 +84,14 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
   if (!isAnalyticsHostAllowed(hostname)) return false;
   if (isAnalyticsDisabled(options.env)) return false;
 
-  const visitorId = readOrCreateWindowStorageId(windowRef, "localStorage", VISITOR_STORAGE_KEY);
-  const sessionId = readOrCreateWindowStorageId(windowRef, "sessionStorage", SESSION_STORAGE_KEY);
-  if (!visitorId || !sessionId) return false;
+  const sharedCookieIdentity = usesSharedCookieIdentity(hostname);
+  const legacyIdentity = sharedCookieIdentity
+    ? null
+    : {
+        visitorId: readOrCreateWindowStorageId(windowRef, "localStorage", VISITOR_STORAGE_KEY),
+        sessionId: readOrCreateWindowStorageId(windowRef, "sessionStorage", SESSION_STORAGE_KEY),
+      };
+  if (legacyIdentity && (!legacyIdentity.visitorId || !legacyIdentity.sessionId)) return false;
 
   analyticsWindow.__INSHELL_ANON_ANALYTICS_INSTALLED__ = true;
   const endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
@@ -95,16 +100,21 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
   let emittedScrollBuckets = new Set<number>();
 
   const track = (input: AnonymousAnalyticsTrackInput) => {
-    const visit = readOrCreateVisitState(windowRef, Date.now());
-    const visitId = visit?.id ?? sessionId;
+    const visit = sharedCookieIdentity ? null : readOrCreateVisitState(windowRef, Date.now());
+    const visitId = visit?.id ?? legacyIdentity?.sessionId;
     const path = normalizePath(input.path ?? locationRef.pathname);
     const content = contentForPath(path, input.contentType, input.contentId);
+    const identityPayload = legacyIdentity
+      ? {
+          visitorId: legacyIdentity.visitorId,
+          sessionId: legacyIdentity.sessionId,
+          visitId,
+        }
+      : {};
     sendAnalyticsEvent(endpoint, {
       version: 1,
       eventId: createId(),
-      visitorId,
-      sessionId,
-      visitId,
+      ...identityPayload,
       eventType: input.eventType,
       path,
       contentType: content.contentType,
@@ -120,8 +130,8 @@ export function installInshellAnonymousAnalytics(options: AnonymousAnalyticsOpti
       automation: navigatorRef.webdriver === true,
       metadata: input.metadata ?? {},
     }, navigatorRef, () => {
-      updateVisitActivity(windowRef, visitId, Date.now());
-    });
+      if (visitId) updateVisitActivity(windowRef, visitId, Date.now());
+    }, sharedCookieIdentity);
     return true;
   };
 
@@ -191,9 +201,10 @@ function sendAnalyticsEvent(
   payload: Record<string, unknown>,
   navigatorRef: globalThis.Navigator,
   onAccepted?: () => void,
+  fetchOnly = false,
 ) {
   const body = JSON.stringify(payload);
-  if (typeof navigatorRef.sendBeacon === "function") {
+  if (!fetchOnly && typeof navigatorRef.sendBeacon === "function") {
     try {
       if (navigatorRef.sendBeacon(endpoint, new globalThis.Blob([body], { type: "application/json" }))) {
         onAccepted?.();
@@ -210,6 +221,7 @@ function sendAnalyticsEvent(
     },
     body,
     keepalive: true,
+    credentials: "same-origin",
   }).then((response) => {
     if (response.ok) onAccepted?.();
   }).catch(() => undefined);
@@ -522,6 +534,10 @@ function isAnalyticsHostAllowed(hostname: string) {
     hostname.endsWith(".inshell-art.pages.dev") ||
     hostname.endsWith(".thought-inshell-art.pages.dev")
   );
+}
+
+function usesSharedCookieIdentity(hostname: string) {
+  return hostname === "inshell.art" || hostname.endsWith(".inshell.art");
 }
 
 function isAnalyticsDisabled(env?: Readonly<Record<string, unknown>>) {


### PR DESCRIPTION
Summary:
- Add first-party shared-cookie anonymous visitor/session/visit identity under .inshell.art.
- Keep D1 storage hashed-only and expose shared-cookie status flags in /api/ops/status.
- Add visitorKey to /api/analytics/visitors and keep rank as display-only.
- Keep pages.dev/staging on legacy local/session storage fallback.

Checks run on staging:
- focused analytics Jest
- pnpm run lint
- pnpm run type-check
- pnpm run test:unit
- pnpm run build:home
- pnpm run build:thought
- pnpm run check:deployment
- pnpm run pub-boundary:check
- gitleaks detect --no-git --redact --no-banner

Staging:
- staging.inshell-art.pages.dev/api/ops/status reports commit 1ce080de6e1abf24a8a7ac8ac95cd938875529c5
- anonymousAnalytics.identityMode is shared_cookie
- sharedCookieDomain is .inshell.art