### PR TITLE
Promote canonical gallery route

### DIFF
--- a/apps/home/src/App.tsx
+++ b/apps/home/src/App.tsx
@@ -8,6 +8,7 @@ import ColorFontPage from "@/components/ColorFontPage";
 import PathPage from "@/components/PathPage";
 import VerifyPage from "@/components/VerifyPage";
 import ThoughtDetailPage from "@/components/ThoughtDetailPage";
+import ThoughtGalleryPage from "@/components/ThoughtGalleryPage";
 import FloatingReportBug from "@/components/FloatingReportBug";
 import PreviewWatermark from "@/components/PreviewWatermark";
 import { maybeResolveAddress } from "@inshell/contracts";
@@ -34,6 +35,7 @@ function getPrimitiveRoute(locationKey: string) {
   if (pathname === "/pulse") return "pulse";
   if (pathname === "/color-font") return "color-font";
   if (pathname === "/path" || parseTokenRouteId(pathname, "path")) return "path";
+  if (pathname === "/gallery") return "gallery";
   if (pathname === "/verify") return "verify";
   if (parseTokenRouteId(pathname, "thought")) return "thought";
   return null;
@@ -95,6 +97,11 @@ export default function App() {
       setFavicon("/path.svg");
       return;
     }
+    if (primitiveRoute === "gallery") {
+      document.title = "THOUGHT Gallery";
+      setFavicon("/inshell.svg");
+      return;
+    }
     if (primitiveRoute === "verify") {
       document.title = `verify — ${SURFACE_TERMINOLOGY.pathDapp}`;
       setFavicon("/inshell.svg");
@@ -142,6 +149,8 @@ export default function App() {
             <ColorFontPage />
           ) : primitiveRoute === "path" ? (
             <PathPage tokenId={pathTokenId} />
+          ) : primitiveRoute === "gallery" ? (
+            <ThoughtGalleryPage />
           ) : primitiveRoute === "verify" ? (
             <VerifyPage />
           ) : primitiveRoute === "thought" && thoughtTokenId ? (

--- a/apps/home/src/components/ThoughtGalleryPage.tsx
+++ b/apps/home/src/components/ThoughtGalleryPage.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  loadThoughtGallery,
+  readCachedThoughtGallery,
+  type ThoughtGalleryItem,
+} from "@/services/thoughtGallery";
+import { PUBLIC_NETWORK_CONFIG } from "@inshell/shared";
+
+type LoadState =
+  | { status: "loading"; items: ThoughtGalleryItem[]; error: null }
+  | { status: "ready"; items: ThoughtGalleryItem[]; error: null }
+  | { status: "error"; items: ThoughtGalleryItem[]; error: string };
+
+const GALLERY_LOADING_DETAILS = [
+  "checking latest block",
+  "reading THOUGHT snapshot",
+  "collecting minted works",
+  "rendering gallery",
+] as const;
+
+function getEnvValue(name: string): unknown {
+  const runtimeEnv: Record<string, unknown> | undefined =
+    (globalThis as any).__VITE_ENV__;
+  const buildEnv: Record<string, unknown> | undefined =
+    (globalThis as any).__INSHELL_VITE_ENV__;
+  const procEnv = (globalThis as any)?.process?.env as
+    | Record<string, unknown>
+    | undefined;
+  return runtimeEnv?.[name] ?? buildEnv?.[name] ?? procEnv?.[name];
+}
+
+function configuredUrl(name: string) {
+  const value = getEnvValue(name);
+  return typeof value === "string" && /^https?:\/\//i.test(value.trim())
+    ? value.trim()
+    : null;
+}
+
+function isPreviewDeployment(): boolean {
+  const deployEnv = getEnvValue("VITE_DEPLOY_ENV");
+  if (typeof deployEnv === "string" && deployEnv.trim().toLowerCase() === "preview") {
+    return true;
+  }
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname === "preview.inshell.art" ||
+    hostname.endsWith(".preview.inshell.art") ||
+    hostname === "staging.inshell-art.pages.dev" ||
+    hostname === "staging.thought-inshell-art.pages.dev" ||
+    (hostname.startsWith("staging.") && hostname.endsWith(".pages.dev"))
+  );
+}
+
+function thoughtAppUrl(): string {
+  return (
+    configuredUrl("VITE_THOUGHT_URL") ??
+    (isPreviewDeployment()
+      ? "https://thought.preview.inshell.art/"
+      : "https://thought.inshell.art/")
+  );
+}
+
+function colorFontUrl(): string {
+  return isPreviewDeployment()
+    ? "https://preview.inshell.art/color-font"
+    : "/color-font";
+}
+
+function canonicalThoughtTitle(value: string): string {
+  return (
+    value
+      .replace(/[^A-Za-z]+/g, " ")
+      .trim()
+      .replace(/\s+/g, " ")
+      .toUpperCase() || "-"
+  );
+}
+
+function shortValue(value?: string, head = 6, tail = 4): string {
+  if (!value) return "-";
+  const trimmed = value.trim();
+  if (trimmed.length <= head + tail + 3) return trimmed;
+  return `${trimmed.slice(0, head)}...${trimmed.slice(-tail)}`;
+}
+
+function thoughtImageUrl(tokenId: number): string {
+  return `/api/thought-image?id=${encodeURIComponent(String(tokenId))}`;
+}
+
+function thoughtDetailUrl(tokenId: number): string {
+  return `/thought/${encodeURIComponent(String(tokenId))}`;
+}
+
+function fallbackThumbnailUri(text: string): string {
+  const label = canonicalThoughtTitle(text);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800"><rect width="800" height="800" fill="#050505"/><text x="400" y="410" fill="#e8edf7" font-family="monospace" font-size="48" text-anchor="middle">${label}</text></svg>`;
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+function galleryTipTime(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "time unavailable";
+  return new Date(seconds * 1000).toISOString().replace(".000Z", "Z");
+}
+
+function ChainLoadingStatus({ detail }: { detail: string }) {
+  return (
+    <span
+      className="inshell-chain-loading"
+      aria-label={`reading from chain: ${detail}...`}
+    >
+      <span className="inshell-chain-loading__line">
+        reading from chain: {detail}
+        <span className="inshell-chain-loading__dots" aria-hidden="true">
+          ...
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function ThoughtGalleryCard({ thought }: { thought: ThoughtGalleryItem }) {
+  const title = canonicalThoughtTitle(thought.rawText);
+  return (
+    <article
+      className="thought-gallery__card"
+      data-token-id={thought.tokenId}
+      aria-label={`THOUGHT #${thought.tokenId}`}
+    >
+      <a
+        className="thought-gallery__thumb"
+        href={thoughtDetailUrl(thought.tokenId)}
+        aria-label={`Open THOUGHT #${thought.tokenId}`}
+      >
+        <img
+          className="thought-gallery__image"
+          src={thought.image ? thoughtImageUrl(thought.tokenId) : fallbackThumbnailUri(title)}
+          alt={`THOUGHT #${thought.tokenId}`}
+          loading="lazy"
+        />
+        <span className="thought-gallery__tip">
+          <strong>{`THOUGHT #${thought.tokenId}`}</strong>
+          <span>{title || "(empty)"}</span>
+          <span className="thought-gallery__tip-break" aria-hidden="true" />
+          <span>{`$PATH #${thought.pathId} THOUGHT unit consumed`}</span>
+          <span>{`minted ${galleryTipTime(thought.mintedAt)}`}</span>
+          <span>{`by ${shortValue(thought.minter, 6, 4)}`}</span>
+        </span>
+      </a>
+    </article>
+  );
+}
+
+export default function ThoughtGalleryPage() {
+  const [state, setState] = useState<LoadState>(() => {
+    const cached = readCachedThoughtGallery();
+    return cached
+      ? { status: "ready", items: cached, error: null }
+      : { status: "loading", items: [], error: null };
+  });
+  const [loadingIndex, setLoadingIndex] = useState(0);
+  const createUrl = useMemo(() => thoughtAppUrl(), []);
+  const count = state.items.length;
+
+  useEffect(() => {
+    if (state.status !== "loading") return undefined;
+    const timer = window.setInterval(() => {
+      setLoadingIndex((index) => (index + 1) % GALLERY_LOADING_DETAILS.length);
+    }, 1400);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [state.status]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void loadThoughtGallery()
+      .then((items) => {
+        if (!cancelled) {
+          setState({ status: "ready", items, error: null });
+        }
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const cached = readCachedThoughtGallery();
+        if (cached) {
+          setState({ status: "ready", items: cached, error: null });
+          return;
+        }
+        const message =
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Gallery unavailable.";
+        setState({ status: "error", items: [], error: message });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="thought-gallery" aria-labelledby="gallery-title">
+      <header className="thought-gallery__header">
+        <div>
+          <p className="thought-gallery__eyebrow">{PUBLIC_NETWORK_CONFIG.environmentLabel}</p>
+          <h1 id="gallery-title" className="thought-gallery__title">
+            Gallery
+          </h1>
+        </div>
+      </header>
+
+      <div className="thought-gallery__status-row">
+        <p className="thought-gallery__status" aria-live="polite">
+          {state.status === "loading" ? (
+            <ChainLoadingStatus detail={GALLERY_LOADING_DETAILS[loadingIndex]} />
+          ) : state.status === "error" ? (
+            state.error
+          ) : count === 0 ? (
+            "no minted THOUGHTs yet."
+          ) : (
+            `${count} minted THOUGHT${count === 1 ? "" : "s"}.`
+          )}
+        </p>
+        <a className="thought-gallery__create" href={createUrl}>
+          create your THOUGHT
+        </a>
+      </div>
+
+      <div className="thought-gallery__grid">
+        {state.items.map((thought) => (
+          <ThoughtGalleryCard key={thought.tokenId} thought={thought} />
+        ))}
+      </div>
+
+      <footer className="thought-gallery__footer" aria-label="Gallery references">
+        <a
+          className="thought-gallery__footer-link"
+          href={colorFontUrl()}
+          aria-label="Open the Color Font page"
+        >
+          color font
+        </a>
+      </footer>
+    </main>
+  );
+}

--- a/apps/home/src/main.css
+++ b/apps/home/src/main.css
@@ -2522,9 +2522,195 @@ body {
   background: var(--detail-scrollbar-thumb);
 }
 
+.thought-gallery {
+  width: min(var(--main-area-width), 100%);
+  min-height: calc(100vh - 56px);
+  box-sizing: border-box;
+  padding: 0;
+  background: transparent;
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+.thought-gallery__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.thought-gallery__eyebrow,
+.thought-gallery__status,
+.thought-gallery__meta,
+.thought-gallery__hash {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 300;
+  line-height: 1.55;
+}
+
+.thought-gallery__eyebrow {
+  margin-bottom: 8px;
+  letter-spacing: 0.12em;
+}
+
+.thought-gallery__title {
+  margin: 0;
+  color: var(--accent);
+  font-size: clamp(30px, 4.8vw, 56px);
+  font-weight: var(--weight-thin, 200);
+  line-height: 0.9;
+  letter-spacing: 0.08em;
+}
+
+.thought-gallery__create,
+.thought-gallery__footer-link {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 300;
+  line-height: 1.55;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.thought-gallery__create:hover,
+.thought-gallery__create:focus-visible,
+.thought-gallery__footer-link:hover,
+.thought-gallery__footer-link:focus-visible {
+  color: var(--accent);
+  outline: none;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+}
+
+.thought-gallery__status-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35em;
+  margin-bottom: 18px;
+}
+
+.thought-gallery__status {
+  min-height: 20px;
+}
+
+.thought-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 22px;
+}
+
+.thought-gallery__card {
+  position: relative;
+  padding: 10px;
+  box-sizing: border-box;
+  border: 0;
+  background: var(--panel);
+  overflow: visible;
+  transition: background-color 180ms ease, box-shadow 180ms ease;
+}
+
+.thought-gallery__thumb {
+  position: relative;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.thought-gallery__image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  background: #050505;
+  border: 0;
+}
+
+.thought-gallery__tip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 5;
+  width: max-content;
+  max-width: min(300px, 78vw);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  background: var(--panel);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 300;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(3px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.thought-gallery__tip strong {
+  color: inherit;
+  font-size: 12px;
+  font-weight: var(--weight-mid, 400);
+}
+
+.thought-gallery__tip-break {
+  height: 4px;
+}
+
+.thought-gallery__thumb:hover .thought-gallery__tip,
+.thought-gallery__thumb:focus-visible .thought-gallery__tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.thought-gallery__thumb:focus-visible {
+  outline: 1px solid var(--accent-border);
+  outline-offset: 6px;
+}
+
+.thought-gallery__footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding: 46px 0 0;
+}
+
 @media (max-width: 760px) {
   .path-detail {
     grid-template-columns: 1fr;
+  }
+
+  .thought-gallery {
+    min-height: calc(100vh - 36px);
+  }
+
+  .thought-gallery__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .thought-gallery__status-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .thought-gallery__grid {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 14px;
   }
 
   .thought-detail {

--- a/apps/home/tests/App.test.tsx
+++ b/apps/home/tests/App.test.tsx
@@ -1069,6 +1069,41 @@ describe("App Component", () => {
     expect(screen.queryByTestId("auction-canvas")).toBeNull();
   });
 
+  test("renders the canonical THOUGHT gallery route at the Inshell root", async () => {
+    mockThoughtGalleryApi([
+      thoughtGalleryItem({
+        tokenId: 1,
+        pathId: "4",
+        rawText: "one thought",
+      }),
+      thoughtGalleryItem({
+        tokenId: 2,
+        pathId: "5",
+        rawText: "second thought",
+      }),
+    ]);
+    window.history.pushState({}, "", "/gallery");
+    render(<App />);
+    await flushAsyncEffects();
+
+    expect(document.title).toBe("THOUGHT Gallery");
+    expect(document.querySelector('link[rel="icon"]')).toHaveAttribute("href", "/inshell.svg");
+    expect(screen.getByRole("heading", { level: 1, name: "Gallery" })).toBeInTheDocument();
+    expect(screen.getByText("2 minted THOUGHTs.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "create your THOUGHT" })).toHaveAttribute(
+      "href",
+      "https://thought.inshell.art/",
+    );
+    expect(screen.getByLabelText("Open THOUGHT #1")).toHaveAttribute("href", "/thought/1");
+    expect(screen.getByLabelText("Open THOUGHT #2")).toHaveAttribute("href", "/thought/2");
+    expect(screen.getByRole("img", { name: "THOUGHT #1" })).toHaveAttribute(
+      "src",
+      "/api/thought-image?id=1",
+    );
+    expect(screen.getByText("$PATH #4 THOUGHT unit consumed")).toBeInTheDocument();
+    expect(screen.queryByTestId("auction-canvas")).toBeNull();
+  });
+
   test("does not treat oversized numeric THOUGHT paths as detail routes", () => {
     window.history.pushState(
       {},


### PR DESCRIPTION
## Summary
- add a real /gallery route to the home app
- render THOUGHT gallery cards from /api/thought-gallery
- prevent /gallery from falling through to PATH/Pulse home content

## Verification
- pnpm --filter @inshell/home test -- --runTestsByPath tests/App.test.tsx
- pnpm --filter @inshell/home lint
- pnpm --filter @inshell/home build
- gitleaks detect --no-git --redact
- browser check on http://127.0.0.1:5173/gallery: 17 cards, 17 images, no PATH canvas/dotfield, no failed requests