### PR TITLE
Remove bearer placeholder from ops status

### DIFF
--- a/apps/home/tests/chainCacheFunction.test.ts
+++ b/apps/home/tests/chainCacheFunction.test.ts
@@ -1808,6 +1808,7 @@ describe("chain cache Pages functions", () => {
     expect(serialized).not.toContain("super-secret");
     expect(serialized).not.toContain("client_secret");
     expect(serialized).not.toContain("api_key");
+    expect(serialized).not.toContain("Bearer ");
     expect(serialized).not.toContain("Bearer fallback-secret");
   });
 

--- a/functions/api/ops/status.ts
+++ b/functions/api/ops/status.ts
@@ -40,7 +40,7 @@ const ROUTES = {
     auth: {
       requiredFor: ["path-tokens", "thought-gallery", "all"],
       publicTargets: ["pulse-auction with tx hash"],
-      headerNames: ["authorization: Bearer <token>", "x-inshell-indexer-token"],
+      headerNames: ["authorization", "x-inshell-indexer-token"],
     },
     targets: ["pulse-auction", "path-tokens", "thought-gallery", "all"],
   },


### PR DESCRIPTION
## Summary
- remove the bearer-shaped placeholder from /api/ops/status refresh auth metadata
- keep exposing only safe header names
- extend the status regression test to reject any serialized 'Bearer ' string

## Checks
- git diff --check -- functions/api/ops/status.ts apps/home/tests/chainCacheFunction.test.ts
- corepack pnpm --filter @inshell/home exec jest --runTestsByPath tests/chainCacheFunction.test.ts --silent
- corepack pnpm --filter @inshell/home build
- gitleaks detect --no-git --redact