### PR TITLE
Fix Pages function protocol import

### DIFF
--- a/functions/api/thought-agent/v2/client.ts
+++ b/functions/api/thought-agent/v2/client.ts
@@ -1,4 +1,4 @@
-import { buildThoughtCodexClientScript } from "@inshell/thought-agent-protocol";
+import { buildThoughtCodexClientScript } from "../../../../packages/thought-agent-protocol/src/index";
 
 const responseHeaders = {
   "access-control-allow-origin": "*",


### PR DESCRIPTION
Fixes the controlled staging deployment failure by using the same root-relative source import convention as the existing Pages Functions. Local lint, type-check, function tests, import execution, and leak scan pass.