### PR TITLE
Sanitize ops status upstream labels

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -1753,10 +1753,21 @@ describe("chain cache Pages functions", () => {
 
     const response = await onOpsStatusGet({
       request: new Request("https://preview.inshell.art/api/ops/status"),
-      env: { INSHELL_CHAIN_DATA_DB: d1.db },
+      env: {
+        INSHELL_CHAIN_DATA_DB: d1.db,
+        PATH_PRIMARY_RPC_UPSTREAM: "https://eth-sepolia.g.alchemy.com/v2/super-secret-path-key",
+        THOUGHT_PRIMARY_RPC_UPSTREAM: "https://eth-sepolia.g.alchemy.com/v2/super-secret-thought-key",
+        PRIVATE_FALLBACK_RPC_UPSTREAM: "https://eth-sepolia.g.alchemy.com/v2/super-secret-fallback-key",
+        PUBLIC_FALLBACK_RPC_UPSTREAM: "https://public-provider.example/rpc?api_key=super-secret",
+        PATH_PRIMARY_RPC_LABEL: "https://eth-sepolia.g.alchemy.com/v2/label-secret-key",
+        THOUGHT_PRIMARY_RPC_LABEL: "client_secret=thought-secret",
+        PRIVATE_FALLBACK_RPC_LABEL: "Bearer fallback-secret",
+        PUBLIC_FALLBACK_RPC_LABEL: "api_key=public-secret",
+      },
     });
     const payload = (await response.json()) as {
       routes?: { event?: { route?: string; targets?: string[] } };
+      rpcUpstreams?: Record<string, { configuredKey?: string | null; label?: string }>;
       indexerEventIngest?: {
         enabled?: boolean;
         route?: string;
@@ -1787,6 +1798,17 @@ describe("chain cache Pages functions", () => {
     expect(payload.indexerEventIngest?.lastTxHash).toBe(`0x${"456".padStart(64, "0")}`);
     expect(payload.indexerEventIngest?.acceptedCount).toBe(3);
     expect(payload.indexerEventIngest?.appliedCount).toBe(2);
+    expect(payload.rpcUpstreams?.pathPrimary?.configuredKey).toBe("PATH_PRIMARY_RPC_UPSTREAM");
+    expect(payload.rpcUpstreams?.pathPrimary?.label).toBe("path-primary");
+    expect(payload.rpcUpstreams?.thoughtPrimary?.label).toBe("thought-primary");
+    expect(payload.rpcUpstreams?.privateFallback?.label).toBe("private-fallback");
+    expect(payload.rpcUpstreams?.publicFallback?.label).toBe("public-fallback");
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("alchemy.com/v2");
+    expect(serialized).not.toContain("super-secret");
+    expect(serialized).not.toContain("client_secret");
+    expect(serialized).not.toContain("api_key");
+    expect(serialized).not.toContain("Bearer fallback-secret");
   });
 
   test("writes KV when snapshot content changes", async () => {

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -169,30 +169,18 @@ export async function onRequestGet(ctx: PagesContextLike): Promise<Response> {
       pathPrimary: upstreamStatus(ctx.env, "PATH_PRIMARY_RPC_UPSTREAM", [
         "PATH_PRIMARY_RPC_UPSTREAM",
         "PATH_RPC_UPSTREAM",
-      ], [
-        "PATH_PRIMARY_RPC_LABEL",
-        "PATH_RPC_LABEL",
       ]),
       thoughtPrimary: upstreamStatus(ctx.env, "THOUGHT_PRIMARY_RPC_UPSTREAM", [
         "THOUGHT_PRIMARY_RPC_UPSTREAM",
         "THOUGHT_RPC_UPSTREAM",
-      ], [
-        "THOUGHT_PRIMARY_RPC_LABEL",
-        "THOUGHT_RPC_LABEL",
       ]),
       privateFallback: upstreamStatus(ctx.env, "PRIVATE_FALLBACK_RPC_UPSTREAM", [
         "PRIVATE_FALLBACK_RPC_UPSTREAM",
         "ETH_RPC_UPSTREAM",
-      ], [
-        "PRIVATE_FALLBACK_RPC_LABEL",
-        "ETH_RPC_LABEL",
       ]),
       publicFallback: upstreamStatus(ctx.env, "PUBLIC_FALLBACK_RPC_UPSTREAM", [
         "PUBLIC_FALLBACK_RPC_UPSTREAM",
         "RPC_UPSTREAM_FALLBACK",
-      ], [
-        "PUBLIC_FALLBACK_RPC_LABEL",
-        "RPC_UPSTREAM_FALLBACK_LABEL",
       ]),
     },
     opsBoundary: {
@@ -234,16 +222,18 @@ function upstreamStatus(
   env: ChainCacheEnv,
   role: string,
   upstreamKeys: EnvKey[],
-  labelKeys: EnvKey[],
 ) {
   const configuredKey = upstreamKeys.find((key) => Boolean(readEnv(env, key)));
-  const label = labelKeys.map((key) => readEnv(env, key)).find(Boolean) || role;
   return {
     role,
     configured: Boolean(configuredKey),
     configuredKey: configuredKey ?? null,
-    label,
+    label: safeUpstreamLabel(role),
   };
+}
+
+function safeUpstreamLabel(role: string) {
+  return role.toLowerCase().replace(/_rpc_upstream$/, "").replace(/_/g, "-");
 }
 
 function publicEnv(env: ChainCacheEnv, key: string) {


### PR DESCRIPTION
## Summary
- stop /api/ops/status from emitting env-provided RPC label values
- emit deterministic logical upstream labels only
- add regression coverage with secret-looking RPC URLs and label values

## Checks
- git diff --check -- functions/api/ops/status.ts apps/home/tests/chainCacheFunction.test.ts
- corepack pnpm --filter @inshell/home exec jest --runTestsByPath tests/chainCacheFunction.test.ts --silent
- corepack pnpm --filter @inshell/home build
- gitleaks detect --no-git --redact