### PR TITLE
Fix same-origin THOUGHT Pages redirect loop

### DIFF
--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -475,8 +475,20 @@ describe("Pages middleware canonical routes", () => {
     expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
     expect(response.headers.get("clear-site-data")).toBeNull();
     expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
-    expect(ctx.assetsFetch.mock.calls[0]?.[0].url).toBe("https://inshell.art/thought/index.html");
+    expect(ctx.assetsFetch.mock.calls[0]?.[0].url).toBe("https://inshell.art/thought/");
     expect(ctx.next).not.toHaveBeenCalled();
+  });
+
+  test("serves both canonical THOUGHT root forms without fetching the redirecting index URL", async () => {
+    for (const pathname of ["/thought", "/thought/"]) {
+      const ctx = middlewareContext(`https://inshell.art${pathname}`);
+      const response = await onRequest(ctx);
+
+      expect(response.status).toBe(200);
+      expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
+      expect(ctx.assetsFetch.mock.calls[0]?.[0].url).toBe("https://inshell.art/thought/");
+      expect(ctx.next).not.toHaveBeenCalled();
+    }
   });
 
   test("redirects works alias to the gallery route", async () => {

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -507,7 +507,7 @@ async function serveAppShell(ctx: MiddlewareContext): Promise<Response> {
 
 async function serveThoughtAppShell(ctx: MiddlewareContext): Promise<Response> {
   const indexUrl = new globalThis.URL(ctx.request.url);
-  indexUrl.pathname = "/thought/index.html";
+  indexUrl.pathname = "/thought/";
   indexUrl.search = "";
   const request = new Request(indexUrl.toString(), ctx.request);
   let response: Response;


### PR DESCRIPTION
## Summary
- fetch the mounted THOUGHT shell through `/thought/` so Cloudflare Pages serves the directory index instead of redirecting `/thought/index.html`
- cover both `/thought` and `/thought/` in middleware regression tests

## Validation
- middleware suite: 25/25
- local Wrangler Pages probes: `/thought`, `/thought/`, `/thought/1` all 200
- lint
- type-check
- build:home
- PUB boundary check
- source-only gitleaks