### PR TITLE
Promote gallery navigation fixes

### DIFF
--- a/apps/home/src/components/ThoughtGalleryPage.tsx
+++ b/apps/home/src/components/ThoughtGalleryPage.tsx
@@ -226,6 +226,9 @@ export default function ThoughtGalleryPage() {
         <a className="thought-gallery__create" href={createUrl}>
           create your THOUGHT
         </a>
+        <a className="thought-gallery__link" href="/">
+          [ home ]
+        </a>
       </div>
 
       <div className="thought-gallery__grid">

--- a/apps/home/src/main.css
+++ b/apps/home/src/main.css
@@ -2567,6 +2567,7 @@ body {
 }
 
 .thought-gallery__create,
+.thought-gallery__link,
 .thought-gallery__footer-link {
   color: var(--muted);
   font-size: 12px;
@@ -2578,6 +2579,8 @@ body {
 
 .thought-gallery__create:hover,
 .thought-gallery__create:focus-visible,
+.thought-gallery__link:hover,
+.thought-gallery__link:focus-visible,
 .thought-gallery__footer-link:hover,
 .thought-gallery__footer-link:focus-visible {
   color: var(--accent);
@@ -2596,6 +2599,10 @@ body {
 
 .thought-gallery__status {
   min-height: 20px;
+}
+
+.thought-gallery__link {
+  margin-left: auto;
 }
 
 .thought-gallery__grid {
@@ -2706,6 +2713,10 @@ body {
     align-items: flex-start;
     flex-direction: column;
     gap: 8px;
+  }
+
+  .thought-gallery__link {
+    margin-left: 0;
   }
 
   .thought-gallery__grid {

--- a/apps/home/tests/App.test.tsx
+++ b/apps/home/tests/App.test.tsx
@@ -210,6 +210,17 @@ function expectedDefaultGalleryUrl() {
     : "https://inshell.art/gallery";
 }
 
+function expectedDefaultThoughtUrl() {
+  const configured = env.VITE_THOUGHT_URL;
+  if (configured) {
+    return new globalThis.URL(configured).toString();
+  }
+  if (String(env.VITE_DEPLOY_ENV ?? "").toLowerCase() === "preview") {
+    return "https://thought.preview.inshell.art/";
+  }
+  return "https://thought.inshell.art/";
+}
+
 describe("App Component", () => {
   beforeEach(() => {
     window.history.pushState({}, "", "/");
@@ -1092,7 +1103,7 @@ describe("App Component", () => {
     expect(screen.getByText("2 minted THOUGHTs.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "create your THOUGHT" })).toHaveAttribute(
       "href",
-      "https://thought.inshell.art/",
+      expectedDefaultThoughtUrl(),
     );
     expect(screen.getByRole("link", { name: "[ home ]" })).toHaveAttribute("href", "/");
     expect(screen.getByLabelText("Open THOUGHT #1")).toHaveAttribute("href", "/thought/1");

--- a/apps/home/tests/App.test.tsx
+++ b/apps/home/tests/App.test.tsx
@@ -1094,6 +1094,7 @@ describe("App Component", () => {
       "href",
       "https://thought.inshell.art/",
     );
+    expect(screen.getByRole("link", { name: "[ home ]" })).toHaveAttribute("href", "/");
     expect(screen.getByLabelText("Open THOUGHT #1")).toHaveAttribute("href", "/thought/1");
     expect(screen.getByLabelText("Open THOUGHT #2")).toHaveAttribute("href", "/thought/2");
     expect(screen.getByRole("img", { name: "THOUGHT #1" })).toHaveAttribute(

--- a/apps/thought/index.html
+++ b/apps/thought/index.html
@@ -72,6 +72,10 @@
       <div class="frontpage-main">
         <div class="thought-canvas-column">
           <h1 id="frontpage-title" class="frontpage-title">THOUGHT</h1>
+          <nav class="frontpage-links" aria-label="THOUGHT creation links">
+            <a id="thought-create-gallery-link" href="/gallery">[ gallery ]</a>
+            <a id="thought-create-home-link" href="https://inshell.art/">[ home ]</a>
+          </nav>
 
           <div class="thought-canvas-panel">
             <div class="thought-canvas-frame">
@@ -362,6 +366,7 @@
           </span>
         </p>
         <a id="gallery-create-link" class="thought-gallery__create" href="https://thought.inshell.art/">create your THOUGHT</a>
+        <a id="gallery-home-link" class="thought-gallery__link" href="https://inshell.art/">[ home ]</a>
       </div>
       <div id="gallery-grid" class="thought-gallery__grid"></div>
       <footer class="thought-gallery__footer">

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -1185,10 +1185,13 @@ const thoughtDebugCtaStatus = document.getElementById("thought-debug-cta-status"
 const thoughtDebugWarning = document.getElementById("thought-debug-warning") as HTMLSelectElement | null;
 const thoughtReportBugLink = document.getElementById("thought-report-bug-link") as HTMLAnchorElement | null;
 const thoughtInstructionsLink = document.getElementById("thought-instructions-link") as HTMLAnchorElement | null;
+const thoughtCreateGalleryLink = document.getElementById("thought-create-gallery-link") as HTMLAnchorElement | null;
+const thoughtCreateHomeLink = document.getElementById("thought-create-home-link") as HTMLAnchorElement | null;
 const thoughtGalleryLink = document.getElementById("thought-gallery-link") as HTMLAnchorElement | null;
 const galleryPage = document.getElementById("gallery-page") as HTMLElement | null;
 const galleryStatus = document.getElementById("gallery-status") as HTMLElement | null;
 const galleryCreateLink = document.getElementById("gallery-create-link") as HTMLAnchorElement | null;
+const galleryHomeLink = document.getElementById("gallery-home-link") as HTMLAnchorElement | null;
 const galleryGrid = document.getElementById("gallery-grid") as HTMLElement | null;
 const colorFontPage = document.getElementById("color-font-page") as HTMLElement | null;
 const colorFontSource = document.getElementById("color-font-source") as HTMLElement | null;
@@ -1325,10 +1328,13 @@ if (
   !thoughtDebugWarning ||
   !thoughtReportBugLink ||
   !thoughtInstructionsLink ||
+  !thoughtCreateGalleryLink ||
+  !thoughtCreateHomeLink ||
   !thoughtGalleryLink ||
   !galleryPage ||
   !galleryStatus ||
   !galleryCreateLink ||
+  !galleryHomeLink ||
   !galleryGrid ||
   !colorFontPage ||
   !colorFontSource ||
@@ -5773,11 +5779,15 @@ const viewThoughtUseLine = (tokenId?: number | null) =>
   `use: view THOUGHT ${tokenId ?? "<id>"}`;
 
 const thoughtCreateUrl = () => new URL(THOUGHT_APP_URL, window.location.origin).toString();
+const inshellHomeUrl = () => new URL("/", PATH_MINT_URL).toString();
 
 const configureGalleryLink = () => {
+  thoughtCreateGalleryLink.href = galleryUrl();
+  thoughtCreateHomeLink.href = inshellHomeUrl();
   thoughtGalleryLink.href = galleryUrl();
   thoughtDetailGalleryLink.href = galleryUrl();
   galleryCreateLink.href = thoughtCreateUrl();
+  galleryHomeLink.href = inshellHomeUrl();
   thoughtDetailCreateLink.href = thoughtCreateUrl();
 };
 

--- a/apps/thought/src/style.css
+++ b/apps/thought/src/style.css
@@ -340,11 +340,38 @@ html.verify-route .frontpage-stage {
   text-align: center;
 }
 
+.frontpage-links {
+  grid-area: links;
+  display: flex;
+  align-items: baseline;
+  align-self: end;
+  justify-self: end;
+  gap: 18px;
+  min-width: 0;
+}
+
+.frontpage-links a {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 300;
+  line-height: 1.55;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.frontpage-links a:hover,
+.frontpage-links a:focus-visible {
+  color: var(--accent);
+  outline: none;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
 .frontpage-main {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
   grid-template-areas:
-    "title ."
+    "title links"
     "canvas side";
   column-gap: 32px;
   row-gap: 18px;
@@ -2240,6 +2267,7 @@ html.thought-route .thought-detail.is-hidden {
   letter-spacing: 0.08em;
 }
 
+.thought-gallery__link,
 .thought-gallery__create {
   color: var(--muted);
   font-size: 12px;
@@ -2249,6 +2277,8 @@ html.thought-route .thought-detail.is-hidden {
   white-space: nowrap;
 }
 
+.thought-gallery__link:hover,
+.thought-gallery__link:focus-visible,
 .thought-gallery__create:hover,
 .thought-gallery__create:focus-visible {
   color: var(--accent);
@@ -2263,6 +2293,10 @@ html.thought-route .thought-detail.is-hidden {
   align-items: baseline;
   gap: 0.35em;
   margin-bottom: 18px;
+}
+
+.thought-gallery__status-row .thought-gallery__link {
+  margin-left: auto;
 }
 
 .thought-gallery__status {
@@ -2400,6 +2434,11 @@ html.thought-route .thought-detail.is-hidden {
 
   .frontpage-title {
     grid-area: auto;
+  }
+
+  .frontpage-links {
+    grid-area: auto;
+    justify-self: auto;
   }
 
   .thought-canvas-panel {

--- a/apps/thought/vite.config.ts
+++ b/apps/thought/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import fs from "node:fs";
 import path from "node:path";
 import type { RollupLog, RollupLogHandler } from "rollup";
 
@@ -15,6 +16,13 @@ function ignoreKnownRollupWarnings(warning: RollupLog, warn: RollupLogHandler) {
 
 function readDevApiOrigin() {
   return process.env.INSHELL_THOUGHT_DEV_API_ORIGIN?.trim() || "https://thought.inshell.art";
+}
+
+function existingRealPaths(paths: string[]) {
+  return paths.flatMap((candidate) => {
+    if (!fs.existsSync(candidate)) return [];
+    return [fs.realpathSync(candidate)];
+  });
 }
 
 export default defineConfig(({ mode }) => {
@@ -50,7 +58,14 @@ export default defineConfig(({ mode }) => {
         },
       },
       fs: {
-        allow: [workspaceRoot],
+        allow: [
+          workspaceRoot,
+          ...existingRealPaths([
+            path.resolve(rootDir, "node_modules"),
+            path.resolve(workspaceRoot, "node_modules"),
+            path.resolve(workspaceRoot, "node_modules/node_modules"),
+          ]),
+        ],
       },
     },
     envDir: __dirname,


### PR DESCRIPTION
## Summary
- Adds [ home ] navigation to the canonical root gallery page served by the home app.
- Adds [ gallery ]/[ home ] navigation to the THOUGHT creation surface and [ home ] to the THOUGHT gallery status row.
- Fixes THOUGHT dev-server filesystem allowlist for symlinked workspace font/dependency paths.

## Verification
- Staging deploy completed successfully: deploy-pages run 28662078981.
- GitHub staging push checks passed for commit 0ca9725.
- Local preview-equivalent home test passed: 153 tests.
- Rendered staging alias verified at https://staging.inshell-art.pages.dev/gallery: [ home ] visible, right-aligned, yDelta 0.