### PR TITLE
Complete THOUGHT work and mint panels

### DIFF
--- a/apps/home/src/components/AuctionCanvas.tsx
+++ b/apps/home/src/components/AuctionCanvas.tsx
@@ -39,11 +39,20 @@ import {
 import {
   PUBLIC_NETWORK_CONFIG,
   SURFACE_TERMINOLOGY,
+  isPathMintHandoffId,
+  parsePathMintReturnRecord,
+  pathMintReturnStorageKey,
+  readPathMintReturnRecord,
+  removePathMintReturnRecord,
   resolveWalletChainRpcUrls,
   trackInshellAnonymousAnalytics,
+  writePathMintReturnRecord,
+  type PathMintReturnRecord,
+  type PathMintReturnStorageHost,
 } from "@inshell/shared";
 import HeaderWalletCTA from "@/components/HeaderWalletCTA";
 import { useWallet } from "@inshell/wallet";
+import { withPathMintSubmissionLock } from "../pathMintSubmissionLock";
 import { InshellWalletPicker } from "@inshell/inshell-shell";
 import {
   buildReportBugLink,
@@ -284,8 +293,33 @@ type PulseBidIntentCheck = {
 
 type PathMintIntent = {
   from: "thought";
+  handoffId: string;
+  originAccount: string | null;
+  chainId: bigint;
+  movement: "THOUGHT";
   returnTo: string;
 };
+
+type PathMintIntentRead =
+  | { kind: "none" }
+  | { kind: "invalid"; reason: string }
+  | { kind: "valid"; intent: PathMintIntent };
+
+type TransactionReceiptOutcome = "success" | "reverted" | "unknown";
+type TransactionReplacement =
+  | { kind: "none" }
+  | {
+      kind: "replacement";
+      cancelled: boolean;
+      hash: string | null;
+      receipt: unknown;
+    };
+type PathMintSubmissionContext = {
+  account: string;
+  chainId: bigint;
+};
+
+const PATH_MINT_RECEIPT_RETRY_MS = 3_000;
 
 function useDesktopOnly(minWidth = 768) {
   const [isDesktop, setIsDesktop] = useState(
@@ -304,50 +338,261 @@ function normalizeReturnTo(raw: string | null): string | null {
   try {
     const url = new URL(raw, window.location.href);
     const protocolOk = url.protocol === "http:" || url.protocol === "https:";
-    const host = url.hostname.toLowerCase();
-    const hostOk =
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "[::1]" ||
-      host === "inshell.art" ||
-      host === "preview.inshell.art" ||
-      host === "thought.inshell.art" ||
-      host === "thought.preview.inshell.art" ||
-      host === "path.inshell.art" ||
-      host === "path.preview.inshell.art" ||
-      host === "gallery.inshell.art" ||
-      host === "gallery.preview.inshell.art";
-    if (!protocolOk || !hostOk) return null;
+    if (!protocolOk || url.origin !== window.location.origin) return null;
 
-    let pathname = url.pathname.replace(/\/+$/, "") || "/";
-    if (
-      (host === "thought.inshell.art" || host === "thought.preview.inshell.art") &&
-      !pathname.startsWith("/thought")
-    ) {
-      pathname = pathname === "/" ? "/thought" : `/thought${pathname}`;
-    } else if (
-      (host === "path.inshell.art" || host === "path.preview.inshell.art") &&
-      !pathname.startsWith("/path")
-    ) {
-      pathname = pathname === "/" ? "/path" : `/path${pathname}`;
-    } else if (host === "gallery.inshell.art" || host === "gallery.preview.inshell.art") {
-      pathname = pathname === "/" || pathname === "/gallery" ? "/gallery" : "/gallery";
-    }
-
-    if (!/^\/(?:thought|path|gallery)(?:\/|$)/.test(pathname)) return null;
+    const pathname = url.pathname.replace(/\/+$/, "") || "/";
+    if (!/^\/thought(?:\/|$)/.test(pathname)) return null;
     return `${pathname}${url.search}${url.hash}`;
   } catch {
     return null;
   }
 }
 
-function readPathMintIntent(): PathMintIntent | null {
-  if (typeof window === "undefined") return null;
+function readPathMintIntent(): PathMintIntentRead {
+  if (typeof window === "undefined") return { kind: "none" };
   const params = new URLSearchParams(window.location.search);
-  if (params.get("intent") !== "mint-path") return null;
-  if (params.get("from") !== "thought") return null;
+  if (params.get("intent") !== "mint-path") return { kind: "none" };
+  if (params.get("from") !== "thought") {
+    return { kind: "invalid", reason: "Invalid THOUGHT mint handoff source." };
+  }
+
+  const handoffId = params.get("handoff");
+  if (!isPathMintHandoffId(handoffId)) {
+    return { kind: "invalid", reason: "Invalid THOUGHT mint handoff id." };
+  }
+  if (params.get("movement") !== "THOUGHT") {
+    return { kind: "invalid", reason: "Invalid THOUGHT mint movement." };
+  }
+
+  const originAccountRaw = params.get("account");
+  const originAccount = originAccountRaw?.trim() || null;
+  if (originAccount && !/^0x[0-9a-fA-F]{40}$/.test(originAccount)) {
+    return { kind: "invalid", reason: "Invalid THOUGHT wallet account." };
+  }
+
+  const chainId = parseChainId(params.get("chainId"));
+  if (
+    chainId === null ||
+    chainId <= 0n ||
+    chainId > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    return { kind: "invalid", reason: "Invalid THOUGHT mint chain." };
+  }
+
   const returnTo = normalizeReturnTo(params.get("returnTo"));
-  return returnTo ? { from: "thought", returnTo } : null;
+  if (!returnTo) {
+    return { kind: "invalid", reason: "Invalid THOUGHT return route." };
+  }
+  const returnUrl = new URL(returnTo, window.location.origin);
+  const returnHandoffId = returnUrl.searchParams.get("pathHandoff");
+  if (returnHandoffId !== handoffId) {
+    return { kind: "invalid", reason: "THOUGHT return handoff does not match." };
+  }
+
+  return {
+    kind: "valid",
+    intent: {
+      from: "thought",
+      handoffId,
+      originAccount: originAccount?.toLowerCase() ?? null,
+      chainId,
+      movement: "THOUGHT",
+      returnTo,
+    },
+  };
+}
+
+function getPathMintReturnStorageHost(): PathMintReturnStorageHost {
+  if (typeof window === "undefined") return {};
+  const host: PathMintReturnStorageHost = {};
+  try {
+    host.localStorage = window.localStorage;
+  } catch {
+    // The shared writer will fall back to session storage.
+  }
+  try {
+    host.sessionStorage = window.sessionStorage;
+  } catch {
+    // The in-memory state remains usable when browser storage is blocked.
+  }
+  return host;
+}
+
+function readMatchingPathMintReturnRecord(
+  intent: PathMintIntent,
+): PathMintReturnRecord | null {
+  return readPathMintReturnRecord(
+    getPathMintReturnStorageHost(),
+    intent.handoffId,
+  );
+}
+
+function transactionReceiptOutcome(receipt: unknown): TransactionReceiptOutcome {
+  if (!receipt || typeof receipt !== "object") return "unknown";
+  const candidate = receipt as Record<string, unknown>;
+  const values = [
+    candidate.execution_status,
+    candidate.executionStatus,
+    candidate.status,
+    candidate.finality_status,
+    candidate.finalityStatus,
+  ];
+  let sawSuccess = false;
+
+  for (const value of values) {
+    if (value === false || value === 0 || value === 0n) return "reverted";
+    if (value === true || value === 1 || value === 1n) {
+      sawSuccess = true;
+      continue;
+    }
+    if (typeof value !== "string") continue;
+    const normalized = value.trim().toLowerCase();
+    if (
+      normalized === "0" ||
+      normalized === "0x0" ||
+      normalized === "failed" ||
+      normalized === "failure" ||
+      normalized === "reverted" ||
+      normalized === "rejected" ||
+      normalized === "cancelled" ||
+      normalized === "canceled"
+    ) {
+      return "reverted";
+    }
+    if (
+      normalized === "1" ||
+      normalized === "0x1" ||
+      normalized === "success" ||
+      normalized === "succeeded" ||
+      normalized === "confirmed" ||
+      normalized === "finalized" ||
+      normalized === "accepted_on_l1" ||
+      normalized === "accepted_on_l2"
+    ) {
+      sawSuccess = true;
+    }
+  }
+
+  if (
+    candidate.reverted === true ||
+    candidate.isReverted === true ||
+    (typeof candidate.revert_reason === "string" &&
+      candidate.revert_reason.trim() !== "") ||
+    (typeof candidate.revertReason === "string" &&
+      candidate.revertReason.trim() !== "")
+  ) {
+    return "reverted";
+  }
+  return sawSuccess ? "success" : "unknown";
+}
+
+function isExplicitTransactionFailure(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return /\b(?:execution|transaction)(?: was)? reverted\b|\breceipt status\s*(?:=|:)?\s*(?:0x0|0)\b/i.test(
+      walletErrorMessage(error),
+    );
+  }
+  const candidate = error as Record<string, unknown>;
+  if (transactionReceiptOutcome(candidate) === "reverted") return true;
+  const code = String(candidate.code ?? "").trim().toUpperCase();
+  if (
+    code === "CALL_EXCEPTION" ||
+    code === "TRANSACTION_REVERTED" ||
+    code === "EXECUTION_REVERTED"
+  ) {
+    return true;
+  }
+  const data =
+    candidate.data && typeof candidate.data === "object"
+      ? (candidate.data as Record<string, unknown>)
+      : null;
+  const receipts = [
+    candidate.receipt,
+    candidate.transactionReceipt,
+    data?.receipt,
+  ];
+  if (receipts.some((receipt) => transactionReceiptOutcome(receipt) === "reverted")) {
+    return true;
+  }
+  const message = walletErrorMessage(error).toLowerCase();
+  return /\b(?:execution|transaction)(?: was)? reverted\b|\brevert(?:ed)?(?: with reason| reason|:)\b|\breceipt status\s*(?:=|:)?\s*(?:0x0|0)\b/i.test(
+    message,
+  );
+}
+
+function transactionReplacement(error: unknown): TransactionReplacement {
+  if (!error || typeof error !== "object") return { kind: "none" };
+  const candidate = error as Record<string, unknown>;
+  if (String(candidate.code ?? "").toUpperCase() !== "TRANSACTION_REPLACED") {
+    return { kind: "none" };
+  }
+  const replacement =
+    candidate.replacement && typeof candidate.replacement === "object"
+      ? (candidate.replacement as Record<string, unknown>)
+      : null;
+  const receipt = candidate.receipt ?? replacement?.receipt ?? null;
+  const receiptRecord =
+    receipt && typeof receipt === "object"
+      ? (receipt as Record<string, unknown>)
+      : null;
+  const hashCandidate =
+    replacement?.hash ??
+    replacement?.transactionHash ??
+    receiptRecord?.hash ??
+    receiptRecord?.transactionHash;
+  const hash =
+    typeof hashCandidate === "string" && /^0x[0-9a-fA-F]{64}$/.test(hashCandidate)
+      ? hashCandidate.toLowerCase()
+      : null;
+  const reason = String(candidate.reason ?? "").trim().toLowerCase();
+  return {
+    kind: "replacement",
+    cancelled:
+      candidate.cancelled === true || reason === "cancelled" || reason === "canceled",
+    hash,
+    receipt,
+  };
+}
+
+async function readPathMintTransactionReceipt(
+  receiptProvider: ProviderInterface,
+  hash: string,
+): Promise<unknown> {
+  if (supportsRpcRequest(receiptProvider)) {
+    return receiptProvider.request?.({
+      method: "eth_getTransactionReceipt",
+      params: [hash],
+    });
+  }
+  const waiter = (receiptProvider as any)?.waitForTransaction;
+  if (typeof waiter === "function") {
+    return waiter.call(receiptProvider, hash);
+  }
+  return null;
+}
+
+async function readPathMintSubmissionContext(
+  walletProvider: ProviderInterface,
+  expectedAccount: string,
+  expectedChainId: bigint,
+): Promise<PathMintSubmissionContext> {
+  if (!supportsRpcRequest(walletProvider)) {
+    throw new Error("wallet context unavailable before PATH mint.");
+  }
+  const [accountsResult, actualChainId] = await Promise.all([
+    walletProvider.request?.({ method: "eth_accounts" }),
+    getChainId(walletProvider),
+  ]);
+  const account = Array.isArray(accountsResult)
+    ? String(accountsResult[0] ?? "").toLowerCase()
+    : "";
+  if (!/^0x[0-9a-f]{40}$/.test(account) || account !== expectedAccount.toLowerCase()) {
+    throw new Error("wallet account changed before PATH mint.");
+  }
+  if (actualChainId !== expectedChainId) {
+    throw new Error("wallet network changed before PATH mint.");
+  }
+  return { account, chainId: actualChainId };
 }
 
 function toNumberSafe(v: string | number): number {
@@ -2345,7 +2590,9 @@ export default function AuctionCanvas({
     () => releaseConfigToAuctionConfig(protocolRelease, decimals),
     [protocolRelease, decimals]
   );
-  const pathMintIntent = useMemo(() => readPathMintIntent(), []);
+  const pathMintIntentRead = useMemo(() => readPathMintIntent(), []);
+  const pathMintIntent =
+    pathMintIntentRead.kind === "valid" ? pathMintIntentRead.intent : null;
   const releaseMissing = !fixtureState && !allowDirectAuction && !protocolRelease;
   const network = useMemo(() => {
     const raw = getEnvValue("VITE_NETWORK");
@@ -2533,7 +2780,77 @@ export default function AuctionCanvas({
     }
   }, [coreData?.price, decimals, fixtureState]);
   const effectiveCurrentAskQuoteDec = currentAskQuoteDec ?? coreCurrentAskDec;
-  const [returnPromptVisible, setReturnPromptVisible] = useState(false);
+  const [pathMintReturnState, setPathMintReturnState] =
+    useState<PathMintReturnRecord | null>(() =>
+      pathMintIntent
+        ? readMatchingPathMintReturnRecord(pathMintIntent)
+        : null
+    );
+  const pathMintReturnStateRef = useRef(pathMintReturnState);
+  const pathMintReturnMonitorInFlightRef = useRef<string | null>(null);
+  const pathMintReturnMonitorRetryTimerRef = useRef<number | null>(null);
+  const pathMintReturnMonitorMountedRef = useRef(true);
+  const pathMintSubmissionInFlightRef = useRef(false);
+  const [pathMintReturnMonitorWake, setPathMintReturnMonitorWake] = useState(0);
+  const persistPathMintReturnState = useCallback(
+    (next: PathMintReturnRecord) => {
+      if (!pathMintIntent || next.handoffId !== pathMintIntent.handoffId) return;
+      pathMintReturnStateRef.current = next;
+      setPathMintReturnState(next);
+      writePathMintReturnRecord(getPathMintReturnStorageHost(), next);
+      if (next.status === "submitted") {
+        setPathMintReturnMonitorWake((value) => value + 1);
+      }
+    },
+    [pathMintIntent]
+  );
+  const clearPathMintReturnState = useCallback(() => {
+    if (pathMintReturnMonitorRetryTimerRef.current !== null) {
+      window.clearTimeout(pathMintReturnMonitorRetryTimerRef.current);
+      pathMintReturnMonitorRetryTimerRef.current = null;
+    }
+    pathMintReturnStateRef.current = null;
+    setPathMintReturnState(null);
+    if (pathMintIntent) {
+      removePathMintReturnRecord(
+        getPathMintReturnStorageHost(),
+        pathMintIntent.handoffId,
+      );
+    }
+  }, [pathMintIntent]);
+  const schedulePathMintReturnMonitor = useCallback((hash: string) => {
+    if (pathMintReturnMonitorRetryTimerRef.current !== null) return;
+    pathMintReturnMonitorRetryTimerRef.current = window.setTimeout(() => {
+      pathMintReturnMonitorRetryTimerRef.current = null;
+      const current = pathMintReturnStateRef.current;
+      if (current?.status === "submitted" && current.txHash === hash) {
+        setPathMintReturnMonitorWake((value) => value + 1);
+      }
+    }, PATH_MINT_RECEIPT_RETRY_MS);
+  }, []);
+  const updatePathMintReturnTokenId = useCallback(
+    (txHashValue: string, tokenId: number) => {
+      const current = pathMintReturnStateRef.current;
+      if (
+        !pathMintIntent ||
+        !current ||
+        current.handoffId !== pathMintIntent.handoffId ||
+        current.txHash.toLowerCase() !== txHashValue.toLowerCase()
+      ) {
+        return;
+      }
+      const next = parsePathMintReturnRecord(
+        {
+          ...current,
+          tokenId: String(tokenId),
+          updatedAt: Date.now(),
+        },
+        pathMintIntent.handoffId,
+      );
+      if (next) persistPathMintReturnState(next);
+    },
+    [pathMintIntent, persistPathMintReturnState]
+  );
   const [walletPickerOpen, setWalletPickerOpen] = useState(false);
   const preflightRef = useRef<Promise<PreflightResult | null> | null>(null);
   const ctaStackRef = useRef<HTMLDivElement | null>(null);
@@ -2645,6 +2962,42 @@ export default function AuctionCanvas({
     chainIdValue !== null &&
     targetChainId !== null &&
     chainIdValue === targetChainId;
+  const pathMintIntentBlock = useMemo(() => {
+    if (pathMintReturnState) return null;
+    if (pathMintIntentRead.kind === "invalid") {
+      return pathMintIntentRead.reason;
+    }
+    if (!pathMintIntent) return null;
+    if (targetChainId === null || pathMintIntent.chainId !== targetChainId) {
+      return `THOUGHT handoff targets chain ${pathMintIntent.chainId.toString()}; PATH is configured for ${
+        targetChainId?.toString() ?? "an unknown chain"
+      }.`;
+    }
+    if (
+      isConnected &&
+      walletAddress &&
+      pathMintIntent.originAccount &&
+      walletAddress.toLowerCase() !== pathMintIntent.originAccount
+    ) {
+      return `Switch to the THOUGHT wallet ${shortAddr(pathMintIntent.originAccount)}.`;
+    }
+    if (
+      isConnected &&
+      chainIdValue !== null &&
+      chainIdValue !== pathMintIntent.chainId
+    ) {
+      return `Switch wallet to THOUGHT chain ${pathMintIntent.chainId.toString()}.`;
+    }
+    return null;
+  }, [
+    chainIdValue,
+    pathMintIntent,
+    pathMintIntentRead,
+    pathMintReturnState,
+    targetChainId,
+    walletAddress,
+    isConnected,
+  ]);
   const hasDetectedWalletConnector = useMemo(() => {
     if (!connectors?.length) return false;
     return connectors.some((connector) => isConnectorAvailable(connector));
@@ -3197,6 +3550,180 @@ export default function AuctionCanvas({
   }, [bids]);
 
   useEffect(() => {
+    pathMintReturnMonitorMountedRef.current = true;
+    return () => {
+      pathMintReturnMonitorMountedRef.current = false;
+      if (pathMintReturnMonitorRetryTimerRef.current !== null) {
+        window.clearTimeout(pathMintReturnMonitorRetryTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pathMintIntent) return;
+    const storageKey = pathMintReturnStorageKey(pathMintIntent.handoffId);
+    if (!storageKey) return;
+
+    const adoptStoredRecord = () => {
+      const record = readPathMintReturnRecord(
+        getPathMintReturnStorageHost(),
+        pathMintIntent.handoffId,
+      );
+      const next = record;
+      pathMintReturnStateRef.current = next;
+      setPathMintReturnState(next);
+      if (next?.status === "submitted") {
+        setPathMintReturnMonitorWake((value) => value + 1);
+      }
+    };
+    const wakeMonitor = () => {
+      if (pathMintReturnStateRef.current?.status === "submitted") {
+        setPathMintReturnMonitorWake((value) => value + 1);
+      }
+    };
+    const handleStorage = (event: globalThis.StorageEvent) => {
+      if (event.key === storageKey) adoptStoredRecord();
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") wakeMonitor();
+    };
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener("focus", wakeMonitor);
+    window.addEventListener("online", wakeMonitor);
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener("focus", wakeMonitor);
+      window.removeEventListener("online", wakeMonitor);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [pathMintIntent]);
+
+  useEffect(() => {
+    const record = pathMintReturnState;
+    if (
+      !pathMintIntent ||
+      record?.status !== "submitted" ||
+      record.handoffId !== pathMintIntent.handoffId ||
+      pathMintReturnMonitorInFlightRef.current === record.txHash
+    ) {
+      return;
+    }
+
+    const waitProvider = provider ?? (getDefaultProvider() as ProviderInterface);
+    pathMintReturnMonitorInFlightRef.current = record.txHash;
+    void Promise.resolve()
+      .then(() => readPathMintTransactionReceipt(waitProvider, record.txHash))
+      .then((receipt) => {
+        const current = pathMintReturnStateRef.current;
+        if (
+          !pathMintReturnMonitorMountedRef.current ||
+          current?.status !== "submitted" ||
+          current.txHash !== record.txHash
+        ) {
+          return;
+        }
+        const outcome = transactionReceiptOutcome(receipt);
+        if (outcome === "success") {
+          const confirmed = parsePathMintReturnRecord(
+            {
+              ...record,
+              status: "confirmed",
+              updatedAt: Date.now(),
+            },
+            pathMintIntent.handoffId,
+          );
+          if (confirmed) persistPathMintReturnState(confirmed);
+          return;
+        }
+        if (outcome === "reverted") {
+          clearPathMintReturnState();
+          setTxError("PATH mint transaction reverted.");
+          setTxState("failed");
+          return;
+        }
+        schedulePathMintReturnMonitor(record.txHash);
+      })
+      .catch((error) => {
+        const current = pathMintReturnStateRef.current;
+        if (
+          !pathMintReturnMonitorMountedRef.current ||
+          current?.status !== "submitted" ||
+          current.txHash !== record.txHash
+        ) {
+          return;
+        }
+        const replacement = transactionReplacement(error);
+        if (replacement.kind === "replacement") {
+          const outcome = transactionReceiptOutcome(replacement.receipt);
+          if (replacement.cancelled || outcome === "reverted") {
+            clearPathMintReturnState();
+            setTxError(
+              replacement.cancelled
+                ? "PATH mint transaction cancelled."
+                : "PATH mint transaction reverted.",
+            );
+            setTxState("failed");
+            return;
+          }
+          if (!replacement.hash) {
+            showToast({
+              kind: "warn",
+              text: "Replacement detected; hash unavailable. Tracking delayed.",
+            });
+            setTxState("submitted");
+            schedulePathMintReturnMonitor(record.txHash);
+            return;
+          }
+          const migrated = parsePathMintReturnRecord(
+            {
+              ...record,
+              status: outcome === "success" ? "confirmed" : "submitted",
+              txHash: replacement.hash,
+              updatedAt: Date.now(),
+            },
+            pathMintIntent.handoffId,
+          );
+          if (!migrated) {
+            clearPathMintReturnState();
+            setTxError("Invalid PATH mint replacement metadata.");
+            setTxState("failed");
+            return;
+          }
+          if (pathMintReturnMonitorInFlightRef.current === record.txHash) {
+            pathMintReturnMonitorInFlightRef.current = null;
+          }
+          setLastTxHash(replacement.hash);
+          persistPathMintReturnState(migrated);
+          setTxState(outcome === "success" ? "confirmed" : "submitted");
+          return;
+        }
+        if (isExplicitTransactionFailure(error)) {
+          clearPathMintReturnState();
+          setTxError("PATH mint transaction reverted.");
+          setTxState("failed");
+          return;
+        }
+        schedulePathMintReturnMonitor(record.txHash);
+      })
+      .finally(() => {
+        if (pathMintReturnMonitorInFlightRef.current === record.txHash) {
+          pathMintReturnMonitorInFlightRef.current = null;
+        }
+      });
+
+  }, [
+    clearPathMintReturnState,
+    pathMintIntent,
+    pathMintReturnState,
+    pathMintReturnMonitorWake,
+    persistPathMintReturnState,
+    provider,
+    schedulePathMintReturnMonitor,
+    showToast,
+  ]);
+
+  useEffect(() => {
     if (!pendingMint || !bids.length) return;
     const targetHash = pendingMint.txHash.toLowerCase();
     const match = bids.find(
@@ -3236,6 +3763,7 @@ export default function AuctionCanvas({
       sourceUrl: buildPathMintSourceUrl(pendingMint.txHash, network ?? "sepolia"),
       sourceStatus: "indexing",
     });
+    updatePathMintReturnTokenId(pendingMint.txHash, tokenId);
     queueToast({ kind: "info", text: `$PATH #${tokenId} minted.` });
     void pullBidsOnce();
     void refreshCore();
@@ -3249,6 +3777,7 @@ export default function AuctionCanvas({
     queueToast,
     pullBidsOnce,
     refreshCore,
+    updatePathMintReturnTokenId,
   ]);
 
   useEffect(() => {
@@ -4565,7 +5094,10 @@ export default function AuctionCanvas({
   };
 
   const handlePending = () => {
-    const hash = effectiveTxHash ?? lastTxHash;
+    const hash =
+      pathMintReturnState?.status === "submitted"
+        ? pathMintReturnState.txHash
+        : effectiveTxHash ?? lastTxHash;
     if (!hash) return;
     const url = resolveExplorerTxUrl(hash);
     if (typeof window !== "undefined") {
@@ -4574,7 +5106,14 @@ export default function AuctionCanvas({
   };
 
   const handleReturnToThought = () => {
-    if (!pathMintIntent || typeof window === "undefined") return;
+    if (
+      !pathMintIntent ||
+      pathMintReturnState?.status !== "confirmed" ||
+      pathMintReturnState.handoffId !== pathMintIntent.handoffId ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
     window.location.assign(pathMintIntent.returnTo);
   };
 
@@ -4586,8 +5125,8 @@ export default function AuctionCanvas({
     await handleMint();
   };
 
-  const trackSubmittedBid = (hash: string) => {
-    if (!walletAddress) return;
+  const trackSubmittedBid = (hash: string, submittedAccount = walletAddress) => {
+    if (!submittedAccount) return;
     clearPathTokenInventoryCache();
     setCurrentAskQuoteDec(null);
     postMintNowTipPendingRef.current = true;
@@ -4601,19 +5140,54 @@ export default function AuctionCanvas({
     window.setTimeout(() => void pullBidsOnce(), 2_000);
     window.setTimeout(() => void pullBidsOnce(), 6_000);
     window.setTimeout(() => void refreshCore(), 2_000);
-    if (pathMintIntent) {
-      setReturnPromptVisible(true);
-    }
     setPendingMint({
       txHash: hash,
-      address: walletAddress,
+      address: submittedAccount,
       baselineTokenId: maxTokenId ?? null,
     });
   };
 
+  const buildPathMintReturnRecord = (
+    status: PathMintReturnRecord["status"],
+    hash: string,
+    submission: PathMintSubmissionContext,
+  ): PathMintReturnRecord | null => {
+    if (!pathMintIntent) return null;
+    return parsePathMintReturnRecord(
+      {
+        version: 1,
+        handoffId: pathMintIntent.handoffId,
+        status,
+        account: submission.account,
+        chainId: Number(submission.chainId),
+        txHash: hash,
+        baselineTokenId: maxTokenId ?? null,
+        updatedAt: Date.now(),
+      },
+      pathMintIntent.handoffId,
+    );
+  };
+
+  const keepPathMintSubmitted = (
+    hash: string,
+    submission?: PathMintSubmissionContext,
+    noticeText = "Submitted. Confirmation check delayed.",
+  ) => {
+    trackSubmittedBid(hash, submission?.account);
+    showToast({
+      kind: "warn",
+      text: noticeText,
+    });
+    txIdleTimerRef.current = window.setTimeout(() => {
+      setTxState("idle");
+      txIdleTimerRef.current = null;
+    }, 15_000);
+  };
+
   const runTx = async (
     phase: TxPhase,
-    call: () => Promise<any>
+    call: () => Promise<any>,
+    pathSubmission?: PathMintSubmissionContext,
   ): Promise<boolean> => {
     try {
       if (txIdleTimerRef.current) {
@@ -4629,7 +5203,7 @@ export default function AuctionCanvas({
         });
       }
       const res = await call();
-      const hash =
+      let hash =
         res?.transaction_hash ??
         res?.transactionHash ??
         res?.hash ??
@@ -4640,6 +5214,20 @@ export default function AuctionCanvas({
       setTxHash(hash);
       setLastTxHash(hash);
       setTxState("submitted");
+      if (phase === "bid" && pathMintIntent) {
+        if (!pathSubmission) {
+          throw new Error("Missing verified PATH mint submission context.");
+        }
+        const submittedRecord = buildPathMintReturnRecord(
+          "submitted",
+          hash,
+          pathSubmission,
+        );
+        if (!submittedRecord) {
+          throw new Error("Invalid PATH mint handoff transaction metadata.");
+        }
+        persistPathMintReturnState(submittedRecord);
+      }
       if (phase === "bid") {
         trackPathMintAnalytics("mint_started", {
           mintStage: "submitted",
@@ -4648,27 +5236,103 @@ export default function AuctionCanvas({
       showToast({ kind: "info", text: `Submitted: ${shortHash(hash)}.` });
       const waitProvider =
         provider ?? (getDefaultProvider() as ProviderInterface);
+      const accountWaiter = (account as any)?.waitForTransaction;
+      const providerWaiter = (waitProvider as any)?.waitForTransaction;
+      const waiterOwner =
+        typeof accountWaiter === "function"
+          ? account
+          : typeof providerWaiter === "function"
+            ? waitProvider
+            : null;
       const waiter =
-        (account as any)?.waitForTransaction ??
-        (waitProvider as any)?.waitForTransaction;
+        waiterOwner === account ? accountWaiter : providerWaiter;
       if (typeof waiter === "function") {
+        let replacementConfirmed = false;
         try {
-          await waiter.call(account ?? waitProvider, hash);
-        } catch (waitErr) {
-          if (phase === "bid" && isTransientRpcError(waitErr)) {
-            trackSubmittedBid(hash);
-            showToast({
-              kind: "warn",
-              text: "Submitted. Confirmation check delayed.",
-            });
-            txIdleTimerRef.current = window.setTimeout(() => {
-              setTxState("idle");
-              txIdleTimerRef.current = null;
-            }, 15_000);
-            return true;
+          const receipt = await waiter.call(waiterOwner, hash);
+          if (phase === "bid" && pathMintIntent) {
+            const outcome = transactionReceiptOutcome(receipt);
+            if (outcome === "reverted") {
+              clearPathMintReturnState();
+              throw new Error("PATH mint transaction reverted.");
+            }
+            if (outcome !== "success") {
+              keepPathMintSubmitted(hash, pathSubmission);
+              return true;
+            }
           }
-          throw waitErr;
+        } catch (waitErr) {
+          if (phase === "bid" && pathMintIntent) {
+            const replacement = transactionReplacement(waitErr);
+            if (replacement.kind === "replacement") {
+              const outcome = transactionReceiptOutcome(replacement.receipt);
+              if (replacement.cancelled || outcome === "reverted") {
+                clearPathMintReturnState();
+                throw new Error(
+                  replacement.cancelled
+                    ? "PATH mint transaction cancelled."
+                    : "PATH mint transaction reverted.",
+                );
+              }
+              if (!replacement.hash) {
+                keepPathMintSubmitted(
+                  hash,
+                  pathSubmission,
+                  "Replacement detected; hash unavailable. Tracking delayed.",
+                );
+                return true;
+              }
+              hash = replacement.hash;
+              setTxHash(hash);
+              setLastTxHash(hash);
+              const current = pathMintReturnStateRef.current;
+              const migrated = parsePathMintReturnRecord(
+                current
+                  ? {
+                      ...current,
+                      status:
+                        outcome === "success" ? "confirmed" : "submitted",
+                      txHash: hash,
+                      updatedAt: Date.now(),
+                    }
+                  : pathSubmission
+                    ? buildPathMintReturnRecord(
+                        outcome === "success" ? "confirmed" : "submitted",
+                        hash,
+                        pathSubmission,
+                      )
+                    : null,
+                pathMintIntent.handoffId,
+              );
+              if (!migrated) {
+                clearPathMintReturnState();
+                throw new Error("Invalid PATH mint replacement metadata.");
+              }
+              persistPathMintReturnState(migrated);
+              if (outcome !== "success") {
+                keepPathMintSubmitted(hash, pathSubmission);
+                return true;
+              }
+              replacementConfirmed = true;
+            } else if (isExplicitTransactionFailure(waitErr)) {
+              clearPathMintReturnState();
+              throw waitErr;
+            } else {
+              keepPathMintSubmitted(hash, pathSubmission);
+              return true;
+            }
+          }
+          if (!replacementConfirmed) {
+            if (phase === "bid" && isTransientRpcError(waitErr)) {
+              keepPathMintSubmitted(hash, pathSubmission);
+              return true;
+            }
+            throw waitErr;
+          }
         }
+      } else if (phase === "bid" && pathMintIntent) {
+        keepPathMintSubmitted(hash, pathSubmission);
+        return true;
       }
       setTxState("confirmed");
       showToast({
@@ -4676,10 +5340,29 @@ export default function AuctionCanvas({
         text: phase === "bid" ? "Settlement confirmed. Loading sale event." : "Confirmed.",
       });
       if (phase === "bid") {
+        if (pathMintIntent) {
+          const submittedRecord = pathMintReturnStateRef.current;
+          const confirmedRecord = parsePathMintReturnRecord(
+            submittedRecord?.txHash.toLowerCase() === String(hash).toLowerCase()
+              ? {
+                  ...submittedRecord,
+                  status: "confirmed",
+                  updatedAt: Date.now(),
+                }
+              : pathSubmission
+                ? buildPathMintReturnRecord("confirmed", hash, pathSubmission)
+                : null,
+            pathMintIntent.handoffId,
+          );
+          if (!confirmedRecord) {
+            throw new Error("Invalid confirmed PATH mint metadata.");
+          }
+          persistPathMintReturnState(confirmedRecord);
+        }
         trackPathMintAnalytics("mint_succeeded", {
           mintStage: "confirmed",
         });
-        trackSubmittedBid(hash);
+        trackSubmittedBid(hash, pathSubmission?.account);
       }
       txIdleTimerRef.current = window.setTimeout(() => {
         setTxState("idle");
@@ -4703,6 +5386,9 @@ export default function AuctionCanvas({
         console.error("mint failed", err);
       }
       if (phase === "bid") {
+        if (pathMintIntent && isExplicitTransactionFailure(err)) {
+          clearPathMintReturnState();
+        }
         const errorCode = walletErrorCode(err);
         trackPathMintAnalytics("mint_failed", {
           mintStage: walletCancelled ? "wallet_signature" : "transaction",
@@ -4719,6 +5405,10 @@ export default function AuctionCanvas({
 
   const handleMint = async () => {
     if (debugActive) return;
+    if (pathMintIntentBlock) {
+      showToast({ kind: "warn", text: pathMintIntentBlock });
+      return;
+    }
     if (auctionBlocksMint) {
       showToast({ kind: "info", text: auctionBlockedMintNotice });
       return;
@@ -4732,87 +5422,157 @@ export default function AuctionCanvas({
       }
       return;
     }
-    if (confirmingMint) {
-      setTxPhase("prepare");
-      setTxState("awaiting_signature");
-      setTxError(null);
-    }
-    const data = await runPreflight();
-    if (!data?.ask || !data.balance || !data.allowance) {
-      if (confirmingMint) {
-        const message = preflight.error || "preflight failed before wallet request.";
-        setTxError(message);
-        setTxPhase(null);
-        setTxState("failed");
-        showToast({
-          kind: "error",
-          text: "Mint preflight failed.",
-          reportState: "mint_preflight_failed",
-          reportError: message,
-        });
-      }
+    if (confirmingMint && pathMintSubmissionInFlightRef.current) {
+      showToast({ kind: "warn", text: "PATH mint already in progress." });
       return;
     }
-    if (data.balance.value < data.ask.value) {
-      setMintReview(null);
-      if (confirmingMint) {
-        setTxError("insufficient balance.");
-        setTxPhase(null);
-        setTxState("failed");
-      }
-      return;
-    }
-    if (!confirmingMint) {
-      const askEstimate = currentAskEstimateRef.current;
-      const priceLabel =
-        mimicLocalTime && askEstimate != null && Number.isFinite(askEstimate)
-          ? formatHumanTokenAmount(askEstimate, 8)
-          : formatTokenAmount(data.ask, decimals);
-      setMintReview({
-        ask: data.ask,
-        symbol: displayTokenSymbol,
-        priceLabel,
-        txValueLabel: nativePayment ? priceLabel : "0",
-        maxPriceLabel: priceLabel,
-        nativePayment,
-        requiresApproval: !nativePayment && data.allowance.value < data.ask.value,
-      });
-      return;
-    }
+    if (confirmingMint) pathMintSubmissionInFlightRef.current = true;
 
-    setMintReview(null);
-    setReturnPromptVisible(false);
-    await refreshWalletChainRpc(targetChainIdHex, evm.provider);
-    await maybeWatchAsset();
-    if (!nativePayment && data.allowance.value < data.ask.value) {
-      const ok = await runTx("approve", () =>
-        account.execute({
-          contractAddress: paymentToken,
-          entrypoint: "approve",
-          calldata: [auctionAddress, data.ask.raw.low, data.ask.raw.high],
-        })
-      );
-      if (!ok) return;
+    try {
+      if (confirmingMint) {
+        setTxPhase("prepare");
+        setTxState("awaiting_signature");
+        setTxError(null);
+      }
+      const data = await runPreflight();
+      if (!data?.ask || !data.balance || !data.allowance) {
+        if (confirmingMint) {
+          const message = preflight.error || "preflight failed before wallet request.";
+          setTxError(message);
+          setTxPhase(null);
+          setTxState("failed");
+          showToast({
+            kind: "error",
+            text: "Mint preflight failed.",
+            reportState: "mint_preflight_failed",
+            reportError: message,
+          });
+        }
+        return;
+      }
+      if (data.balance.value < data.ask.value) {
+        setMintReview(null);
+        if (confirmingMint) {
+          setTxError("insufficient balance.");
+          setTxPhase(null);
+          setTxState("failed");
+        }
+        return;
+      }
+      if (!confirmingMint) {
+        const askEstimate = currentAskEstimateRef.current;
+        const priceLabel =
+          mimicLocalTime && askEstimate != null && Number.isFinite(askEstimate)
+            ? formatHumanTokenAmount(askEstimate, 8)
+            : formatTokenAmount(data.ask, decimals);
+        setMintReview({
+          ask: data.ask,
+          symbol: displayTokenSymbol,
+          priceLabel,
+          txValueLabel: nativePayment ? priceLabel : "0",
+          maxPriceLabel: priceLabel,
+          nativePayment,
+          requiresApproval: !nativePayment && data.allowance.value < data.ask.value,
+        });
+        return;
+      }
+
+      setMintReview(null);
+      const submitMint = async () => {
+        if (pathMintIntent) {
+          const storedRecord = readPathMintReturnRecord(
+            getPathMintReturnStorageHost(),
+            pathMintIntent.handoffId,
+          );
+          if (storedRecord) {
+            pathMintReturnStateRef.current = storedRecord;
+            setPathMintReturnState(storedRecord);
+            setTxState(storedRecord.status === "submitted" ? "submitted" : "confirmed");
+            setTxPhase(null);
+            showToast({
+              kind: "info",
+              text:
+                storedRecord.status === "submitted"
+                  ? "PATH mint already submitted."
+                  : "PATH mint already confirmed.",
+            });
+            return;
+          }
+        }
+
+        await refreshWalletChainRpc(targetChainIdHex, evm.provider);
+        await maybeWatchAsset();
+        if (!nativePayment && data.allowance.value < data.ask.value) {
+          const ok = await runTx("approve", () =>
+            account.execute({
+              contractAddress: paymentToken,
+              entrypoint: "approve",
+              calldata: [auctionAddress, data.ask.raw.low, data.ask.raw.high],
+            })
+          );
+          if (!ok) return;
+        }
+
+        const pathSubmission = pathMintIntent
+          ? await readPathMintSubmissionContext(
+              evm.provider as ProviderInterface,
+              pathMintIntent.originAccount ?? walletAddress,
+              pathMintIntent.chainId,
+            )
+          : undefined;
+        const bidCall = {
+          contractAddress: auctionAddress,
+          entrypoint: "bid",
+          calldata: [data.ask.raw.low, data.ask.raw.high],
+          value: nativePayment ? data.ask.value : undefined,
+        };
+        await runTx(
+          "bid",
+          () => {
+            assertPulseBidIntent({
+              contractAddress: bidCall.contractAddress,
+              expectedContractAddress: auctionAddress,
+              calldata: bidCall.calldata,
+              maxPrice: data.ask,
+              value: bidCall.value,
+              nativePayment,
+              chainId: pathSubmission?.chainId ?? chainIdValue,
+              targetChainId,
+            });
+            return account.execute(bidCall);
+          },
+          pathSubmission,
+        );
+      };
+
+      if (pathMintIntent) {
+        const lockResult = await withPathMintSubmissionLock(
+          pathMintIntent.handoffId,
+          submitMint,
+        );
+        if (lockResult !== "acquired") {
+          setTxState("idle");
+          setTxPhase(null);
+          showToast({
+            kind: "warn",
+            text:
+              lockResult === "unsupported"
+                ? "PATH minting requires browser tab coordination (Web Locks), which this browser does not support."
+                : "This PATH mint is already open in another tab.",
+          });
+        }
+      } else {
+        await submitMint();
+      }
+    } catch (error) {
+      const message = walletErrorMessage(error) || "PATH mint preparation failed.";
+      setTxError(message);
+      setTxPhase(null);
+      setTxState("failed");
+      showToast({ kind: "error", text: message });
+    } finally {
+      if (confirmingMint) pathMintSubmissionInFlightRef.current = false;
     }
-    const bidCall = {
-      contractAddress: auctionAddress,
-      entrypoint: "bid",
-      calldata: [data.ask.raw.low, data.ask.raw.high],
-      value: nativePayment ? data.ask.value : undefined,
-    };
-    await runTx("bid", () => {
-      assertPulseBidIntent({
-        contractAddress: bidCall.contractAddress,
-        expectedContractAddress: auctionAddress,
-        calldata: bidCall.calldata,
-        maxPrice: data.ask,
-        value: bidCall.value,
-        nativePayment,
-        chainId: chainIdValue,
-        targetChainId,
-      });
-      return account.execute(bidCall);
-    });
   };
 
   const persistentNotice = useMemo<Notice | null>(() => {
@@ -4820,6 +5580,15 @@ export default function AuctionCanvas({
       ctaOverrideActive || noticeOverrideActive
         ? effectiveAskLabel
         : liveAskLabel ?? effectiveAskLabel;
+    if (pathMintReturnState?.status === "confirmed") {
+      return { kind: "info", text: "$PATH minted. Return to THOUGHT." };
+    }
+    if (pathMintReturnState?.status === "submitted") {
+      return { kind: "info", text: "$PATH mint submitted. Waiting for confirmation." };
+    }
+    if (pathMintIntentBlock) {
+      return { kind: "warn", text: pathMintIntentBlock };
+    }
     if (auctionBlocksMint) {
       return { kind: "info", text: auctionBlockedMintNotice };
     }
@@ -4910,13 +5679,6 @@ export default function AuctionCanvas({
     if (pendingMint) {
       return { kind: "info", text: "Settlement confirmed. Loading sale event." };
     }
-    if (
-      pathMintIntent &&
-      returnPromptVisible &&
-      (effectiveTxState === "idle" || effectiveTxState === "confirmed")
-    ) {
-      return { kind: "info", text: "$PATH minted. Return to THOUGHT." };
-    }
     if (!effectiveWalletDetected) {
       return {
         kind: "error",
@@ -5002,8 +5764,8 @@ export default function AuctionCanvas({
     displayTokenSymbol,
     auctionBlocksMint,
     auctionBlockedMintNotice,
-    pathMintIntent,
-    returnPromptVisible,
+    pathMintIntentBlock,
+    pathMintReturnState,
     pendingMint,
     isMetaMaskWallet,
   ]);
@@ -5073,6 +5835,19 @@ export default function AuctionCanvas({
       : "off";
 
   const ctaState = (() => {
+    if (pathMintReturnState?.status === "confirmed") {
+      return {
+        label: "return",
+        disabled: false,
+        onClick: handleReturnToThought,
+      };
+    }
+    if (pathMintReturnState?.status === "submitted") {
+      return { label: "pending", disabled: false, onClick: handlePending };
+    }
+    if (pathMintIntentBlock) {
+      return { label: "mint", disabled: true, onClick: handleMint };
+    }
     if (effectiveWalletUnlocked && effectiveChainKnown && !effectiveChainOk) {
       return { label: "mint", disabled: true, onClick: handleMint };
     }
@@ -5096,17 +5871,6 @@ export default function AuctionCanvas({
     }
     if (effectiveTxState === "failed") {
       return { label: "retry", disabled: false, onClick: handleRetry };
-    }
-    if (
-      pathMintIntent &&
-      returnPromptVisible &&
-      (effectiveTxState === "idle" || effectiveTxState === "confirmed")
-    ) {
-      return {
-        label: "return",
-        disabled: false,
-        onClick: handleReturnToThought,
-      };
     }
     if (
       mintReview &&
@@ -6222,7 +6986,7 @@ export default function AuctionCanvas({
       style={dotfieldStyle}
       data-layout-zoomed={isPathStageLayoutZoomed ? "true" : "false"}
     >
-      {!isDesktop && (
+      {!isDesktop && !pathMintIntent && (
         <div className="dotfield__overlay">
           <div className="muted small">
             This view needs more room. Please widen your window or use a larger screen.
@@ -6292,6 +7056,9 @@ export default function AuctionCanvas({
               : "is-info"
             : "is-empty"
         }`}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
       >
         {displayNotice?.text ?? ""}
         {displayWalletRpcFix && (

--- a/apps/home/src/pathMintSubmissionLock.ts
+++ b/apps/home/src/pathMintSubmissionLock.ts
@@ -1,0 +1,50 @@
+export type PathMintSubmissionLockResult =
+  | "acquired"
+  | "busy"
+  | "unsupported";
+
+type PathMintLockManager = {
+  request(
+    name: string,
+    options: { mode: "exclusive"; ifAvailable: true },
+    callback: (lock: unknown | null) => Promise<void>,
+  ): Promise<void>;
+};
+
+export async function withPathMintSubmissionLock(
+  handoffId: string,
+  task: () => Promise<void>,
+): Promise<PathMintSubmissionLockResult> {
+  const lockManager = (
+    typeof navigator === "undefined"
+      ? null
+      : (navigator as globalThis.Navigator & {
+          locks?: PathMintLockManager;
+        })
+  )?.locks;
+  if (typeof lockManager?.request !== "function") return "unsupported";
+
+  let result: PathMintSubmissionLockResult = "busy";
+  let taskFailure: { error: unknown } | null = null;
+  try {
+    await lockManager.request(
+      `inshell:path-mint-submit:${handoffId}`,
+      { mode: "exclusive", ifAvailable: true },
+      async (lock) => {
+        if (!lock) return;
+        result = "acquired";
+        try {
+          await task();
+        } catch (error) {
+          taskFailure = { error };
+        }
+      },
+    );
+  } catch {
+    // An inaccessible Web Locks implementation cannot safely coordinate tabs.
+    return "unsupported";
+  }
+
+  if (taskFailure) throw taskFailure.error;
+  return result;
+}

--- a/apps/home/tests/AuctionCanvas.test.tsx
+++ b/apps/home/tests/AuctionCanvas.test.tsx
@@ -20,6 +20,7 @@ import {
 import { encodeFunctionData, getAbiItem } from "viem";
 import React from "react";
 import AuctionCanvas from "../src/components/AuctionCanvas";
+import { withPathMintSubmissionLock } from "../src/pathMintSubmissionLock";
 import { mockAuctionCore } from "./testUtils";
 /* global SVGLineElement */
 
@@ -42,6 +43,101 @@ const STARTUP_GRACE_MS = 2500;
 const DELAY_MS = 500;
 const SAMPLE_BASE_MS = Date.now() - 2 * 60 * 1000;
 const DEFAULT_WALLET_ADDRESS = "0x1111222233334444555566667777888899990000";
+const PATH_HANDOFF_ID = "mint-test-handoff-1";
+const PATH_MINT_RETURN_STORAGE_PREFIX = "inshell:path-mint-return:v1:";
+const PATH_TX_HASH = `0x${"ab".repeat(32)}`;
+
+type PathMintLockRequest = (
+  name: string,
+  options: { mode: "exclusive"; ifAvailable: true },
+  callback: (lock: unknown | null) => Promise<void>,
+) => Promise<void>;
+
+function setPathMintLockRequest(request: PathMintLockRequest | null) {
+  Object.defineProperty(navigator, "locks", {
+    configurable: true,
+    value: request ? { request } : undefined,
+  });
+}
+
+function createPathWalletProvider(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  return {
+    request: jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_accounts") return [DEFAULT_WALLET_ADDRESS];
+      if (method === "eth_chainId") return "0xaa36a7";
+      if (method === "wallet_addEthereumChain") return null;
+      return null;
+    }),
+    ...overrides,
+  };
+}
+
+function setPathMintIntentUrl(
+  overrides: {
+    handoffId?: string;
+    account?: string | null;
+    chainId?: string;
+    movement?: string;
+    returnTo?: string;
+  } = {},
+) {
+  const handoffId = overrides.handoffId ?? PATH_HANDOFF_ID;
+  const returnTo =
+    overrides.returnTo ?? `/thought?pathHandoff=${encodeURIComponent(handoffId)}`;
+  const params = new URLSearchParams({
+    intent: "mint-path",
+    from: "thought",
+    returnTo,
+    handoff: handoffId,
+    chainId: overrides.chainId ?? "11155111",
+    movement: overrides.movement ?? "THOUGHT",
+  });
+  const account =
+    overrides.account === undefined ? DEFAULT_WALLET_ADDRESS : overrides.account;
+  if (account !== null) params.set("account", account);
+  window.history.pushState({}, "", `/?${params.toString()}`);
+  return { handoffId, returnTo };
+}
+
+function pathMintReturnRecord(
+  overrides: Partial<{
+    handoffId: string;
+    status: "submitted" | "confirmed";
+    account: string;
+    chainId: number;
+    txHash: string;
+    tokenId: string;
+    baselineTokenId: number | null;
+    updatedAt: number;
+  }> = {},
+) {
+  return {
+    version: 1,
+    handoffId: overrides.handoffId ?? PATH_HANDOFF_ID,
+    status: overrides.status ?? "confirmed",
+    account: overrides.account ?? DEFAULT_WALLET_ADDRESS,
+    chainId: overrides.chainId ?? 11155111,
+    txHash: overrides.txHash ?? PATH_TX_HASH,
+    baselineTokenId: overrides.baselineTokenId ?? 2,
+    updatedAt: overrides.updatedAt ?? Date.now(),
+    ...(overrides.tokenId === undefined ? {} : { tokenId: overrides.tokenId }),
+  };
+}
+
+function clearPathMintReturnRecords(storage: {
+  length: number;
+  key(index: number): string | null;
+  removeItem(key: string): void;
+}) {
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index);
+    if (key?.startsWith(PATH_MINT_RETURN_STORAGE_PREFIX)) {
+      storage.removeItem(key);
+    }
+  }
+}
 
 function normalizeMockChainId(value: unknown): number | null {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
@@ -190,6 +286,13 @@ async function clickMintThenSign() {
 
 describe("AuctionCanvas", () => {
   beforeEach(() => {
+    clearPathMintReturnRecords(window.localStorage);
+    clearPathMintReturnRecords(window.sessionStorage);
+    setPathMintLockRequest(async (_name, _options, callback) => {
+      await callback({ name: "available-path-mint-lock" });
+    });
+    delete (mockProvider as any).waitForTransaction;
+    delete (mockProvider as any).request;
     mockWalletState = createWalletState();
     (globalThis as any).__VITE_ENV__ = {
       VITE_NETWORK: "sepolia",
@@ -232,6 +335,11 @@ describe("AuctionCanvas", () => {
     delete (window as any).ethereum;
     window.localStorage.removeItem("inshellDebug");
     window.localStorage.removeItem("inshell.pathMintProof.v1");
+    clearPathMintReturnRecords(window.localStorage);
+    clearPathMintReturnRecords(window.sessionStorage);
+    setPathMintLockRequest(null);
+    delete (mockProvider as any).waitForTransaction;
+    delete (mockProvider as any).request;
     window.history.pushState({}, "", "/");
   });
 
@@ -3207,16 +3315,16 @@ describe("AuctionCanvas", () => {
   });
 
   test("shows return CTA after THOUGHT mint-path success", async () => {
-    const returnTo = "/thought/runs/tar_123";
-    window.history.pushState(
-      {},
-      "",
-      `/?intent=mint-path&from=thought&returnTo=${encodeURIComponent(returnTo)}`
-    );
-    const execute = jest.fn().mockResolvedValue({ transaction_hash: "0x1" });
-    const waitForTransaction = jest.fn().mockResolvedValue({});
-    mockWalletState.account = { execute, waitForTransaction };
-    mockWalletState.watchAsset = jest.fn().mockResolvedValue(true);
+    const { handoffId } = setPathMintIntentUrl({ account: null });
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    const waitForTransaction = jest.fn().mockResolvedValue({ status: 1 });
+    mockWalletState = createWalletState({
+      account: { execute, waitForTransaction },
+      watchAsset: jest.fn().mockResolvedValue(true),
+      evm: { provider: createPathWalletProvider() },
+    });
     mockCallContract.mockReset();
     mockCallContract.mockImplementation(async (args: any) => {
       if (args?.entrypoint === "get_current_price") {
@@ -3231,12 +3339,850 @@ describe("AuctionCanvas", () => {
       return { result: [] } as any;
     });
 
-    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const { rerender } = render(
+      <AuctionCanvas address="0xabc" provider={mockProvider as any} />
+    );
     await clickMintThenSign();
 
     await waitFor(() => {
       expect(screen.getByText(/\[\s*return\s*\]/i)).toBeTruthy();
     });
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        handoffId,
+        status: "confirmed",
+        account: DEFAULT_WALLET_ADDRESS.toLowerCase(),
+        chainId: 11155111,
+        txHash: PATH_TX_HASH,
+      }),
+    );
+
+    mockUseAuctionBids.mockReturnValue({
+      bids: [
+        ...sampleBids,
+        {
+          key: `tx:${PATH_TX_HASH}`,
+          atMs: Date.now(),
+          amount: { raw: { low: "3", high: "0" }, dec: "3", value: 3n },
+          bidder: DEFAULT_WALLET_ADDRESS,
+          blockNumber: 12,
+          epochIndex: 7,
+          tokenId: 7,
+          txHash: PATH_TX_HASH,
+        },
+      ],
+      ready: true,
+      loading: false,
+      error: null,
+    });
+    rerender(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(
+            `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+          ) ?? "{}",
+        ).tokenId,
+      ).toBe("7");
+    });
+  });
+
+  test("lets execution failure beat accepted finality in a PATH receipt", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { handoffId } = setPathMintIntentUrl();
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockResolvedValue({
+          status: "confirmed",
+          execution_status: "REVERTED",
+          finality_status: "ACCEPTED_ON_L2",
+        }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+    try {
+      render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+      await clickMintThenSign();
+      await waitFor(() => {
+        expect(screen.getByText(/\[\s*retry\s*\]/i)).toBeTruthy();
+      });
+      expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+      expect(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ),
+      ).toBeNull();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("keeps a timed-out PATH receipt submitted without offering return", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest
+          .fn()
+          .mockRejectedValue(new Error("RPC request timed out")),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+    await waitFor(() => {
+      expect(screen.getByText(/\[\s*pending\s*\]/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(
+            `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+          ) ?? "{}",
+        ).status,
+      ).toBe("submitted");
+    });
+  });
+
+  test("migrates a repriced PATH mint to its confirmed replacement hash", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const replacementHash = `0x${"bc".repeat(32)}`;
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockRejectedValue({
+          code: "TRANSACTION_REPLACED",
+          reason: "repriced",
+          cancelled: false,
+          replacement: { hash: replacementHash },
+          receipt: { status: 1, transactionHash: replacementHash },
+        }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+
+    expect(await screen.findByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(
+            `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+          ) ?? "{}",
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          status: "confirmed",
+          txHash: replacementHash,
+        }),
+      );
+    });
+  });
+
+  test("keeps only a pending replacement hash for a repriced PATH mint", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const replacementHash = `0x${"cd".repeat(32)}`;
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    const receiptReads: string[] = [];
+    (mockProvider as any).request = jest.fn(
+      async ({ method, params }: { method: string; params?: string[] }) => {
+        if (method === "eth_getTransactionReceipt") {
+          receiptReads.push(params?.[0] ?? "");
+          return null;
+        }
+        return null;
+      },
+    );
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockRejectedValue({
+          code: "TRANSACTION_REPLACED",
+          reason: "repriced",
+          cancelled: false,
+          replacement: { hash: replacementHash },
+        }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+
+    await waitFor(() => {
+      const record = JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+      );
+      expect(record).toEqual(
+        expect.objectContaining({
+          status: "submitted",
+          txHash: replacementHash,
+        }),
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(new globalThis.Event("focus"));
+    });
+    await waitFor(() => {
+      expect(receiptReads[receiptReads.length - 1]).toBe(replacementHash);
+    });
+    expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+  });
+
+  test("retains the submitted PATH record when a replacement hash is unavailable", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockRejectedValue({
+          code: "TRANSACTION_REPLACED",
+          reason: "repriced",
+          cancelled: false,
+        }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+
+    expect(
+      await screen.findByText(/Replacement detected; hash unavailable/i),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(
+            `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+          ) ?? "{}",
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          status: "submitted",
+          txHash: PATH_TX_HASH,
+        }),
+      );
+    });
+    expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+  });
+
+  test("treats a cancelled PATH replacement as terminal", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { handoffId } = setPathMintIntentUrl();
+    const replacementHash = `0x${"de".repeat(32)}`;
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockRejectedValue({
+          code: "TRANSACTION_REPLACED",
+          reason: "cancelled",
+          cancelled: true,
+          replacement: { hash: replacementHash },
+          receipt: { status: 1, transactionHash: replacementHash },
+        }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    try {
+      render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+      await clickMintThenSign();
+      expect(await screen.findByText(/\[\s*retry\s*\]/i)).toBeTruthy();
+      expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+      expect(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ),
+      ).toBeNull();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("resumes a submitted PATH receipt after reload", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted" })),
+    );
+    const waitForTransaction = jest.fn(function (this: unknown) {
+      expect(this).toBe(mockProvider);
+      return Promise.resolve({ status: "0x1" });
+    });
+    (mockProvider as any).waitForTransaction = waitForTransaction;
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await waitFor(() => {
+      expect(waitForTransaction).toHaveBeenCalledWith(PATH_TX_HASH);
+      expect(screen.getByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    });
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+    ).status,
+    ).toBe("confirmed");
+  });
+
+  test("polls a restored PATH receipt through production providers in StrictMode", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted" })),
+    );
+    const request = jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_getTransactionReceipt") return { status: "0x1" };
+      if (method === "eth_chainId") return "0xaa36a7";
+      if (method === "eth_getCode") return "0x01";
+      return null;
+    });
+    (mockProvider as any).request = request;
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(
+      <React.StrictMode>
+        <AuctionCanvas address="0xabc" provider={mockProvider as any} />
+      </React.StrictMode>,
+    );
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith({
+        method: "eth_getTransactionReceipt",
+        params: [PATH_TX_HASH],
+      });
+      expect(screen.getByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    });
+  });
+
+  test("announces a submitted-to-confirmed PATH handoff as an atomic status", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted" })),
+    );
+    let resolveReceipt: ((receipt: unknown) => void) | null = null;
+    const receipt = new Promise<unknown>((resolve) => {
+      resolveReceipt = resolve;
+    });
+    (mockProvider as any).request = jest.fn(
+      async ({ method }: { method: string }) =>
+        method === "eth_getTransactionReceipt" ? receipt : null,
+    );
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const status = await screen.findByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-atomic", "true");
+    expect(status).toHaveTextContent("$PATH mint submitted. Waiting for confirmation.");
+
+    await act(async () => {
+      resolveReceipt?.({ status: 1 });
+      await receipt;
+    });
+    await waitFor(() => {
+      expect(status).toHaveTextContent("$PATH minted. Return to THOUGHT.");
+      expect(screen.getByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    });
+  });
+
+  test("keeps the THOUGHT PATH handoff usable below the desktop breakpoint", async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 600,
+    });
+    setPathMintIntentUrl();
+    mockWalletState = createWalletState({ account: {} });
+    const view = render(
+      <AuctionCanvas address="0xabc" provider={mockProvider as any} />,
+    );
+    try {
+      expect(screen.queryByText(/This view needs more room/i)).toBeNull();
+      expect(await screen.findByText(/\[\s*mint\s*\]/i)).toBeTruthy();
+    } finally {
+      view.unmount();
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalWidth,
+      });
+    }
+  });
+
+  test("retains an ambiguous receipt transport failure and retries on focus", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted" })),
+    );
+    let receiptReads = 0;
+    const request = jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_getTransactionReceipt") {
+        receiptReads += 1;
+        if (receiptReads === 1) {
+          throw new Error("transaction failed to fetch receipt");
+        }
+        return { status: 1 };
+      }
+      if (method === "eth_chainId") return "0xaa36a7";
+      if (method === "eth_getCode") return "0x01";
+      return null;
+    });
+    (mockProvider as any).request = request;
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await waitFor(() => expect(receiptReads).toBe(1));
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+      ).status,
+    ).toBe("submitted");
+    await act(async () => {
+      window.dispatchEvent(new globalThis.Event("focus"));
+    });
+    await waitFor(() => {
+      expect(receiptReads).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    });
+  });
+
+  test("adopts a submitted PATH record written by another same-origin tab", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const key = `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`;
+    const serialized = JSON.stringify(pathMintReturnRecord({ status: "submitted" }));
+    window.localStorage.setItem(key, serialized);
+    await act(async () => {
+      window.dispatchEvent(
+        new globalThis.StorageEvent("storage", { key, newValue: serialized }),
+      );
+    });
+    expect(await screen.findByText(/\[\s*pending\s*\]/i)).toBeTruthy();
+    expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+  });
+
+  test("uses the freshest valid PATH return storage copy", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const older = Date.now() - 5_000;
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted", updatedAt: older })),
+    );
+    window.sessionStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "confirmed", updatedAt: older + 1_000 })),
+    );
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    expect(await screen.findByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+      ).status,
+    ).toBe("confirmed");
+    expect(
+      window.sessionStorage.getItem(
+        `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      ),
+    ).toBeNull();
+  });
+
+  test("does not restore an expired PATH return record", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(
+        pathMintReturnRecord({
+          updatedAt: Date.now() - 86_400_001,
+        }),
+      ),
+    );
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/\[\s*return\s*\]/i)).toBeNull();
+  });
+
+  test("keeps an old submitted PATH record until a terminal receipt exists", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(
+        pathMintReturnRecord({
+          status: "submitted",
+          updatedAt: Date.now() - 86_400_001,
+        }),
+      ),
+    );
+    const request = jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_getTransactionReceipt") return null;
+      return null;
+    });
+    (mockProvider as any).request = request;
+    mockWalletState = createWalletState({
+      address: null,
+      isConnected: false,
+      chainId: null,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    expect(await screen.findByText(/\[\s*pending\s*\]/i)).toBeTruthy();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+        ) ?? "{}",
+      ).status,
+    ).toBe("submitted");
+    expect(request).toHaveBeenCalledWith({
+      method: "eth_getTransactionReceipt",
+      params: [PATH_TX_HASH],
+    });
+  });
+
+  test("blocks duplicate confirm clicks in the same tab", async () => {
+    setPathMintIntentUrl();
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ transaction_hash: PATH_TX_HASH });
+    mockWalletState = createWalletState({
+      account: {
+        execute,
+        waitForTransaction: jest.fn().mockResolvedValue({ status: 1 }),
+      },
+      evm: { provider: createPathWalletProvider() },
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const confirm = await clickMintForReview();
+
+    await act(async () => {
+      fireEvent.click(confirm);
+      fireEvent.click(confirm);
+    });
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+  });
+
+  test("runs the PATH task when the Web Lock is available", async () => {
+    const request = jest.fn(
+      async (
+        _name: string,
+        _options: { mode: "exclusive"; ifAvailable: true },
+        callback: (lock: unknown | null) => Promise<void>,
+      ) => {
+        await callback({ name: "available-path-mint-lock" });
+      },
+    );
+    setPathMintLockRequest(request);
+    const task = jest.fn(async () => {});
+
+    const result = await withPathMintSubmissionLock(
+      "mint-web-lock-success-1",
+      task,
+    );
+
+    expect(result).toBe("acquired");
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "inshell:path-mint-submit:mint-web-lock-success-1",
+      { mode: "exclusive", ifAvailable: true },
+      expect.any(Function),
+    );
+  });
+
+  test("reports busy and skips the PATH task when another tab owns the Web Lock", async () => {
+    setPathMintLockRequest(async (_name, _options, callback) => {
+      await callback(null);
+    });
+    const task = jest.fn(async () => {});
+
+    const result = await withPathMintSubmissionLock(
+      "mint-web-lock-busy-1",
+      task,
+    );
+
+    expect(result).toBe("busy");
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  test("fails closed without Web Locks even when localStorage is writable", async () => {
+    const storageKey = "inshell:path-mint-submit-lock:v1:legacy-active-lock";
+    const storedLease = JSON.stringify({
+      owner: "legacy-tab",
+      expiresAt: Date.now() + 15_000,
+    });
+    window.localStorage.setItem(storageKey, storedLease);
+    setPathMintLockRequest(null);
+    const task = jest.fn(async () => {});
+
+    try {
+      const result = await withPathMintSubmissionLock(
+        "mint-no-web-lock-1",
+        task,
+      );
+
+      expect(result).toBe("unsupported");
+      expect(task).not.toHaveBeenCalled();
+      expect(window.localStorage.getItem(storageKey)).toBe(storedLease);
+    } finally {
+      window.localStorage.removeItem(storageKey);
+    }
+  });
+
+  test("shows another-tab busy when the PATH Web Lock is held", async () => {
+    setPathMintLockRequest(async (_name, _options, callback) => {
+      await callback(null);
+    });
+    setPathMintIntentUrl();
+    const execute = jest.fn();
+    mockWalletState = createWalletState({
+      account: { execute },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+    expect(await screen.findByText(/already open in another tab/i)).toBeTruthy();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("explains unsupported browser coordination before opening the wallet", async () => {
+    setPathMintLockRequest(null);
+    setPathMintIntentUrl();
+    const execute = jest.fn();
+    mockWalletState = createWalletState({
+      account: { execute },
+      evm: { provider: createPathWalletProvider() },
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    await clickMintThenSign();
+    expect(
+      await screen.findByText(/requires browser tab coordination \(Web Locks\)/i),
+    ).toBeTruthy();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("rechecks storage before submitting a PATH mint", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    const execute = jest.fn();
+    mockWalletState = createWalletState({
+      account: { execute },
+      evm: { provider: createPathWalletProvider() },
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const confirm = await clickMintForReview();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord({ status: "submitted" })),
+    );
+
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(await screen.findByText(/\[\s*pending\s*\]/i)).toBeTruthy();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("rechecks wallet account immediately before PATH submission", async () => {
+    setPathMintIntentUrl();
+    const execute = jest.fn();
+    const changedAccount = `0x${"cd".repeat(20)}`;
+    const request = jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_accounts") return [changedAccount];
+      if (method === "eth_chainId") return "0xaa36a7";
+      return null;
+    });
+    mockWalletState = createWalletState({
+      account: { execute },
+      evm: { provider: createPathWalletProvider({ request }) },
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+
+    await clickMintThenSign();
+    expect(await screen.findByText(/wallet account changed before PATH mint/i)).toBeTruthy();
+    expect(request).toHaveBeenCalledWith({ method: "eth_accounts" });
+    expect(request).toHaveBeenCalledWith({ method: "eth_chainId" });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("rechecks wallet chain immediately before PATH submission", async () => {
+    setPathMintIntentUrl();
+    const execute = jest.fn();
+    const request = jest.fn(async ({ method }: { method: string }) => {
+      if (method === "eth_accounts") return [DEFAULT_WALLET_ADDRESS];
+      if (method === "eth_chainId") return "0x1";
+      return null;
+    });
+    mockWalletState = createWalletState({
+      account: { execute },
+      evm: { provider: createPathWalletProvider({ request }) },
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+
+    await clickMintThenSign();
+    expect(await screen.findByText(/wallet network changed before PATH mint/i)).toBeTruthy();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("treats a stored confirmed result as authoritative over query account", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.localStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(
+        pathMintReturnRecord({ account: `0x${"cd".repeat(20)}` }),
+      ),
+    );
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+
+    expect(await screen.findByText(/\[\s*return\s*\]/i)).toBeTruthy();
+    expect(screen.queryByText(/Switch to the THOUGHT wallet/i)).toBeNull();
+  });
+
+  test("keeps confirmed return above wallet and network state", async () => {
+    const { handoffId } = setPathMintIntentUrl();
+    window.sessionStorage.setItem(
+      `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      JSON.stringify(pathMintReturnRecord()),
+    );
+    mockWalletState = createWalletState({
+      address: `0x${"cd".repeat(20)}`,
+      chainId: 1n,
+      account: null,
+    });
+
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    const returnButton = await screen.findByText(/\[\s*return\s*\]/i);
+    expect(returnButton).not.toBeDisabled();
+    expect(screen.queryByText(/\[\s*connect\s*\]/i)).toBeNull();
+    expect(screen.queryByText(/Switch to the THOUGHT wallet/i)).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      ),
+    ).not.toBeNull();
+    expect(
+      window.sessionStorage.getItem(
+        `${PATH_MINT_RETURN_STORAGE_PREFIX}${handoffId}`,
+      ),
+    ).toBeNull();
+  });
+
+  test.each([
+    {
+      name: "wallet",
+      intent: { account: `0x${"aa".repeat(20)}` },
+      notice: /Switch to the THOUGHT wallet/i,
+    },
+    {
+      name: "chain",
+      intent: {},
+      wallet: { chainId: 1n },
+      notice: /Switch wallet to THOUGHT chain 11155111/i,
+    },
+  ])("blocks a $name mismatch before PATH mint", async ({ intent, wallet, notice }) => {
+    setPathMintIntentUrl(intent);
+    const execute = jest.fn();
+    mockWalletState = createWalletState({ account: { execute }, ...wallet });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+
+    expect(await screen.findByText(notice)).toBeTruthy();
+    const mintButton = screen.getByText(/\[\s*mint\s*\]/i);
+    expect(mintButton).toBeDisabled();
+    fireEvent.click(mintButton);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-THOUGHT return routes and movement values", async () => {
+    setPathMintIntentUrl({
+      movement: "PATH",
+      returnTo: `/gallery?pathHandoff=${PATH_HANDOFF_ID}`,
+    });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    expect(await screen.findByText(/Invalid THOUGHT mint movement/i)).toBeTruthy();
+    expect(screen.getByText(/\[\s*mint\s*\]/i)).toBeDisabled();
+  });
+
+  test("rejects handoff ids that THOUGHT cannot restore", async () => {
+    setPathMintIntentUrl({ handoffId: "bad.handoff" });
+    render(<AuctionCanvas address="0xabc" provider={mockProvider as any} />);
+    expect(await screen.findByText(/Invalid THOUGHT mint handoff id/i)).toBeTruthy();
+    expect(screen.getByText(/\[\s*mint\s*\]/i)).toBeDisabled();
   });
 
   test("keeps wallet menu out of the PATH-local CTA stack", async () => {

--- a/apps/thought/evm/addresses.anvil.json
+++ b/apps/thought/evm/addresses.anvil.json
@@ -1,8 +1,20 @@
 {
   "rpcUrl": "http://127.0.0.1:8545",
   "chainId": 31337,
+  "path": {
+    "address": "0x2e8880cAdC08E9B438c6052F5ce3869FBd6cE513"
+  },
   "pathNft": {
-    "address": "0x8A93d247134d91e0de6f96547cB0204e5BE8e5D8"
+    "address": "0x2e8880cAdC08E9B438c6052F5ce3869FBd6cE513"
+  },
+  "pathPulseAdapter": {
+    "address": "0xb007167714e2940013EC3bb551584130B7497E22"
+  },
+  "pulseAuction": {
+    "address": "0x6b39b761b1b64C8C095BF0e3Bb0c6a74705b4788"
+  },
+  "paymentToken": {
+    "address": "0x0000000000000000000000000000000000000000"
   },
   "pathMovement": {
     "name": "THOUGHT",
@@ -15,25 +27,25 @@
   },
   "devPathTokens": {
     "firstId": 1,
-    "lastId": 10,
+    "lastId": 1,
     "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   },
   "thoughtSpecRegistry": {
-    "address": "0x927b167526bAbB9be047421db732C663a0b77B11"
+    "address": "0x4DAf17c8142A483B2E2348f56ae0F2cFDAe22ceE"
   },
   "protocolRegistry": {
-    "address": "0x01c1DeF3b91672704716159C9041Aeca392DdFfb"
+    "address": "0x24d41dbc3d60d0784f8a937c59FBDe51440D5140"
   },
   "thoughtRenderer": {
-    "address": "0x638A246F0Ec8883eF68280293FFE8Cfbabe61B44"
+    "address": "0x618fB9dbd2BD6eb968B4c1af36af6CB0b45310Ec"
   },
   "thoughtNft": {
-    "address": "0x6C2d83262fF84cBaDb3e416D527403135D757892"
+    "address": "0xa779C1D17bC5230c07afdC51376CAC1cb3Dd5314"
   },
   "protocolRelease": {
-    "id": "0xcab9cb82294d90e90d60203b27195c4daa75ea365f3d9b249caf5cd4006d6673",
-    "manifestHash": "0xc46e1b3dbab5128bc4af98bc009dca3e45e6903c8263e0eb49cb5eb32fc16e0d",
-    "rendererProfileHash": "0xbce80f7dc9c4f4cf4c6bdda3df41647f9bf193d6352d594a182971e1e3045443",
+    "id": "0xea4493c669fc366e224e66a43233e1e97efecd18568ef494dfc31b4a3c961b65",
+    "manifestHash": "0x305f59465c93edf46e5ab0ca372b017f6cba5c98052e695ae6b9ca5778515d4b",
+    "rendererProfileHash": "0x6c124e260dcbfe801614b89da24bb31d407303e7cd93cc3e6a6ac372c862de88",
     "workProfileHash": "0x8b590ab95432b0dd5002a4fb1419475751bdf0210a73338bf633533005d182bb",
     "status": "draft-local"
   },
@@ -43,7 +55,7 @@
       "specId": "0x0a33583e39050834eb77372ea8b41ceded8fe4bb47c31fe1a72ebb880351b410",
       "specHash": "0xe56691af2ea250f66a09c6766ea90f5180af45f56d129b5cdce1ca42204d7f0a",
       "ref": "THOUGHT.v2.md",
-      "pointer": "0x9bd624BefB05a4FD466c3055C985155D04Fbff4B",
+      "pointer": "0xbC06964732EbBd248F10C60CbdECEFd1B1F7d6e9",
       "byteLength": 2811
     }
   ],

--- a/apps/thought/index.html
+++ b/apps/thought/index.html
@@ -164,6 +164,20 @@
                 </div>
               </section>
               <section
+                id="thought-wallet-strip"
+                class="thought-wallet-strip is-hidden"
+                aria-label="Mint wallet context"
+              >
+                <div class="thought-wallet-strip__copy">
+                  <p id="thought-wallet-strip-title" class="thought-wallet-strip__title">wallet</p>
+                  <p id="thought-wallet-strip-detail" class="thought-wallet-strip__detail">not connected</p>
+                  <p id="thought-wallet-strip-meta" class="thought-wallet-strip__meta">
+                    reads address only. no signature. no tx.
+                  </p>
+                </div>
+                <div id="thought-wallet-strip-actions" class="thought-wallet-strip__actions"></div>
+              </section>
+              <section
                 id="thought-dock-action-area"
                 class="thought-dock-action-rail"
                 aria-label="THOUGHT Panel actions"
@@ -171,8 +185,19 @@
               <section
                 id="thought-dock-path"
                 class="thought-dock-path thought-path-panel is-hidden"
-                aria-label="PATH selection"
+                aria-label="THOUGHT mint"
               >
+                <ol id="thought-dock-path-flow" class="thought-dock-path-flow" aria-label="THOUGHT mint progress">
+                  <li data-step="select">PATH</li>
+                  <li data-step="authorize">SIGN</li>
+                  <li data-step="confirm">MINT</li>
+                </ol>
+                <div class="thought-mint-step" role="status" aria-live="polite" aria-atomic="true">
+                  <p id="thought-dock-path-title" class="thought-mint-step__title" tabindex="-1">choose a PATH</p>
+                  <p id="thought-dock-path-detail" class="thought-mint-step__detail">
+                    One THOUGHT needs one available PATH mint.
+                  </p>
+                </div>
                 <div
                   id="thought-dock-path-inventory"
                   class="thought-dock-path-inventory is-hidden"
@@ -183,7 +208,7 @@
                   </p>
                   <div
                     id="thought-dock-path-inventory-list"
-                    class="thought-dock-path-actions"
+                    class="thought-dock-path-actions thought-dock-path-inventory-list"
                     role="group"
                     aria-label="Available PATH tokens"
                   ></div>
@@ -207,8 +232,11 @@
                   ></select>
                 </div>
                 <p id="thought-dock-path-provenance" class="thought-dock-path-provenance is-hidden"></p>
-                <p id="thought-dock-path-status" class="thought-dock-path-status" aria-live="polite"></p>
-                <div id="thought-dock-path-context" class="thought-dock-path-context is-hidden"></div>
+                <p id="thought-dock-path-status" class="thought-dock-path-status"></p>
+                <details id="thought-dock-path-review" class="thought-dock-path-review is-hidden">
+                  <summary id="thought-dock-path-review-summary">review wallet request</summary>
+                  <div id="thought-dock-path-context" class="thought-dock-path-context is-hidden"></div>
+                </details>
                 <div class="thought-dock-path-actions">
                   <button id="thought-dock-path-primary" class="thought-dock-button" type="button">continue</button>
                   <button
@@ -220,33 +248,12 @@
                   </button>
                   <button
                     id="thought-dock-path-tertiary"
-                    class="thought-dock-button thought-dock-button--secondary is-hidden"
+                    class="thought-dock-button thought-dock-button--tertiary is-hidden"
                     type="button"
                   >
                     refresh
                   </button>
                 </div>
-                <div id="thought-dock-path-flow" class="thought-dock-path-flow" aria-label="mint flow">
-                  <span data-step="select">select $PATH</span>
-                  <span>/</span>
-                  <span data-step="authorize">authorize</span>
-                  <span>/</span>
-                  <span data-step="confirm">confirm</span>
-                </div>
-              </section>
-              <section
-                id="thought-wallet-strip"
-                class="thought-wallet-strip is-hidden"
-                aria-label="Wallet controls"
-              >
-                <div class="thought-wallet-strip__copy">
-                  <p id="thought-wallet-strip-title" class="thought-wallet-strip__title">wallet</p>
-                  <p id="thought-wallet-strip-detail" class="thought-wallet-strip__detail">not connected</p>
-                  <p id="thought-wallet-strip-meta" class="thought-wallet-strip__meta">
-                    reads address only. no signature. no tx.
-                  </p>
-                </div>
-                <div id="thought-wallet-strip-actions" class="thought-wallet-strip__actions"></div>
               </section>
             </div>
             <div id="thought-dock-expanded" class="thought-dock-detail-tray" hidden></div>
@@ -254,7 +261,6 @@
               id="thought-dock-details"
               class="thought-dock-status-screen"
               aria-label="THOUGHT status"
-              aria-live="polite"
             >
               <p id="thought-panel-status-title" class="thought-panel__status-title">Give a thought to your Agent</p>
               <p id="thought-panel-status-detail" class="thought-panel__status-detail">No run yet</p>
@@ -990,6 +996,11 @@
       <button id="mint-sheet-close" class="mint-sheet-close" type="button">close</button>
     </div>
     <p id="mint-sheet-copy" class="mint-sheet-copy">one THOUGHT needs one $PATH.</p>
+    <ol id="mint-sheet-flow" class="mint-sheet-flow" aria-label="THOUGHT mint progress">
+      <li data-step="select">PATH</li>
+      <li data-step="authorize">SIGN</li>
+      <li data-step="confirm">MINT</li>
+    </ol>
     <div id="mint-sheet-path-field" class="mint-sheet-field">
       <label class="mint-sheet-label" for="mint-sheet-path-box">$PATH #</label>
       <input
@@ -1013,15 +1024,8 @@
     <div id="mint-sheet-context" class="mint-sheet-context is-hidden"></div>
     <div class="mint-sheet-actions">
       <button id="mint-sheet-primary" class="mint-sheet-primary" type="button">continue</button>
-      <button id="mint-sheet-secondary" class="mint-sheet-primary is-hidden" type="button">view thought</button>
-      <button id="mint-sheet-tertiary" class="mint-sheet-primary is-hidden" type="button">refresh</button>
-    </div>
-    <div id="mint-sheet-flow" class="mint-sheet-flow" aria-label="mint flow">
-      <span data-step="select">select $PATH</span>
-      <span aria-hidden="true">/</span>
-      <span data-step="authorize">authorize</span>
-      <span aria-hidden="true">/</span>
-      <span data-step="confirm">confirm</span>
+      <button id="mint-sheet-secondary" class="mint-sheet-primary mint-sheet-primary--secondary is-hidden" type="button">view thought</button>
+      <button id="mint-sheet-tertiary" class="mint-sheet-primary mint-sheet-primary--tertiary is-hidden" type="button">refresh</button>
     </div>
   </section>
 

--- a/apps/thought/index.html
+++ b/apps/thought/index.html
@@ -148,7 +148,7 @@
           </header>
           <div class="thought-panel__body">
             <div class="thought-dock-control-area">
-              <section id="thought-dock" class="thought-dock" aria-label="Prompt composer">
+              <section id="thought-dock" class="thought-dock" aria-label="THOUGHT work">
                 <div class="thought-dock-prompt-row">
                   <label id="thought-dock-label" class="thought-dock-label" for="thought-dock-prompt">
                     prompt
@@ -162,81 +162,51 @@
                     placeholder="give a thought here"
                   />
                 </div>
+                <section
+                  id="thought-dock-action-area"
+                  class="thought-dock-action-rail"
+                  aria-label="THOUGHT work actions"
+                ></section>
               </section>
-              <section
-                id="thought-wallet-strip"
-                class="thought-wallet-strip is-hidden"
-                aria-label="Mint wallet context"
-              >
-                <div class="thought-wallet-strip__copy">
-                  <p id="thought-wallet-strip-title" class="thought-wallet-strip__title">wallet</p>
-                  <p id="thought-wallet-strip-detail" class="thought-wallet-strip__detail">not connected</p>
-                  <p id="thought-wallet-strip-meta" class="thought-wallet-strip__meta">
-                    reads address only. no signature. no tx.
-                  </p>
-                </div>
-                <div id="thought-wallet-strip-actions" class="thought-wallet-strip__actions"></div>
-              </section>
-              <section
-                id="thought-dock-action-area"
-                class="thought-dock-action-rail"
-                aria-label="THOUGHT Panel actions"
-              ></section>
               <section
                 id="thought-dock-path"
                 class="thought-dock-path thought-path-panel is-hidden"
                 aria-label="THOUGHT mint"
               >
                 <ol id="thought-dock-path-flow" class="thought-dock-path-flow" aria-label="THOUGHT mint progress">
-                  <li data-step="select">PATH</li>
+                  <li data-step="select">PICK</li>
                   <li data-step="authorize">SIGN</li>
                   <li data-step="confirm">MINT</li>
                 </ol>
-                <div class="thought-mint-step" role="status" aria-live="polite" aria-atomic="true">
-                  <p id="thought-dock-path-title" class="thought-mint-step__title" tabindex="-1">choose a PATH</p>
-                  <p id="thought-dock-path-detail" class="thought-mint-step__detail">
-                    One THOUGHT needs one available PATH mint.
-                  </p>
+                <div
+                  id="thought-dock-mint-step"
+                  class="thought-mint-step is-hidden"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  <p id="thought-dock-path-title" class="thought-mint-step__title"></p>
                 </div>
                 <div
                   id="thought-dock-path-inventory"
                   class="thought-dock-path-inventory is-hidden"
                   aria-labelledby="thought-dock-path-inventory-label"
                 >
-                  <p id="thought-dock-path-inventory-label" class="thought-dock-label">
+                  <p
+                    id="thought-dock-path-inventory-label"
+                    class="thought-dock-label thought-dock-label--secondary"
+                  >
                     available $PATH
                   </p>
-                  <div
-                    id="thought-dock-path-inventory-list"
-                    class="thought-dock-path-actions thought-dock-path-inventory-list"
-                    role="group"
-                    aria-label="Available PATH tokens"
-                  ></div>
+                  <div class="thought-dock-select-wrap">
+                    <select
+                      id="thought-dock-path-inventory-select"
+                      class="thought-dock-select"
+                      aria-labelledby="thought-dock-path-inventory-label"
+                    ></select>
+                    <span class="thought-dock-select-arrow" aria-hidden="true"></span>
+                  </div>
                 </div>
-                <div id="thought-dock-path-field" class="thought-dock-path-field">
-                  <label class="thought-dock-label" for="thought-dock-path-box">$PATH #</label>
-                  <input
-                    id="thought-dock-path-box"
-                    class="thought-dock-input thought-dock-path-input"
-                    type="text"
-                    inputmode="numeric"
-                    list="thought-dock-path-options"
-                    autocomplete="off"
-                    spellcheck="false"
-                  />
-                  <datalist id="thought-dock-path-options"></datalist>
-                  <select
-                    id="thought-dock-path-select"
-                    class="thought-dock-input thought-dock-path-input thought-dock-path-select is-hidden"
-                    aria-label="$PATH #"
-                  ></select>
-                </div>
-                <p id="thought-dock-path-provenance" class="thought-dock-path-provenance is-hidden"></p>
-                <p id="thought-dock-path-status" class="thought-dock-path-status"></p>
-                <details id="thought-dock-path-review" class="thought-dock-path-review is-hidden">
-                  <summary id="thought-dock-path-review-summary">review wallet request</summary>
-                  <div id="thought-dock-path-context" class="thought-dock-path-context is-hidden"></div>
-                </details>
                 <div class="thought-dock-path-actions">
                   <button id="thought-dock-path-primary" class="thought-dock-button" type="button">continue</button>
                   <button
@@ -255,15 +225,33 @@
                   </button>
                 </div>
               </section>
+              <section
+                id="thought-dock-works"
+                class="thought-dock-works is-hidden"
+                aria-label="THOUGHT load a saved work"
+              >
+                <label
+                  id="thought-dock-works-label"
+                  class="thought-dock-label thought-dock-label--secondary"
+                  for="thought-dock-works-select"
+                >
+                  load a saved work
+                </label>
+                <div class="thought-dock-select-wrap">
+                  <select
+                    id="thought-dock-works-select"
+                    class="thought-dock-select"
+                    aria-labelledby="thought-dock-works-label"
+                  ></select>
+                  <span class="thought-dock-select-arrow" aria-hidden="true"></span>
+                </div>
+              </section>
             </div>
-            <div id="thought-dock-expanded" class="thought-dock-detail-tray" hidden></div>
             <section
               id="thought-dock-details"
               class="thought-dock-status-screen"
-              aria-label="THOUGHT status"
+              aria-label="THOUGHT console"
             >
-              <p id="thought-panel-status-title" class="thought-panel__status-title">Give a thought to your Agent</p>
-              <p id="thought-panel-status-detail" class="thought-panel__status-detail">No run yet</p>
               <div id="thought-dock-details-body" class="thought-dock-status-screen__body"></div>
             </section>
           </div>
@@ -381,7 +369,7 @@
                 type="text"
                 autocomplete="off"
                 spellcheck="false"
-                placeholder="author a one-round THOUGHT agent with your prompt"
+                placeholder="author a one-round THOUGHT Agent with your prompt"
               />
             </div>
             <div id="thought-file-field" class="frontpage-field">
@@ -529,7 +517,7 @@
     <section id="agent-demo-page" class="thought-agent-demo is-hidden" aria-labelledby="agent-demo-title">
       <header class="thought-agent-demo__header">
         <div>
-          <p class="thought-agent-demo__eyebrow">THOUGHT / agent handoff</p>
+          <p class="thought-agent-demo__eyebrow">THOUGHT / Agent handoff</p>
           <h1 id="agent-demo-title" class="thought-agent-demo__title">Run with your Agent</h1>
         </div>
         <a class="thought-agent-demo__home" href="/">[ THOUGHT ]</a>
@@ -865,7 +853,7 @@
             </div>
             <div>
               <dt>mint THOUGHT</dt>
-              <dd>submits a wallet-confirmed transaction using a selected $PATH permission.</dd>
+              <dd>submits a wallet-confirmed transaction using a picked $PATH permission.</dd>
             </div>
           </dl>
           <p>Funds or tokens move only after wallet transaction confirmation.</p>
@@ -997,7 +985,7 @@
     </div>
     <p id="mint-sheet-copy" class="mint-sheet-copy">one THOUGHT needs one $PATH.</p>
     <ol id="mint-sheet-flow" class="mint-sheet-flow" aria-label="THOUGHT mint progress">
-      <li data-step="select">PATH</li>
+      <li data-step="select">PICK</li>
       <li data-step="authorize">SIGN</li>
       <li data-step="confirm">MINT</li>
     </ol>

--- a/apps/thought/src/color-font-doc.ts
+++ b/apps/thought/src/color-font-doc.ts
@@ -14,7 +14,7 @@ export type ColorFontDoc = {
 export const buildColorFontPlainText = (doc: ColorFontDoc) => [
   `Color Font ${doc.version}`,
   "",
-  "source: onchain ABI",
+  "source: on-chain ABI",
   `id: ${doc.id}`,
   `version: ${doc.version}`,
   ...(doc.chainName ? [`chain: ${doc.chainName}`] : []),

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -140,6 +140,11 @@ import {
   isThoughtV2LocalMintRuntime,
 } from "./thought-v2-local-release";
 import {
+  THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY,
+  isThoughtV2LocalDeploymentError,
+  verifyThoughtV2LocalDeployment,
+} from "./thought-v2-local-deployment";
+import {
   createThoughtPollWakeScheduler,
   hasThoughtPollDeadlineExpired,
 } from "./thought-poll-wake";
@@ -5763,11 +5768,10 @@ const getReadPathNft = () => {
   return readPathNft;
 };
 
-let localThoughtV2DeploymentVerified = false;
 let localThoughtV2DeploymentPromise: Promise<void> | null = null;
 
 const verifyLocalThoughtV2Deployment = async () => {
-  if (!IS_LOCAL_THOUGHT_V2 || localThoughtV2DeploymentVerified) {
+  if (!IS_LOCAL_THOUGHT_V2) {
     return;
   }
   if (localThoughtV2DeploymentPromise) {
@@ -5776,11 +5780,12 @@ const verifyLocalThoughtV2Deployment = async () => {
 
   localThoughtV2DeploymentPromise = (async () => {
     const provider = getReadProvider();
+    const pathProvider = getPathReadProvider();
     const thought = getReadThoughtNFT();
     const pathNft = getReadPathNft();
     const registry = getReadThoughtSpecRegistry();
-    if (!provider || !thought || !pathNft || !registry) {
-      throw new Error("local THOUGHT V2 deployment unavailable.");
+    if (!provider || !pathProvider || !thought || !pathNft || !registry) {
+      throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY);
     }
 
     const expected = THOUGHT_V2_LOCAL_RELEASE;
@@ -5791,42 +5796,82 @@ const verifyLocalThoughtV2Deployment = async () => {
       expected.contracts.thoughtRenderer,
       expected.contracts.protocolRegistry,
     ];
-    const [codes, pathAddress, specRegistryAddress, rendererAddress, protocolRegistryAddress, releaseId, manifestHash, rendererProfileHash, workProfileHash, authorizedMinter, quota, frozen, specValid] =
-      await Promise.all([
-        Promise.all(contractAddresses.map((address) => provider.getCode(address))),
-        thought.pathNft() as Promise<string>,
-        thought.thoughtSpecRegistry() as Promise<string>,
-        thought.thoughtRenderer() as Promise<string>,
-        thought.protocolRegistry() as Promise<string>,
-        thought.protocolReleaseId() as Promise<string>,
-        thought.protocolManifestHash() as Promise<string>,
-        thought.RENDERER_PROFILE_KECCAK256() as Promise<string>,
-        thought.WORK_PROFILE_KECCAK256() as Promise<string>,
-        pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
-        pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
-        pathNft.isMovementFrozen(PATH_MOVEMENT_THOUGHT) as Promise<boolean>,
-        registry.isRegisteredThoughtSpec(expected.spec.evmSpecId, expected.spec.evmSpecHash) as Promise<boolean>,
-      ]);
-
     const sameAddress = (left: string, right: string) => left.toLowerCase() === right.toLowerCase();
-    const anchorsMatch =
-      codes.every((code) => code !== "0x") &&
-      sameAddress(pathAddress, expected.contracts.pathNft) &&
-      sameAddress(specRegistryAddress, expected.contracts.thoughtSpecRegistry) &&
-      sameAddress(rendererAddress, expected.contracts.thoughtRenderer) &&
-      sameAddress(protocolRegistryAddress, expected.contracts.protocolRegistry) &&
-      releaseId.toLowerCase() === expected.protocol.protocolReleaseId &&
-      manifestHash.toLowerCase() === expected.protocol.manifestKeccak256 &&
-      rendererProfileHash.toLowerCase() === expected.protocol.rendererProfile.keccak256 &&
-      workProfileHash.toLowerCase() === expected.protocol.workProfile.keccak256 &&
-      sameAddress(authorizedMinter, expected.contracts.thoughtNft) &&
-      quota === 1n &&
-      frozen &&
-      specValid;
-    if (!anchorsMatch) {
-      throw new Error("local THOUGHT V2 deployment mismatch.");
-    }
-    localThoughtV2DeploymentVerified = true;
+    await verifyThoughtV2LocalDeployment({
+      contractAddresses,
+      readCode: (address) => sameAddress(address, expected.contracts.pathNft)
+        ? pathProvider.getCode(address)
+        : provider.getCode(address),
+      readAnchors: async () => {
+        const [
+          pathAddress,
+          specRegistryAddress,
+          rendererAddress,
+          protocolRegistryAddress,
+          releaseId,
+          manifestHash,
+          rendererProfileHash,
+          workProfileHash,
+          authorizedMinter,
+          quota,
+          frozen,
+          specValid,
+        ] = await Promise.all([
+          thought.pathNft() as Promise<string>,
+          thought.thoughtSpecRegistry() as Promise<string>,
+          thought.thoughtRenderer() as Promise<string>,
+          thought.protocolRegistry() as Promise<string>,
+          thought.protocolReleaseId() as Promise<string>,
+          thought.protocolManifestHash() as Promise<string>,
+          thought.RENDERER_PROFILE_KECCAK256() as Promise<string>,
+          thought.WORK_PROFILE_KECCAK256() as Promise<string>,
+          pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
+          pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
+          pathNft.isMovementFrozen(PATH_MOVEMENT_THOUGHT) as Promise<boolean>,
+          registry.isRegisteredThoughtSpec(expected.spec.evmSpecId, expected.spec.evmSpecHash) as Promise<boolean>,
+        ]);
+        return {
+          pathAddress,
+          specRegistryAddress,
+          rendererAddress,
+          protocolRegistryAddress,
+          releaseId,
+          manifestHash,
+          rendererProfileHash,
+          workProfileHash,
+          authorizedMinter,
+          quota,
+          frozen,
+          specValid,
+        };
+      },
+      anchorsMatch: ({
+        pathAddress,
+        specRegistryAddress,
+        rendererAddress,
+        protocolRegistryAddress,
+        releaseId,
+        manifestHash,
+        rendererProfileHash,
+        workProfileHash,
+        authorizedMinter,
+        quota,
+        frozen,
+        specValid,
+      }) =>
+        sameAddress(pathAddress, expected.contracts.pathNft) &&
+        sameAddress(specRegistryAddress, expected.contracts.thoughtSpecRegistry) &&
+        sameAddress(rendererAddress, expected.contracts.thoughtRenderer) &&
+        sameAddress(protocolRegistryAddress, expected.contracts.protocolRegistry) &&
+        releaseId.toLowerCase() === expected.protocol.protocolReleaseId &&
+        manifestHash.toLowerCase() === expected.protocol.manifestKeccak256 &&
+        rendererProfileHash.toLowerCase() === expected.protocol.rendererProfile.keccak256 &&
+        workProfileHash.toLowerCase() === expected.protocol.workProfile.keccak256 &&
+        sameAddress(authorizedMinter, expected.contracts.thoughtNft) &&
+        quota === 1n &&
+        frozen &&
+        specValid,
+    });
   })().finally(() => {
     localThoughtV2DeploymentPromise = null;
   });
@@ -8127,6 +8172,9 @@ const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean 
         items: [],
         error: inventory.message,
       };
+      if (IS_LOCAL_THOUGHT_V2 && isThoughtV2LocalDeploymentError(inventory.message)) {
+        setMintFlowError(inventory.message, "thought");
+      }
     } else {
       pathInventoryState = {
         status: "loaded",
@@ -16733,6 +16781,19 @@ const sortPathIds = (pathIds: Iterable<bigint>) =>
   [...pathIds].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 
 const readWalletPathInventory = async (walletAddress: string): Promise<PathInventoryReadResult> => {
+  if (IS_LOCAL_THOUGHT_V2) {
+    try {
+      await verifyLocalThoughtV2Deployment();
+    } catch (error) {
+      return {
+        kind: "unavailable",
+        message: error instanceof Error
+          ? error.message
+          : THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY,
+      };
+    }
+  }
+
   let candidateIds: Set<bigint> | null = null;
   if (THOUGHT_CHAIN_ID !== 31337) {
     try {
@@ -16775,6 +16836,12 @@ const readWalletPathInventory = async (walletAddress: string): Promise<PathInven
       pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
     ]);
   } catch {
+    if (IS_LOCAL_THOUGHT_V2) {
+      return {
+        kind: "unavailable",
+        message: THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY,
+      };
+    }
     // Keep listing owned IDs even when availability metadata cannot be read.
   }
 

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -12,6 +12,7 @@ import {
   AbiCoder,
   BrowserProvider,
   Contract,
+  formatEther,
   getBytes,
   id,
   keccak256,
@@ -80,6 +81,7 @@ import {
   getNextWork,
   getPreviousWork,
   getWorkById,
+  formatSavedWorkPromptLabel,
   parseWorkId,
   readThoughtWorks,
   writeThoughtWorks,
@@ -106,6 +108,7 @@ import {
   THOUGHT_PREVIEW_MANUAL_RATE_LIMIT,
   THOUGHT_PREVIEW_MODE_STORAGE_KEY,
   THOUGHT_PREVIEW_TIMEOUT_MS,
+  formatThoughtByteLimitUsage,
   isPreviewMode,
   normalizePreviewMode,
   prevalidateThoughtCandidate,
@@ -114,6 +117,7 @@ import {
   type PreviewMode,
   type PreviewProviderKind,
   type PreviewStatus,
+  type ThoughtByteLimitUsage,
 } from "./thought-preview-policy";
 import { createSingleRequestJsonRpcProvider } from "./rpc-provider";
 import {
@@ -133,12 +137,22 @@ import {
   parseThoughtConsoleHistory,
   serializeThoughtConsoleHistory,
   type ThoughtConsoleContext,
+  type ThoughtConsoleEntry,
   type ThoughtConsoleTone,
 } from "./thought-console";
 import {
   presentThoughtMint,
   type ThoughtMintPresentation,
 } from "./thought-mint-presentation";
+import {
+  THOUGHT_PATH_ACQUISITION_STORAGE_KEY,
+  parsePendingThoughtPathAcquisition,
+  pendingThoughtPathAcquisitionMatches,
+  serializePendingThoughtPathAcquisition,
+  withThoughtPathAcquisitionLock,
+  type PendingThoughtPathAcquisition,
+  type ThoughtPathAcquisitionState,
+} from "./thought-path-acquisition";
 import {
   THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY,
   THOUGHT_PENDING_MINT_TX_STORAGE_KEY,
@@ -178,6 +192,10 @@ import {
   type ThoughtV2LocalAgentEvidence,
 } from "./thought-v2-local-agent";
 import {
+  buildThoughtAgentFixtureLine,
+  shouldUseThoughtAgentFixture,
+} from "./thought-agent-fixture";
+import {
   THOUGHT_V2_LOCAL_RELEASE,
   isThoughtV2LocalMintRuntime,
 } from "./thought-v2-local-release";
@@ -195,6 +213,10 @@ import {
   measureThoughtV2Line,
   type ThoughtV2LineKind,
 } from "./thought-v2-renderer";
+import {
+  describeThoughtTextPolicyIssue,
+  type ThoughtTextPolicyIssue,
+} from "./thought-text-policy";
 import {
   getThoughtShellWallet,
   mountThoughtShell,
@@ -324,6 +346,15 @@ type EvmAddresses = {
   recommendedThoughtSpecId?: string;
   recommendedThoughtSpecHash?: string;
   pathNft?: {
+    address?: string;
+  };
+  pathPulseAdapter?: {
+    address?: string;
+  };
+  pulseAuction?: {
+    address?: string;
+  };
+  paymentToken?: {
     address?: string;
   };
   thoughtSpecRegistry?: {
@@ -483,7 +514,8 @@ type MintSheetAction =
   | "choose_another"
   | "enter_path_manually"
   | "mint_path"
-  | "refresh"
+  | "confirm_path_mint"
+  | "view_path_tx"
   | "recover_submission"
   | "reset"
   | "switch_network";
@@ -505,21 +537,6 @@ type MintSheetReviewConfig = {
   note?: string;
   rows?: MintSheetReviewRow[];
   verifyLink?: boolean;
-};
-
-type WalletStripTone = "idle" | "ready" | "warning" | "error" | "running";
-
-type WalletAction = "connect" | "disconnect" | "refresh" | "switch_network" | "copy_address";
-
-type WalletStripView = {
-  visible: boolean;
-  title: string;
-  detail: string;
-  address?: string;
-  chainLabel?: string;
-  meta?: string;
-  tone: WalletStripTone;
-  actions: WalletAction[];
 };
 
 type CliEntryKind = "intro" | "command" | "output" | "error";
@@ -986,6 +1003,27 @@ const removeSharedBrowserItem = (key: string) => {
   safeStorageRemove(getSessionStorage(), key);
 };
 
+const readPendingPathAcquisition = () => {
+  const pending = parsePendingThoughtPathAcquisition(
+    readSharedBrowserItem(THOUGHT_PATH_ACQUISITION_STORAGE_KEY),
+  );
+  if (!pending) {
+    removeSharedBrowserItem(THOUGHT_PATH_ACQUISITION_STORAGE_KEY);
+  }
+  return pending;
+};
+
+const writePendingPathAcquisition = (pending: PendingThoughtPathAcquisition | null) => {
+  if (!pending) {
+    removeSharedBrowserItem(THOUGHT_PATH_ACQUISITION_STORAGE_KEY);
+    return;
+  }
+  writeSharedBrowserItem(
+    THOUGHT_PATH_ACQUISITION_STORAGE_KEY,
+    serializePendingThoughtPathAcquisition(pending),
+  );
+};
+
 const thoughtBrowserStorage: WorkStorage = {
   getItem: readSharedBrowserItem,
   setItem: writeSharedBrowserItem,
@@ -1274,6 +1312,11 @@ const RECOMMENDED_THOUGHT_SPEC_ID =
   EVM_ADDRESSES.thoughtSpecs?.[0]?.specId?.trim() ||
   "";
 const LOCAL_BROWSER_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const THOUGHT_AGENT_FIXTURE_MODE = shouldUseThoughtAgentFixture({
+  dev: IS_DEV_MODE,
+  hostname: window.location.hostname,
+  search: window.location.search,
+});
 const DEPLOY_ENV =
   typeof import.meta.env.VITE_DEPLOY_ENV === "string"
     ? import.meta.env.VITE_DEPLOY_ENV.trim().toLowerCase()
@@ -1548,6 +1591,18 @@ const THOUGHT_WALLET_RPC_URLS = resolveWalletChainRpcUrls({
   localFallbackRpcUrl: "http://127.0.0.1:8546",
 });
 const PATH_NFT_ADDRESS = EVM_ADDRESSES.pathNft?.address?.trim() ?? "";
+const PATH_PULSE_ADAPTER_ADDRESS =
+  (typeof import.meta.env.VITE_THOUGHT_PATH_ADAPTER_ADDRESS === "string"
+    ? import.meta.env.VITE_THOUGHT_PATH_ADAPTER_ADDRESS.trim()
+    : "") ||
+  EVM_ADDRESSES.pathPulseAdapter?.address?.trim() ||
+  "";
+const PATH_AUCTION_ADDRESS =
+  (typeof import.meta.env.VITE_THOUGHT_PATH_AUCTION_ADDRESS === "string"
+    ? import.meta.env.VITE_THOUGHT_PATH_AUCTION_ADDRESS.trim()
+    : "") ||
+  EVM_ADDRESSES.pulseAuction?.address?.trim() ||
+  "";
 const defaultPathMintUrl = () => {
   if (LOCAL_BROWSER_HOSTS.has(window.location.hostname)) {
     return sameOriginAppUrl("/path");
@@ -1715,7 +1770,7 @@ const THOUGHT_GALLERY_LOADING_DETAILS = [
 const PATH_LIST_LOADING_DETAILS = [
   "reading from chain: wallet $PATH inventory",
   "reading from chain: checking latest block",
-  "reading from chain: scanning PATH transfer logs",
+  "reading from chain: scanning $PATH transfer logs",
   "reading from chain: collecting token ids",
   "reading from chain: checking current owners",
   "reading from chain: checking THOUGHT quota status",
@@ -1724,7 +1779,7 @@ const PATH_CHECK_LOADING_DETAILS = [
   "reading from chain: checking wallet",
   "reading from chain: owner",
   "reading from chain: stage and quota",
-  "reading from chain: THOUGHT unit status",
+  "reading from chain: THOUGHT mint status",
 ] as const;
 const MINT_PREP_LOADING_DETAILS = [
   "preparing THOUGHT mint.",
@@ -1847,6 +1902,18 @@ const PATH_NFT_ABI = [
   "function getStageMinted(uint256 tokenId) view returns (uint32)",
   "function ownerOf(uint256 tokenId) view returns (address)",
 ] as const;
+const PATH_PULSE_ADAPTER_ABI = [
+  "function auction() view returns (address)",
+  "function pathNft() view returns (address)",
+  "function wiringFrozen() view returns (bool)",
+] as const;
+const PATH_AUCTION_ABI = [
+  "function bid(uint256 maxPrice) payable",
+  "function curveActive() view returns (bool)",
+  "function getCurrentPrice() view returns (uint256)",
+  "function mintAdapter() view returns (address)",
+  "function paymentToken() view returns (address)",
+] as const;
 const THOUGHT_SPEC_REGISTRY_ABI = [
   "function latestThoughtSpecId() view returns (bytes32)",
   "function thoughtSpecMeta(bytes32 specId) view returns (bool exists, string specName, bytes32 specHash, string ref, address pointer, uint32 byteLength, uint64 registeredAt)",
@@ -1932,36 +1999,22 @@ const localHelper = document.getElementById("local-helper") as HTMLElement | nul
 const thoughtCanvasPanel = document.querySelector(".thought-canvas-panel") as HTMLElement | null;
 const thoughtCanvasFrame = document.querySelector(".thought-canvas-frame") as HTMLElement | null;
 const thoughtPanel = document.getElementById("thought-panel") as HTMLElement | null;
-const thoughtPanelStatusTitle = document.getElementById("thought-panel-status-title") as HTMLElement | null;
-const thoughtPanelStatusDetail = document.getElementById("thought-panel-status-detail") as HTMLElement | null;
 const thoughtDock = document.getElementById("thought-dock") as HTMLElement | null;
 const thoughtDockPrompt = document.getElementById("thought-dock-prompt") as HTMLInputElement | null;
-const thoughtWalletStrip = document.getElementById("thought-wallet-strip") as HTMLElement | null;
-const thoughtWalletStripTitle = document.getElementById("thought-wallet-strip-title") as HTMLElement | null;
-const thoughtWalletStripDetail = document.getElementById("thought-wallet-strip-detail") as HTMLElement | null;
-const thoughtWalletStripMeta = document.getElementById("thought-wallet-strip-meta") as HTMLElement | null;
-const thoughtWalletStripActions = document.getElementById("thought-wallet-strip-actions") as HTMLElement | null;
 const thoughtDockPath = document.getElementById("thought-dock-path") as HTMLElement | null;
 const thoughtDockPathInventory = document.getElementById("thought-dock-path-inventory") as HTMLElement | null;
 const thoughtDockPathInventoryLabel = document.getElementById("thought-dock-path-inventory-label") as HTMLElement | null;
-const thoughtDockPathInventoryList = document.getElementById("thought-dock-path-inventory-list") as HTMLElement | null;
-const thoughtDockPathField = document.getElementById("thought-dock-path-field") as HTMLElement | null;
-const thoughtDockPathBox = document.getElementById("thought-dock-path-box") as HTMLInputElement | null;
-const thoughtDockPathOptions = document.getElementById("thought-dock-path-options") as HTMLDataListElement | null;
-const thoughtDockPathSelect = document.getElementById("thought-dock-path-select") as HTMLSelectElement | null;
-const thoughtDockPathProvenance = document.getElementById("thought-dock-path-provenance") as HTMLElement | null;
-const thoughtDockPathStatus = document.getElementById("thought-dock-path-status") as HTMLElement | null;
-const thoughtDockPathReview = document.getElementById("thought-dock-path-review") as (HTMLElement & { open: boolean }) | null;
-const thoughtDockPathReviewSummary = document.getElementById("thought-dock-path-review-summary") as HTMLElement | null;
-const thoughtDockPathContext = document.getElementById("thought-dock-path-context") as HTMLElement | null;
+const thoughtDockPathInventorySelect = document.getElementById("thought-dock-path-inventory-select") as HTMLSelectElement | null;
 const thoughtDockPathFlow = document.getElementById("thought-dock-path-flow") as HTMLElement | null;
+const thoughtDockMintStep = document.getElementById("thought-dock-mint-step") as HTMLElement | null;
 const thoughtDockPathTitle = document.getElementById("thought-dock-path-title") as HTMLElement | null;
-const thoughtDockPathDetail = document.getElementById("thought-dock-path-detail") as HTMLElement | null;
 const thoughtDockPathPrimary = document.getElementById("thought-dock-path-primary") as HTMLButtonElement | null;
 const thoughtDockPathSecondary = document.getElementById("thought-dock-path-secondary") as HTMLButtonElement | null;
 const thoughtDockPathTertiary = document.getElementById("thought-dock-path-tertiary") as HTMLButtonElement | null;
+const thoughtDockWorks = document.getElementById("thought-dock-works") as HTMLElement | null;
+const thoughtDockWorksLabel = document.getElementById("thought-dock-works-label") as HTMLLabelElement | null;
+const thoughtDockWorksSelect = document.getElementById("thought-dock-works-select") as HTMLSelectElement | null;
 const thoughtDockActionArea = document.getElementById("thought-dock-action-area") as HTMLElement | null;
-const thoughtDockExpanded = document.getElementById("thought-dock-expanded") as HTMLElement | null;
 const thoughtDockDetails = document.getElementById("thought-dock-details") as HTMLElement | null;
 const thoughtDockDetailsBody = document.getElementById("thought-dock-details-body") as HTMLElement | null;
 const modelBox = document.getElementById("model-box") as HTMLSelectElement | null;
@@ -2128,36 +2181,22 @@ if (
   !thoughtCanvasPanel ||
   !thoughtCanvasFrame ||
   !thoughtPanel ||
-  !thoughtPanelStatusTitle ||
-  !thoughtPanelStatusDetail ||
   !thoughtDock ||
   !thoughtDockPrompt ||
-  !thoughtWalletStrip ||
-  !thoughtWalletStripTitle ||
-  !thoughtWalletStripDetail ||
-  !thoughtWalletStripMeta ||
-  !thoughtWalletStripActions ||
   !thoughtDockPath ||
   !thoughtDockPathInventory ||
   !thoughtDockPathInventoryLabel ||
-  !thoughtDockPathInventoryList ||
-  !thoughtDockPathField ||
-  !thoughtDockPathBox ||
-  !thoughtDockPathOptions ||
-  !thoughtDockPathSelect ||
-  !thoughtDockPathProvenance ||
-  !thoughtDockPathStatus ||
-  !thoughtDockPathReview ||
-  !thoughtDockPathReviewSummary ||
-  !thoughtDockPathContext ||
+  !thoughtDockPathInventorySelect ||
   !thoughtDockPathFlow ||
+  !thoughtDockMintStep ||
   !thoughtDockPathTitle ||
-  !thoughtDockPathDetail ||
   !thoughtDockPathPrimary ||
   !thoughtDockPathSecondary ||
   !thoughtDockPathTertiary ||
+  !thoughtDockWorks ||
+  !thoughtDockWorksLabel ||
+  !thoughtDockWorksSelect ||
   !thoughtDockActionArea ||
-  !thoughtDockExpanded ||
   !thoughtDockDetails ||
   !thoughtDockDetailsBody ||
   !modelBox ||
@@ -2292,7 +2331,7 @@ if (
   throw new Error("Front page elements are missing.");
 }
 
-mountThoughtShell(thoughtShellRoot, THOUGHT_CHAIN_ID);
+mountThoughtShell(thoughtShellRoot, THOUGHT_CHAIN_ID, () => refreshThoughtWalletFromShell());
 
 localModelValue.textContent = LOCAL_MODEL_LABEL;
 
@@ -2350,6 +2389,13 @@ type ThoughtDockWorkView = {
   workId: number | null;
 };
 
+type ThoughtMintWorkSnapshot = Readonly<{
+  text: string;
+  svg: string;
+  workId: number | null;
+  runContext: ThoughtRunContext;
+}>;
+
 type ThoughtDockState =
   | { kind: "empty" }
   | { kind: "ready"; prompt: string }
@@ -2362,10 +2408,15 @@ type ThoughtDockState =
   | { kind: "agent_returned"; run: AgentDemoRun; rawCandidate: string }
   | { kind: "previewing"; rawCandidate: string }
   | { kind: "preview_unavailable"; rawCandidate: string; reason: string }
-  | { kind: "preview_rejected"; rawCandidate: string; reason: string }
+  | {
+      kind: "preview_rejected";
+      rawCandidate: string;
+      reason: string;
+      reasonCode?: number;
+      issue?: ThoughtTextPolicyIssue;
+    }
   | { kind: "work_ready"; work: ThoughtDockWorkView }
-  | { kind: "minting"; work: ThoughtDockWorkView }
-  | { kind: "minted"; tokenId?: string; txHash?: string }
+  | { kind: "minted"; tokenId?: string; txHash?: string; existing?: boolean }
   | { kind: "run_access_needed"; details: string }
   | { kind: "expired"; run?: AgentDemoRun }
   | { kind: "failed"; message: string; details?: string };
@@ -2377,33 +2428,19 @@ type DockRailTone =
   | "warning"
   | "error";
 
-type DockRailActionKind =
-  | "primary"
-  | "secondary"
-  | "quiet";
-
 type DockRailAction = {
   id: string;
   label: string;
   ariaLabel: string;
-  kind: DockRailActionKind;
   disabled?: boolean;
+  expanded?: boolean;
   onClick: () => void;
 };
-
-type DockDetailView =
-  | { kind: "none" }
-  | { kind: "agentTask"; sealedTask: string; launchUri?: string }
-  | { kind: "error"; title: string; body: string; retryActionId?: string }
-  | { kind: "wallet"; message: string }
-  | { kind: "path"; message: string }
-  | { kind: "debug"; json: unknown };
 
 type DockRailView = {
   status: string;
   tone: DockRailTone;
   actions: DockRailAction[];
-  detail: DockDetailView;
   maxActions?: number;
 };
 
@@ -2442,6 +2479,7 @@ let thoughtDockState: ThoughtDockState = { kind: "empty" };
 let thoughtDockRun: AgentDemoRun | null = null;
 let thoughtDockAdapterId: ThoughtDockAgentAdapterId = "codex";
 let thoughtDockPollGeneration = 0;
+let workLibraryRevealed = false;
 const thoughtDockPollWakeScheduler = createThoughtPollWakeScheduler();
 const refreshThoughtDockPolling = () => {
   thoughtDockPollWakeScheduler.pollNow();
@@ -2681,7 +2719,7 @@ const agentDemoDockStatusForPhase = () => {
     case "draft":
       return "enter prompt.";
     case "choose-agent":
-      return "choose an agent.";
+      return "choose an Agent.";
     case "creating":
       return "creating sealed run.";
     case "sealed":
@@ -2736,7 +2774,7 @@ const parseAgentDemoReturn = (rawValue: string) => {
   }
   const parsed = JSON.parse(rawValue) as Record<string, unknown>;
   if (parsed.schema !== THOUGHT_AGENT_RESULT_VERSION || typeof parsed.agentLine !== "string") {
-    throw new Error("agent result schema invalid.");
+    throw new Error("Agent result schema invalid.");
   }
   const candidate = parsed.agentLine;
   assertThoughtLine(candidate, "agent");
@@ -2809,7 +2847,7 @@ const submitAgentDemoProtocolResult = async (candidate: string) => {
   if (!agentDemoRun) return;
   const run = agentDemoRun;
   agentDemoPhase = "waiting";
-  agentDemoStatusDetail = "agent posting result to protocol endpoint.";
+  agentDemoStatusDetail = "Agent posting result to protocol endpoint.";
   renderAgentDemo();
 
   const bridge = agentDemoBridgeInfo();
@@ -3025,8 +3063,7 @@ const isThoughtDockRunningState = (state: ThoughtDockState) =>
   state.kind === "claim_authorization" ||
   state.kind === "waiting_for_agent" ||
   state.kind === "agent_returned" ||
-  state.kind === "previewing" ||
-  state.kind === "minting";
+  state.kind === "previewing";
 
 const isThoughtDockInputLockedState = (state: ThoughtDockState) =>
   state.kind !== "empty" && state.kind !== "ready";
@@ -3104,6 +3141,83 @@ const clearStoredThoughtDockRun = (runId?: string) => {
   removeSharedBrowserItem(THOUGHT_DOCK_PENDING_RUN_KEY);
 };
 
+const recordThoughtDockConsoleTransition = (state: ThoughtDockState) => {
+  if (
+    state.kind === "agent_select" ||
+    state.kind === "creating_run" ||
+    state.kind === "agent_task_ready" ||
+    state.kind === "opening_agent" ||
+    state.kind === "claim_authorization" ||
+    state.kind === "waiting_for_agent" ||
+    state.kind === "agent_returned" ||
+    state.kind === "previewing"
+  ) {
+    const rail = getThoughtDockRailView(state);
+    emitThoughtConsoleEvent({
+      kind: `work_${state.kind}`,
+      title: rail.status.replace(/\.\.\.$/, ""),
+      ...(state.kind === "waiting_for_agent" && state.message
+        ? { detail: state.message }
+        : {}),
+      tone: rail.tone === "success" || rail.tone === "warning" || rail.tone === "error"
+        ? rail.tone
+        : "neutral",
+    });
+    return;
+  }
+  if (state.kind === "preview_unavailable") {
+    emitThoughtConsoleEvent({
+      kind: "work_preview_unavailable",
+      title: "preview unavailable",
+      detail: state.reason,
+      tone: "warning",
+      eventId: `work-preview-unavailable:${hashText(state.rawCandidate)}:${state.reason}`,
+    });
+    return;
+  }
+  if (state.kind === "preview_rejected") {
+    const textTooLong = state.issue?.title === "text too long" || state.reasonCode === 3;
+    emitThoughtConsoleEvent({
+      kind: "work_preview_rejected",
+      title: state.issue?.title ?? (textTooLong ? "text too long" : "work rejected"),
+      detail: state.issue?.detail ?? state.reason,
+      ...(state.issue?.nextStep ? { nextStep: state.issue.nextStep } : {}),
+      tone: state.issue || textTooLong ? "warning" : "error",
+      eventId: `work-preview-rejected:${hashText(state.rawCandidate)}:${state.reason}`,
+    });
+    return;
+  }
+  if (state.kind === "run_access_needed") {
+    emitThoughtConsoleEvent({
+      kind: "work_run_access_needed",
+      title: "run access needed",
+      detail: state.details,
+      tone: "warning",
+      eventId: `work-run-access:${state.details}`,
+    });
+    return;
+  }
+  if (state.kind === "expired") {
+    emitThoughtConsoleEvent({
+      kind: "work_run_expired",
+      title: "Agent run expired",
+      detail: "The saved Agent run can no longer be resumed.",
+      tone: "error",
+      eventId: `work-run-expired:${state.run?.runId ?? mintAttemptId}`,
+    });
+    return;
+  }
+  if (state.kind === "failed") {
+    emitThoughtConsoleEvent({
+      kind: "work_failed",
+      title: "work error",
+      detail: state.details || state.message,
+      tone: "error",
+      eventId: `work-error:${state.message}:${state.details ?? ""}`,
+    });
+  }
+};
+
 const thoughtDockRunFromStored = (stored: StoredThoughtDockRun): AgentDemoRun => ({
   runId: stored.runId,
   prompt: stored.prompt,
@@ -3140,6 +3254,7 @@ const storeThoughtDockRun = (run: AgentDemoRun, adapterId: ThoughtDockAgentAdapt
 
 const setThoughtDockState = (next: ThoughtDockState) => {
   thoughtDockState = next;
+  recordThoughtDockConsoleTransition(next);
   renderThoughtDock();
 };
 
@@ -3182,7 +3297,7 @@ const shouldRefocusThoughtDockFromClick = (target: EventTarget | null) => {
     return false;
   }
 
-  if (target.closest(".thought-dock-status-screen, .thought-dock-path, .thought-wallet-strip, .thought-wallet-surface")) {
+  if (target.closest(".thought-dock-status-screen, .thought-dock-path, .thought-wallet-surface")) {
     return false;
   }
 
@@ -3193,18 +3308,21 @@ const shouldRefocusThoughtDockFromClick = (target: EventTarget | null) => {
 const thoughtDockButton = (
   label: string,
   onClick: () => void,
-  options?: { secondary?: boolean; quiet?: boolean; disabled?: boolean; ariaLabel?: string },
+  options?: {
+    disabled?: boolean;
+    ariaLabel?: string;
+    expanded?: boolean;
+  },
 ) => {
   const button = document.createElement("button");
   button.type = "button";
-  button.className = [
-    "thought-dock-button",
-    options?.secondary ? "thought-dock-button--secondary" : "",
-    options?.quiet ? "thought-dock-button--quiet" : "",
-  ].filter(Boolean).join(" ");
+  button.className = "thought-dock-button thought-work-cta";
   button.textContent = label;
   if (options?.ariaLabel) {
     button.setAttribute("aria-label", options.ariaLabel);
+  }
+  if (options?.expanded !== undefined) {
+    button.setAttribute("aria-expanded", String(options.expanded));
   }
   button.disabled = !!options?.disabled;
   button.addEventListener("click", onClick);
@@ -3225,24 +3343,22 @@ const dockRailAction = (
   id: string,
   label: string,
   ariaLabel: string,
-  kind: DockRailActionKind,
   onClick: () => void,
-  options?: { disabled?: boolean },
+  options?: { disabled?: boolean; expanded?: boolean },
 ): DockRailAction => ({
   id,
   label,
   ariaLabel,
-  kind,
   onClick,
   disabled: options?.disabled,
+  expanded: options?.expanded,
 });
 
 const renderDockRailAction = (action: DockRailAction) =>
   thoughtDockButton(action.label, action.onClick, {
-    secondary: action.kind === "secondary",
-    quiet: action.kind === "quiet",
     disabled: action.disabled,
     ariaLabel: action.ariaLabel,
+    expanded: action.expanded,
   });
 
 const thoughtDockActions = (...buttons: HTMLElement[]) => {
@@ -3252,44 +3368,15 @@ const thoughtDockActions = (...buttons: HTMLElement[]) => {
   return element;
 };
 
-const thoughtDockStatusChip = (status: string, tone: DockRailTone) => {
-  const element = document.createElement("p");
-  element.className = [
-    "thought-dock-status",
-    status ? "" : "thought-dock-status--empty",
-    tone === "error" ? "thought-dock-error" : "",
-    tone === "warning" ? "thought-dock-status--warning" : "",
-    tone === "idle" ? "thought-dock-status--muted" : "",
-  ].filter(Boolean).join(" ");
-  const label = document.createElement("span");
-  label.className = "thought-dock-status-label";
-  label.textContent = status;
-  element.append(label);
-  return element;
-};
-
-const thoughtDockRailAnimationSignature = (content: string, rail: DockRailView) =>
+const thoughtDockRailRenderSignature = (rail: DockRailView) =>
   JSON.stringify({
-    content,
-    status: rail.status,
-    tone: rail.tone,
     actions: rail.actions.map((action) => ({
       id: action.id,
       label: action.label,
-      kind: action.kind,
       disabled: !!action.disabled,
+      expanded: action.expanded,
     })),
   });
-
-const animateThoughtDockRailEntry = () => {
-  const chips = thoughtDockActionArea.querySelectorAll<HTMLElement>(
-    ".thought-dock-status:not(.thought-dock-status--empty), .thought-dock-button",
-  );
-  chips.forEach((chip, index) => {
-    chip.style.setProperty("--thought-dock-chip-enter-delay", `${index * 18}ms`);
-    chip.classList.add("thought-dock-chip-enter");
-  });
-};
 
 const syncThoughtDockRailInset = () => {
   if (thoughtDockRailInsetFrame) {
@@ -3313,6 +3400,25 @@ const statusScreenLine = (
   ].filter(Boolean).join(" ");
   line.textContent = text;
   return line;
+};
+
+const appendThoughtProgressEllipsis = (
+  element: HTMLElement,
+  text: string,
+  active: boolean,
+) => {
+  element.textContent = text.replace(/\.{1,3}$/, "");
+  const ellipsis = document.createElement("span");
+  ellipsis.className = "thought-progress-ellipsis";
+  ellipsis.classList.toggle("is-active", active);
+  ellipsis.setAttribute("aria-hidden", "true");
+  for (let index = 0; index < 3; index += 1) {
+    const dot = document.createElement("span");
+    dot.className = "thought-progress-ellipsis__dot";
+    dot.textContent = ".";
+    ellipsis.append(dot);
+  }
+  element.append(ellipsis);
 };
 
 const statusScreenEntry = (lines: HTMLElement[]) => {
@@ -3365,16 +3471,87 @@ const writeThoughtConsoleHistory = () => {
   }
 };
 
-const emitThoughtConsoleEvent = (input: {
+type ThoughtConsoleEventDraft = {
   kind: string;
   title: string;
   detail?: string;
+  nextStep?: string;
   eventId?: string;
   tone?: ThoughtConsoleTone;
   transient?: boolean;
-}) => {
+};
+
+const lowerInitial = (value: string) =>
+  value ? `${value.charAt(0).toLowerCase()}${value.slice(1)}` : value;
+
+const suggestedThoughtConsoleNextStep = (
+  input: Pick<ThoughtConsoleEventDraft, "kind" | "title" | "detail">,
+) => {
+  const title = input.title.toLowerCase();
+  if (title === "text too long") {
+    return input.detail?.startsWith("prompt:")
+      ? `reduce prompt to ${THOUGHT_V2_PROTOCOL_RELEASE.limits.promptMaxBytes} UTF-8 bytes or less`
+      : `rerun with Agent output at ${THOUGHT_V2_PROTOCOL_RELEASE.limits.agentMaxBytes} UTF-8 bytes or less`;
+  }
+  switch (input.kind) {
+    case "work_preview_unavailable":
+      return "retry preview";
+    case "work_preview_rejected":
+      return "reset and send the work again";
+    case "work_run_access_needed":
+    case "work_run_expired":
+    case "work_failed":
+      return "reset and send the work again";
+    case "work_blocked":
+      return "run the work again, then retry mint";
+    case "wallet_connection_failed":
+      return "retry wallet connection";
+    case "conflicting_mint_reverted":
+      return "keep tracking the original transaction";
+    case "multiple_mint_hashes_returned":
+      return "wait for a retained hash; do not submit again";
+    case "pending_mint_deployment_mismatch":
+      return "open the original deployment and track the retained hash";
+    case "mint_submission_detached":
+    case "mint_activity_checked":
+      return "check wallet activity before retrying";
+    case "work_save_failed":
+      return "complete the work, then save again";
+    default:
+      break;
+  }
+  if (title.includes("wallet request already open")) {
+    return "resolve the open wallet request";
+  }
+  if (title.includes("wallet unavailable")) {
+    return "install or enable a wallet";
+  }
+  if (title.includes("switch wallet account")) {
+    return "switch to the $PATH owner account, then refresh wallet from the shell bar";
+  }
+  if (title.includes("switch network")) {
+    return "switch to the THOUGHT network, then refresh wallet from the shell bar";
+  }
+  if (title.includes("inventory unavailable")) {
+    return "refresh wallet from the shell bar";
+  }
+  if (title.includes("need a path") || title.includes("no path can mint")) {
+    return "mint a $PATH, then refresh wallet from the shell bar";
+  }
+  if (title.includes("path")) {
+    return "pick another $PATH or refresh wallet from the shell bar";
+  }
+  return undefined;
+};
+
+const emitThoughtConsoleEvent = (input: ThoughtConsoleEventDraft) => {
+  const actionNeeded = input.tone === "warning" || input.tone === "error";
+  const nextStep = actionNeeded
+    ? input.nextStep ?? suggestedThoughtConsoleNextStep(input)
+    : input.nextStep;
   const next = appendThoughtConsoleEvent(thoughtConsoleHistory, {
     ...input,
+    ...(nextStep ? { nextStep } : {}),
     time: thoughtDockConsoleTime(),
     context: currentThoughtConsoleContext(),
   });
@@ -3389,10 +3566,20 @@ const recordThoughtConsoleContextBoundary = (input?: {
   kind?: string;
   title?: string;
   detail?: string;
+  nextStep?: string;
   tone?: ThoughtConsoleTone;
 }) => {
+  const actionNeeded = input?.tone === "warning" || input?.tone === "error";
+  const nextStep = actionNeeded
+    ? input?.nextStep ?? suggestedThoughtConsoleNextStep({
+        kind: input.kind ?? "context_warning",
+        title: input.title ?? "context warning",
+        detail: input.detail,
+      })
+    : input?.nextStep;
   const next = appendThoughtConsoleContextBoundary(thoughtConsoleHistory, {
     ...input,
+    ...(nextStep ? { nextStep } : {}),
     time: thoughtDockConsoleTime(),
     context: currentThoughtConsoleContext(),
   });
@@ -3410,16 +3597,28 @@ const thoughtConsoleToneForPresentation = (
   return "neutral";
 };
 
+const thoughtConsoleNextStepForPresentation = (
+  presentation: ThoughtMintPresentation,
+) => {
+  if (presentation.consoleNextStep) {
+    return presentation.consoleNextStep;
+  }
+  const action = presentation.actions.find((item) => item.id !== "none" && !item.disabled);
+  return action?.label ? lowerInitial(action.label) : undefined;
+};
+
 const recordMintConsoleState = (
   state: ThoughtDockState,
   presentation: ThoughtMintPresentation,
 ) => {
   if (state.kind === "work_ready" && mintFlowState === "closed") {
+    const readiness = getCurrentWorkMintReadiness();
     emitThoughtConsoleEvent({
-      kind: "work_ready",
-      title: "work ready",
-      detail: presentation.detail,
-      eventId: `work-ready:${currentRunContext?.clientGeneratedAt ?? currentOutputText}`,
+      kind: readiness.ready ? "work_ready" : "work_blocked",
+      title: readiness.ready ? "work ready" : "work blocked",
+      detail: readiness.ready ? "ready to mint" : readiness.reason,
+      tone: readiness.ready ? "success" : "warning",
+      eventId: `work:${readiness.ready ? "ready" : "blocked"}:${currentRunContext?.clientGeneratedAt ?? currentOutputText}`,
     });
     return;
   }
@@ -3428,10 +3627,14 @@ const recordMintConsoleState = (
     return;
   }
 
+  const presentationNextStep = presentation.consoleNextStep || presentation.tone === "warning"
+    ? thoughtConsoleNextStepForPresentation(presentation)
+    : undefined;
   const base = {
     title: presentation.title,
     detail: presentation.detail,
     tone: thoughtConsoleToneForPresentation(presentation),
+    ...(presentationNextStep ? { nextStep: presentationNextStep } : {}),
   };
 
   if (mintFlowState === "thought_checking" || mintFlowState === "path_checking") {
@@ -3460,7 +3663,7 @@ const recordMintConsoleState = (
     emitThoughtConsoleEvent({
       ...base,
       kind: "path_selected",
-      detail: mintFlowData.pathId ? `PATH #${mintFlowData.pathId.toString()} · 1 THOUGHT mint available` : base.detail,
+      detail: mintFlowData.pathId ? `$PATH #${mintFlowData.pathId.toString()} · 1 THOUGHT mint available` : base.detail,
     });
     return;
   }
@@ -3478,7 +3681,7 @@ const recordMintConsoleState = (
       ...base,
       kind: "authorization_signed",
       detail: mintFlowData.pathId
-        ? `PATH #${mintFlowData.pathId.toString()} · valid until ${new Date(Number(mintFlowData.deadline ?? 0n) * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+        ? `$PATH #${mintFlowData.pathId.toString()} · valid until ${new Date(Number(mintFlowData.deadline ?? 0n) * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
         : base.detail,
       eventId: `authorization-signed:${mintAuthorizationRequestId}`,
     });
@@ -3494,19 +3697,19 @@ const recordMintConsoleState = (
     });
     return;
   }
-  if (mintFlowState === "minted" || state.kind === "minted") {
-    emitThoughtConsoleEvent({
-      ...base,
-      kind: "transaction_confirmed",
-      eventId: `minted:${walletState.mintedTokenId ?? mintFlowData.existingTokenId ?? walletState.txHash ?? mintFlowData.txHash}`,
-    });
-    return;
-  }
   if (mintFlowState === "text_taken") {
     emitThoughtConsoleEvent({
       ...base,
       kind: "thought_exists",
       eventId: `existing:${mintFlowData.existingTokenId ?? mintFlowData.textHash}`,
+    });
+    return;
+  }
+  if (mintFlowState === "minted" || state.kind === "minted") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "transaction_confirmed",
+      eventId: `minted:${walletState.mintedTokenId ?? mintFlowData.existingTokenId ?? walletState.txHash ?? mintFlowData.txHash}`,
     });
     return;
   }
@@ -3519,28 +3722,118 @@ const recordMintConsoleState = (
   }
 };
 
-const renderThoughtConsoleHistory = () => {
-  const entries = [...thoughtConsoleHistory.entries].reverse().map((entry) => {
+const THOUGHT_CONSOLE_PROGRESS_KINDS = new Set([
+  "work_creating_run",
+  "work_opening_agent",
+  "work_waiting_for_agent",
+  "work_agent_returned",
+  "work_previewing",
+  "wallet_connection_requested",
+  "authorization_requested",
+  "transaction_requested",
+  "transaction_submitted",
+  "path_mint_returned",
+  "path_mint_handoff",
+]);
+
+const isThoughtConsoleProgressEntry = (entry: ThoughtConsoleEntry) =>
+  THOUGHT_CONSOLE_PROGRESS_KINDS.has(entry.kind) ||
+  (entry.kind === "work_claim_authorization" && entry.title === "Codex authorized");
+
+const isThoughtConsoleProgressActive = (
+  entry: ThoughtConsoleEntry,
+  state: ThoughtDockState,
+) => {
+  switch (entry.kind) {
+    case "work_creating_run":
+      return state.kind === "creating_run";
+    case "work_opening_agent":
+      return state.kind === "opening_agent";
+    case "work_waiting_for_agent":
+      return state.kind === "waiting_for_agent";
+    case "work_agent_returned":
+      return state.kind === "agent_returned";
+    case "work_previewing":
+      return state.kind === "previewing";
+    case "work_claim_authorization":
+      return state.kind === "claim_authorization" && Boolean(state.approving);
+    case "wallet_connection_requested":
+      return walletConnectInFlight;
+    case "authorization_requested":
+      return mintFlowState === "authorizing";
+    case "transaction_requested":
+    case "transaction_submitted":
+      return mintFlowState === "minting";
+    case "path_mint_returned":
+      return mintFlowState === "thought_checking" || mintFlowState === "path_checking";
+    default:
+      return false;
+  }
+};
+
+const THOUGHT_CONSOLE_TOP_EPSILON_PX = 2;
+
+const newestFirstThoughtConsoleEntries = (entries: ThoughtConsoleEntry[]) => {
+  const timeGroups: ThoughtConsoleEntry[][] = [];
+  entries.forEach((entry) => {
+    const currentGroup = timeGroups.at(-1);
+    if (currentGroup?.at(-1)?.time === entry.time) {
+      currentGroup.push(entry);
+      return;
+    }
+    timeGroups.push([entry]);
+  });
+  return timeGroups.reverse().flat();
+};
+
+const renderThoughtConsoleHistory = (state: ThoughtDockState) => {
+  const newestEntry = thoughtConsoleHistory.entries.at(-1);
+  const previousNewestEntryId = thoughtDockDetailsBody.dataset.newestEntryId || undefined;
+  const previousScrollTop = thoughtDockDetails.scrollTop;
+  const wasPinnedToLatest = previousScrollTop <= THOUGHT_CONSOLE_TOP_EPSILON_PX;
+  const entries = newestFirstThoughtConsoleEntries(thoughtConsoleHistory.entries).map((entry) => {
     const tone: DockRailTone = entry.tone === "neutral" ? "idle" : entry.tone;
-    const lines = buildThoughtConsoleLines(entry).map((line, index) => statusScreenLine(line, {
+    const actionNeeded = entry.tone === "warning" || entry.tone === "error";
+    const nextStep = actionNeeded
+      ? entry.nextStep ?? suggestedThoughtConsoleNextStep(entry)
+      : entry.nextStep;
+    const lines = buildThoughtConsoleLines({
+      ...entry,
+      ...(nextStep ? { nextStep } : {}),
+    }).map((line, index) => statusScreenLine(line, {
       heading: index === 0,
-      tone: index < 2 ? tone : undefined,
+      tone,
     }));
+    if (lines[0] && isThoughtConsoleProgressEntry(entry)) {
+      appendThoughtProgressEllipsis(
+        lines[0],
+        lines[0].textContent ?? "",
+        entry.id === newestEntry?.id && isThoughtConsoleProgressActive(entry, state),
+      );
+    }
     const element = statusScreenEntry(lines);
+    element.dataset.consoleEntryId = entry.id;
     element.dataset.attemptId = entry.context.attemptId;
     element.classList.toggle("is-boundary", entry.boundary);
     element.classList.toggle("is-current-attempt", entry.context.attemptId === mintAttemptId);
     return element;
   });
   thoughtDockDetailsBody.replaceChildren(...entries);
+  thoughtDockDetailsBody.dataset.newestEntryId = newestEntry?.id ?? "";
   thoughtDockDetails.hidden = false;
+  const hasNewLatestEntry = newestEntry?.id !== previousNewestEntryId;
+  if (hasNewLatestEntry || wasPinnedToLatest) {
+    thoughtDockDetails.scrollTop = 0;
+  } else {
+    thoughtDockDetails.scrollTop = previousScrollTop;
+  }
 };
 
 const renderThoughtDockDetails = (
-  _state: ThoughtDockState,
+  state: ThoughtDockState,
   _presentation: ThoughtMintPresentation,
 ) => {
-  renderThoughtConsoleHistory();
+  renderThoughtConsoleHistory(state);
 };
 
 const getResolvedThoughtDockState = (): ThoughtDockState => {
@@ -3549,6 +3842,14 @@ const getResolvedThoughtDockState = (): ThoughtDockState => {
       kind: "minted",
       tokenId: String(walletState.mintedTokenId),
       txHash: walletState.txHash || undefined,
+    };
+  }
+
+  if (mintFlowState === "text_taken" && mintFlowData.existingTokenId !== null) {
+    return {
+      kind: "minted",
+      tokenId: String(mintFlowData.existingTokenId),
+      existing: true,
     };
   }
 
@@ -3564,9 +3865,68 @@ const getResolvedThoughtDockState = (): ThoughtDockState => {
   return thoughtDockState;
 };
 
+type ThoughtWorkMintReadiness =
+  | { ready: true }
+  | { ready: false; reason: string };
+
+const getCurrentWorkMintReadiness = (): ThoughtWorkMintReadiness => {
+  if (!THOUGHT_V2_MINT_ENABLED) {
+    return { ready: false, reason: THOUGHT_V2_MINT_UNAVAILABLE_COPY };
+  }
+  if (!currentOutputText || !currentRunContext) {
+    return { ready: false, reason: "This work has no current V2 run context. Run it again before minting." };
+  }
+  if (!hasCurrentContractWorkSvg()) {
+    return { ready: false, reason: "This work has no verified contract preview. Run it again before minting." };
+  }
+  if (!IS_LOCAL_THOUGHT_V2) {
+    return { ready: true };
+  }
+  if (currentRunContext.mode === MY_BRAIN_MODE) {
+    return { ready: false, reason: "THOUGHT V2 minting requires a current Agent work." };
+  }
+  if (!currentRunContext.thoughtSpec) {
+    return { ready: false, reason: "This work has no current V2 spec anchor. Run it again before minting." };
+  }
+  if (!currentRunContext.agentEvidence) {
+    return { ready: false, reason: "This work has no current V2 Agent evidence. Run it again before minting." };
+  }
+  try {
+    buildThoughtV2LocalAgentProcess(currentRunContext.agentEvidence, currentOutputText);
+  } catch (error) {
+    return {
+      ready: false,
+      reason: error instanceof Error ? error.message : "This work is not valid for THOUGHT V2 minting.",
+    };
+  }
+  return { ready: true };
+};
+
+const captureCurrentMintWork = (): ThoughtMintWorkSnapshot | null => {
+  const readiness = getCurrentWorkMintReadiness();
+  if (!readiness.ready || !currentRunContext) {
+    return null;
+  }
+  const runContext = Object.freeze({
+    ...currentRunContext,
+    ...(currentRunContext.thoughtSpec
+      ? { thoughtSpec: Object.freeze({ ...currentRunContext.thoughtSpec }) }
+      : {}),
+    ...(currentRunContext.agentEvidence
+      ? { agentEvidence: Object.freeze({ ...currentRunContext.agentEvidence }) }
+      : {}),
+  });
+  return Object.freeze({
+    text: currentOutputText,
+    svg: currentWorkSvg,
+    workId: currentWorkId,
+    runContext,
+  });
+};
+
 const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
   const resetAction = (run?: AgentDemoRun | null) =>
-    dockRailAction("reset", "reset", "reset THOUGHT Dock and clear input", "secondary", () => {
+    dockRailAction("reset", "reset", "reset THOUGHT Dock and clear input", () => {
       if (run) {
         void cancelThoughtDockRun(run, { clearPrompt: true, focusPrompt: true });
         return;
@@ -3574,244 +3934,81 @@ const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
       resetThoughtDock({ clearPrompt: true, focusPrompt: true });
     });
   const cancelAgentSelectAction = (prompt: string) =>
-    dockRailAction("cancel", "cancel", "cancel Agent selection", "secondary", () => {
+    dockRailAction("cancel", "cancel", "cancel Agent selection", () => {
       setThoughtDockState({ kind: "ready", prompt });
       focusThoughtDockPrompt({ preventScroll: true });
     });
+  const loadAction = () => {
+    const loadPanelOpen = workLibraryRevealed;
+    return dockRailAction(
+      "load",
+      loadPanelOpen ? "load ↓" : "load",
+      loadPanelOpen ? "collapse saved works" : "open saved works",
+      () => {
+        workLibraryRevealed = !loadPanelOpen;
+        if (workLibraryRevealed) {
+          mintDockRevealed = false;
+          writeCurrentOutputSession();
+          emitThoughtConsoleEvent({
+            kind: "work_library_opened",
+            title: "load a saved work",
+            detail: "Saved works use this browser's local storage. They are not on-chain or synced across browsers or devices.",
+            tone: "neutral",
+          });
+        }
+        syncThoughtDock();
+        if (workLibraryRevealed) {
+          requestAnimationFrame(() => thoughtDockWorksSelect.focus({ preventScroll: true }));
+        }
+      },
+      { expanded: loadPanelOpen },
+    );
+  };
   const newThoughtAction = () =>
-    dockRailAction("new-thought", "new thought", "start a new THOUGHT", "primary", () => {
+    dockRailAction("new-thought", "new thought", "start a new THOUGHT", () => {
       window.location.href = "/";
     });
-  const mintResetAction = () =>
-    dockRailAction("reset", "reset", "reset THOUGHT Dock and clear input", "secondary", () => {
-      resetThoughtDock({ clearPrompt: true, focusPrompt: true });
-    });
-  const openGlobalWalletAction = (label = "connect wallet") =>
-    dockRailAction("open-wallet", label, "open global wallet controls", "primary", () => {
-      openInshellWallet();
-    });
-  const showMintDockAction = (label = "select path") =>
-    dockRailAction("select-path", label, "Select PATH for this THOUGHT mint", "primary", () => {
-      mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
-      syncInterface();
-      focusMintPathInput();
-    });
-  const mintPathAction = () =>
-    dockRailAction("mint-path", "mint path", "open PATH mint page", "secondary", () => {
-      handleMintPath();
-    });
-  const authorizeAction = () =>
-    dockRailAction("authorize", "authorize", "authorize PATH for this THOUGHT", "primary", () => {
-      void authorizeMint();
-    });
-  const confirmMintAction = () =>
-    dockRailAction("confirm-mint", "confirm mint", "confirm THOUGHT mint in wallet", "primary", () => {
-      void confirmMint();
-    });
-  const retryMintAction = () =>
-    dockRailAction("retry-mint", "retry", "retry mint preparation", "primary", () => {
-      void refreshMintSheetPath();
-    });
-  const viewThoughtAction = () =>
-    dockRailAction("view", "view", "view THOUGHT", "primary", () => {
-      void handleViewThought(walletState.mintedTokenId ?? mintFlowData.existingTokenId);
-    });
-  const viewTxAction = () =>
-    dockRailAction("view-tx", "view tx", "view THOUGHT mint transaction", "primary", () => {
-      void handleViewTx();
-    });
-  const mintFlowStatus = () => {
-    if (mintFlowState === "closed") {
-      return "Preparing mint...";
-    }
-    if (mintFlowState === "thought_checking") {
-      return "Checking THOUGHT...";
-    }
-    if (mintFlowState === "text_taken") {
-      return "Already minted";
-    }
-    if (mintFlowState === "wallet_required") {
-      return "wallet required";
-    }
-    if (mintFlowState === "path_required") {
-      return "select PATH";
-    }
-    if (mintFlowState === "path_checking") {
-      return "checking PATH";
-    }
-    if (mintFlowState === "path_ready") {
-      return "authorize PATH";
-    }
-    if (mintFlowState === "authorizing") {
-      return "authorize PATH";
-    }
-    if (mintFlowState === "authorized") {
-      return "ready to mint";
-    }
-    if (mintFlowState === "minting") {
-      return walletState.txState === "submitted" ? "minting" : "confirm mint";
-    }
-    if (mintFlowState === "minted") {
-      return "Minted";
-    }
-    if (mintFlowState === "error") {
-      return mintFlowData.errorKind === "wrong_network" ? "Wrong network" : "Error";
-    }
-    return "Minting...";
-  };
-  const mintFlowTone = (): DockRailTone => {
-    if (mintFlowState === "minted" || mintFlowState === "authorized") {
-      return "success";
-    }
-    if (mintFlowState === "text_taken") {
-      return "warning";
-    }
-    if (mintFlowState === "wallet_required" || mintFlowState === "path_required" || mintFlowState === "path_ready") {
-      return "idle";
-    }
-    if (mintFlowState === "error") {
-      return mintFlowData.errorKind === "wrong_network" ? "warning" : "error";
-    }
-    return "running";
-  };
-  const mintFlowDetail = (): DockDetailView => {
-    if (mintFlowState === "text_taken") {
-      return {
-        kind: "error",
-        title: "Already minted",
-        body: "PATH permission is only requested for a new THOUGHT. This exact work already exists on-chain.",
-      };
-    }
-    if (mintFlowState === "wallet_required") {
-      return isInjectedWalletMissing()
-        ? { kind: "wallet", message: "no wallet connector is available." }
-        : { kind: "wallet", message: "connect from the global wallet to continue." };
-    }
-    if (mintFlowState === "path_required") {
-      return { kind: "path", message: "Choose the $PATH that will authorize this THOUGHT mint." };
-    }
-    if (mintFlowState === "path_ready") {
-      const selectedPathId = selectedCliPathId();
-      return selectedPathId
-        ? { kind: "path", message: `$PATH #${selectedPathId} has a THOUGHT unit available.` }
-        : { kind: "none" };
-    }
-    if (mintFlowState === "error") {
-      if (mintFlowData.errorKind === "wrong_network") {
-        return { kind: "wallet", message: "switch network from the global wallet to continue." };
-      }
-      return { kind: "error", title: mintFlowStatus(), body: mintFlowData.error || getMintSheetStatusCopy() || "Mint failed." };
-    }
-    return { kind: "none" };
-  };
-  const mintFlowActions = (): { actions: DockRailAction[]; maxActions?: number } => {
-    if (mintFlowState === "closed" || mintFlowState === "thought_checking") {
-      return { actions: [] };
-    }
-    if (mintFlowState === "text_taken") {
-      return { actions: [viewThoughtAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "wallet_required") {
-      return { actions: [openGlobalWalletAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "path_required") {
-      if (mintFlowUiMode === "dock") {
-        return { actions: [mintResetAction()] };
-      }
-      return { actions: [showMintDockAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "path_checking" || mintFlowState === "authorizing") {
-      return { actions: [mintResetAction()] };
-    }
-    if (mintFlowState === "path_ready") {
-      if (mintFlowUiMode === "dock") {
-        return { actions: [mintResetAction()] };
-      }
-      return { actions: [authorizeAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "authorized") {
-      if (mintFlowUiMode === "dock") {
-        return { actions: [mintResetAction()] };
-      }
-      return { actions: [confirmMintAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "minting") {
-      return walletState.txHash
-        ? { actions: [viewTxAction()] }
-        : { actions: [] };
-    }
-    if (mintFlowState === "minted") {
-      return { actions: [viewThoughtAction(), mintResetAction()] };
-    }
-    if (mintFlowState === "error") {
-      if (mintFlowData.errorKind === "wrong_network") {
-        return { actions: [openGlobalWalletAction("open wallet"), mintResetAction()] };
-      }
-      if (isPathRecoveryError()) {
-        if (mintFlowUiMode === "dock") {
-          return { actions: [mintResetAction()] };
-        }
-        return {
-          actions: [showMintDockAction("choose path"), mintPathAction(), mintResetAction()],
-          maxActions: 3,
-        };
-      }
-      return { actions: [retryMintAction(), mintResetAction()] };
-    }
-    return { actions: [mintResetAction()] };
-  };
-  const mintFlowRail = (): DockRailView => {
-    const presentation = getCurrentMintPresentation();
-    return {
-      status: "",
-      tone: presentation.tone,
-      actions: [],
-      detail: { kind: "none" },
-    };
-  };
 
   switch (state.kind) {
     case "empty":
       return {
-        status: "",
+        status: "Prompt needed",
         tone: "idle",
         actions: [
           dockRailAction(
             "send-agent",
             "send to your agent",
             "Enter a THOUGHT before running with your Agent",
-            "primary",
             () => {},
             { disabled: true },
           ),
+          loadAction(),
         ],
-        detail: { kind: "none" },
       };
     case "ready":
       return {
-        status: "",
+        status: "Prompt ready",
         tone: "idle",
         actions: [
-          dockRailAction("send-agent", "send to your agent", "run this THOUGHT with your Agent", "primary", () => {
+          dockRailAction("send-agent", "send to your agent", "run this THOUGHT with your Agent", () => {
             openThoughtDockAgentSelect();
           }),
+          loadAction(),
         ],
-        detail: { kind: "none" },
       };
     case "agent_select":
       return {
-        status: "",
+        status: "Choose Agent",
         tone: "idle",
         actions: [
-          dockRailAction("codex", "codex", "run this THOUGHT with Codex", "primary", () => {
+          dockRailAction("codex", "codex", "run this THOUGHT with Codex", () => {
             void runThoughtDockAdapter("codex");
           }),
-          dockRailAction("claude", "claude", "open this THOUGHT in Claude Code", "secondary", () => {
+          dockRailAction("claude", "claude", "open this THOUGHT in Claude Code", () => {
             void runThoughtDockAdapter("claude");
           }),
           cancelAgentSelectAction(state.prompt),
         ],
-        detail: { kind: "none" },
         maxActions: 3,
       };
     case "creating_run":
@@ -3819,21 +4016,18 @@ const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
         status: thoughtDockAgentLifecycleStatus(state.adapterId),
         tone: "running",
         actions: [],
-        detail: { kind: "none" },
       };
     case "agent_task_ready":
       return {
         status: "Task ready",
         tone: "idle",
         actions: [resetAction(state.run)],
-        detail: { kind: "none" },
       };
     case "opening_agent":
       return {
         status: `Opening ${thoughtAgentProductLabel(state.adapterId)}...`,
         tone: "running",
         actions: [resetAction(state.run)],
-        detail: { kind: "none" },
       };
     case "claim_authorization": {
       const code = state.authorization.verificationCode || "------";
@@ -3848,14 +4042,12 @@ const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
                 "allow-codex",
                 "allow codex",
                 `allow Codex claim ${code}`,
-                "primary",
                 () => {
                   void approveThoughtDockClaim(state.run, state.adapterId, state.authorization);
                 },
               ),
               resetAction(state.run),
             ],
-        detail: { kind: "none" },
       };
     }
     case "waiting_for_agent":
@@ -3863,117 +4055,145 @@ const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
         status: thoughtDockAgentLifecycleStatus(state.adapterId, state.run.remoteState),
         tone: "running",
         actions: [resetAction(state.run)],
-        detail: { kind: "none" },
       };
     case "agent_returned":
-      return { status: "Return received...", tone: "success", actions: [], detail: { kind: "none" } };
+      return { status: "Return received...", tone: "success", actions: [] };
     case "previewing":
-      return { status: "Previewing...", tone: "running", actions: [], detail: { kind: "none" } };
+      return { status: "Previewing...", tone: "running", actions: [] };
     case "preview_unavailable":
       return {
         status: "Preview unavailable",
         tone: "warning",
         actions: [
-          dockRailAction("retry", "retry", "retry preview", "primary", () => {
+          dockRailAction("retry", "retry", "retry preview", () => {
             void retryThoughtDockPreview();
           }),
           resetAction(),
         ],
-        detail: state.reason ? { kind: "error", title: "Preview unavailable", body: state.reason } : { kind: "none" },
       };
     case "preview_rejected":
       return {
         status: "Rejected",
-        tone: "error",
+        tone: state.reasonCode === 3 ? "warning" : "error",
         actions: [resetAction()],
-        detail: { kind: "error", title: "Preview rejected", body: state.reason },
       };
     case "work_ready":
       {
         const workReady = getThoughtWorkReadyPresentation({
           mintEnabled: THOUGHT_V2_MINT_ENABLED,
-          walletConnected: Boolean(walletState.address),
         });
+        const workMintReadiness = getCurrentWorkMintReadiness();
+        const mintPanelOpen = mintDockRevealed;
+        const canOpenMint = workReady.canMint && workMintReadiness.ready;
+        const currentWorkSaved = currentWorkId !== null && Boolean(
+          getWorkById(readStoredThoughtWorks(), currentWorkId),
+        );
         return {
-          status: "Work ready",
-          tone: workReady.canMint ? "success" : "warning",
+          status: canOpenMint ? "Work ready" : "Work blocked",
+          tone: canOpenMint ? "success" : "warning",
           actions: [
-            ...(workReady.canMint
-              ? [dockRailAction("mint", "mint", "mint this accepted THOUGHT work", "primary", () => {
-                  void mintThoughtDockWork();
-                })]
+            ...(canOpenMint
+              ? [dockRailAction(
+                  "mint",
+                  mintPanelOpen ? "mint ↓" : "mint",
+                  mintPanelOpen ? "collapse Mint panel" : "mint this accepted THOUGHT work",
+                  () => {
+                    if (mintPanelOpen) {
+                      mintDockRevealed = false;
+                      writeCurrentOutputSession();
+                      syncThoughtDock();
+                      return;
+                    }
+                    revealMintDock();
+                    emitThoughtConsoleEvent({
+                      kind: "mint_requirement",
+                      title: "to mint THOUGHT",
+                      detail: "1 THOUGHT requires 1 available $PATH. $PATH is the permission token for Inshell’s three fully on-chain movements for Agent Art.",
+                      tone: "warning",
+                    });
+                    syncThoughtDock();
+                    void mintThoughtDockWork();
+                  },
+                  { expanded: mintPanelOpen },
+                )]
               : []),
+            dockRailAction(
+              "save",
+              currentWorkSaved ? "saved" : "save",
+              currentWorkSaved ? "current work is saved" : "save current work",
+              () => {
+                saveCurrentWorkFromDock();
+              },
+              { disabled: currentWorkSaved },
+            ),
+            loadAction(),
             resetAction(),
           ],
-          detail: { kind: "none" },
+          maxActions: 4,
         };
       }
-    case "minting":
-      return mintFlowRail();
-    case "minted":
+    case "minted": {
+      const currentWorkSaved = currentWorkId !== null && Boolean(
+        getWorkById(readStoredThoughtWorks(), currentWorkId),
+      );
       return {
-        status: "Minted",
+        status: state.existing ? "Already exists" : "Minted",
         tone: "success",
         actions: [
-          dockRailAction("view", "view", "view minted THOUGHT", "primary", () => {
-            void handleViewThought(walletState.mintedTokenId);
+          dockRailAction("view", "view", "view minted THOUGHT", () => {
+            void handleViewThought(state.tokenId ? Number(state.tokenId) : walletState.mintedTokenId);
           }),
+          dockRailAction(
+            "save",
+            currentWorkSaved ? "saved" : "save",
+            currentWorkSaved ? "current work is saved" : "save current work",
+            () => {
+              saveCurrentWorkFromDock();
+            },
+            { disabled: currentWorkSaved },
+          ),
+          loadAction(),
           resetAction(),
         ],
-        detail: { kind: "none" },
+        maxActions: 4,
       };
+    }
     case "run_access_needed":
       return {
         status: "",
         tone: "warning",
         actions: [newThoughtAction()],
-        detail: { kind: "error", title: "Run access needed", body: state.details },
       };
     case "expired":
       return {
         status: "Codex link expired",
         tone: "error",
         actions: [resetAction()],
-        detail: {
-          kind: "error",
-          title: "Codex link expired",
-          body: "Codex did not claim this run within 5 minutes. Reset and send it again.",
-        },
       };
     case "failed":
       return {
         status: "Error",
         tone: "error",
         actions: [resetAction()],
-        detail: { kind: "error", title: state.message, body: state.details || state.message },
       };
   }
-};
-
-type ThoughtPanelMode =
-  | "create"
-  | "sealing_run"
-  | "opening_agent"
-  | "waiting_for_agent"
-  | "run_review"
-  | "integrity_failed"
-  | "ready_to_mint"
-  | "wallet_needed"
-  | "path_needed"
-  | "minting"
-  | "minted"
-  | "failed";
-
-type ThoughtPanelStatusView = {
-  mode: ThoughtPanelMode;
-  title: string;
-  detail: string;
 };
 
 const shortRunId = (runId: string) =>
   runId.length > 14 ? `${runId.slice(0, 8)}...${runId.slice(-4)}` : runId;
 
 const isInjectedWalletMissing = () => !walletState.detected && !getEthereumProvider();
+
+const formatPathAcquisitionPrice = (price: bigint) => {
+  const [whole, rawFraction = ""] = formatEther(price).split(".");
+  const fraction = rawFraction.replace(/0+$/, "");
+  if (!fraction) return whole;
+  const firstNonZero = fraction.search(/[1-9]/);
+  const visibleLength = whole === "0" && firstNonZero >= 0
+    ? Math.min(fraction.length, firstNonZero + 6)
+    : Math.min(fraction.length, 6);
+  return `${whole}.${fraction.slice(0, visibleLength)}`;
+};
 
 const getCurrentMintPresentation = () => presentThoughtMint({
   state: mintFlowState,
@@ -3990,6 +4210,15 @@ const getCurrentMintPresentation = () => presentThoughtMint({
     held: pathInventoryState.items.length,
     available: availablePathInventoryItems().length,
     error: pathInventoryState.error,
+  },
+  pathAcquisition: {
+    state: pathAcquisitionState,
+    completed: pathAcquisitionCompletedForAttempt,
+    priceLabel: pathAcquisitionPrice > 0n
+      ? `${formatPathAcquisitionPrice(pathAcquisitionPrice)} ${THOUGHT_CURRENCY_LABEL}`
+      : THOUGHT_CURRENCY_LABEL,
+    txHash: pathAcquisitionTxHash,
+    error: pathAcquisitionError,
   },
   pathId: mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim(),
   existingTokenId: walletState.mintedTokenId ?? mintFlowData.existingTokenId,
@@ -4019,19 +4248,19 @@ const visibleMintErrorCopy = () => {
     return "wrong network.";
   }
   if (mintFlowData.errorKind === "path_not_found") {
-    return "wallet does not hold this PATH.";
+    return "wallet does not hold this $PATH.";
   }
   if (mintFlowData.errorKind === "path_consumed" || mintFlowData.errorKind === "path_not_ready") {
-    return "PATH has no THOUGHT unit available.";
+    return "$PATH has no THOUGHT mint available.";
   }
   if (mintFlowData.errorKind === "signature") {
-    return mintFlowData.error || "authorization failed.";
+    return mintFlowData.error || "signature failed.";
   }
   if (mintFlowData.errorKind === "thought") {
     return mintFlowData.error || "mint failed.";
   }
   if (mintFlowData.errorKind === "path_invalid" || mintFlowData.errorKind === "path_unknown") {
-    return "enter a valid PATH.";
+    return "enter a valid $PATH.";
   }
   if (/not submitted/i.test(mintFlowData.error)) {
     return "wallet transaction not submitted.";
@@ -4042,314 +4271,36 @@ const visibleMintErrorCopy = () => {
   return "mint failed.";
 };
 
-const thoughtPanelStatusForMintFlow = (): ThoughtPanelStatusView => {
-  const presentation = getCurrentMintPresentation();
-  return {
-    mode: presentation.panelMode,
-    title: presentation.title,
-    detail: presentation.detail,
-  };
-};
-
-const getThoughtPanelStatusView = (state: ThoughtDockState): ThoughtPanelStatusView => {
-  switch (state.kind) {
-    case "empty":
-    case "ready":
-      return { mode: "create", title: "Give a thought to your Agent", detail: "No run yet" };
-    case "agent_select":
-      return { mode: "create", title: "Give a thought to your Agent", detail: "Choose Codex or Claude" };
-    case "creating_run":
-      return { mode: "sealing_run", title: "Sealing run", detail: "Preparing Agent task" };
-    case "agent_task_ready":
-    case "opening_agent":
-      return {
-        mode: "opening_agent",
-        title: `Opening ${thoughtAgentProductLabel(state.adapterId)}`,
-        detail: "Run sealed",
-      };
-    case "claim_authorization":
-      return {
-        mode: "waiting_for_agent",
-        title: state.authorization.state === "authorized" || state.approving
-          ? "Codex authorized"
-          : "Authorize Codex",
-        detail: state.authorization.verificationCode
-          ? `Code ${state.authorization.verificationCode}`
-          : "Confirm this claim request",
-      };
-    case "waiting_for_agent":
-      return {
-        mode: "waiting_for_agent",
-        title: thoughtDockAgentLifecycleTitle(state.adapterId, state.run.remoteState),
-        detail: state.run?.runId ? `Run ${shortRunId(state.run.runId)} sealed` : "Return will appear here automatically",
-      };
-    case "agent_returned":
-    case "previewing":
-      return { mode: "run_review", title: "Agent result received", detail: "Checking integrity" };
-    case "preview_unavailable":
-    case "preview_rejected":
-      return { mode: "integrity_failed", title: "Run cannot mint", detail: "See details" };
-    case "work_ready":
-      return {
-        mode: "ready_to_mint",
-        title: "work ready",
-        detail: getThoughtWorkReadyPresentation({
-          mintEnabled: THOUGHT_V2_MINT_ENABLED,
-          walletConnected: Boolean(walletState.address),
-        }).detail,
-      };
-    case "minting":
-      return thoughtPanelStatusForMintFlow();
-    case "minted":
-      return { mode: "minted", title: "minted", detail: "official token created" };
-    case "expired":
-      return { mode: "failed", title: "Codex link expired", detail: "Reset and send again" };
-    case "run_access_needed":
-      return { mode: "failed", title: "Run access needed", detail: "This link is missing its view token" };
-    case "failed":
-      return { mode: "failed", title: "mint error", detail: "see details" };
-  }
-};
-
-const renderThoughtDockDetailTray = (detail: DockDetailView) => {
-  const children: HTMLElement[] = [];
-
-  if (detail.kind === "agentTask") {
-    const task = document.createElement("pre");
-    task.className = "thought-dock-detail-code";
-    task.textContent = detail.sealedTask;
-    children.push(task);
-  } else if (detail.kind === "error") {
-    const title = document.createElement("p");
-    title.className = "thought-dock-detail-title";
-    title.textContent = detail.title;
-    const body = document.createElement("p");
-    body.className = "thought-dock-detail-body";
-    body.textContent = detail.body;
-    children.push(title, body);
-  } else if (detail.kind === "wallet" || detail.kind === "path") {
-    const body = document.createElement("p");
-    body.className = "thought-dock-detail-body";
-    body.textContent = detail.message;
-    children.push(body);
-  } else if (detail.kind === "debug") {
-    const json = document.createElement("pre");
-    json.className = "thought-dock-detail-code";
-    json.textContent = JSON.stringify(detail.json, null, 2);
-    children.push(json);
-  }
-
-  thoughtDockExpanded.hidden = children.length === 0;
-  thoughtDockExpanded.replaceChildren(...children);
-};
-
-const walletStripShouldBeVisible = (state: ThoughtDockState) =>
-  mintFlowState !== "text_taken" &&
-  (
-    state.kind === "work_ready" ||
-    state.kind === "minting" ||
-    walletState.address.length > 0 ||
-    (mintFlowState !== "closed" && mintFlowState !== "minted")
-  );
-
-const pathInventorySummary = () => {
-  if (!walletState.address || walletState.chainId !== THOUGHT_CHAIN_ID) {
-    return "";
-  }
-
-  if (!pathInventoryMatchesCurrentWallet()) {
-    return "PATH: not checked";
-  }
-
-  if (pathInventoryState.status === "loading" || pathInventoryState.status === "idle") {
-    return "PATH: reading";
-  }
-
-  if (pathInventoryState.status === "unavailable" || pathInventoryState.status === "error") {
-    return "PATH: unavailable";
-  }
-
-  const held = pathInventoryState.items.length;
-  const available = availablePathInventoryItems().length;
-  return `PATH: ${available} available / ${held} held`;
-};
-
-const getWalletStageView = (state: ThoughtDockState): WalletStripView => {
-  if (!walletStripShouldBeVisible(state)) {
-    return {
-      visible: false,
-      title: "wallet",
-      detail: "",
-      tone: "idle",
-      actions: [],
-    };
-  }
-
-  if (isInjectedWalletMissing()) {
-    return {
-      visible: true,
-      title: "wallet",
-      detail: "no supported wallet found",
-      meta: "install or enable an injected wallet, then refresh.",
-      tone: "warning",
-      actions: [],
-    };
-  }
-
-  if (!walletState.address) {
-    return {
-      visible: true,
-      title: "wallet",
-      detail: "not connected",
-      meta: walletDisconnectedByUser
-        ? "disconnected in THOUGHT. to fully remove site access, disconnect this site in your wallet."
-        : "read only. no signature. no tx.",
-      tone: walletConnectInFlight ? "running" : "idle",
-      actions: [],
-    };
-  }
-
-  if (walletState.chainId !== THOUGHT_CHAIN_ID) {
-    return {
-      visible: true,
-      title: "wallet",
-      detail: "wrong network",
-      address: walletState.address,
-      chainLabel: getWalletNetworkLabel(),
-      meta: `${shortHex(walletState.address)} · ${getWalletNetworkLabel().toLowerCase()}`,
-      tone: "warning",
-      actions: [],
-    };
-  }
-
-  return {
-    visible: true,
-    title: "wallet",
-    detail: `${shortHex(walletState.address)} · ${getWalletNetworkLabel().toLowerCase()}`,
-    address: walletState.address,
-    chainLabel: getWalletNetworkLabel(),
-    meta: pathInventorySummary() || "PATH: not checked",
-    tone: walletState.preflightLoading ? "running" : "ready",
-    actions: [],
-  };
-};
-
-const handleWalletStripAction = (action: WalletAction) => {
-  if (action === "connect" || action === "refresh" || action === "switch_network") {
-    void runThoughtDockWalletCommand();
-    return;
-  }
-
-  if (action === "disconnect") {
-    disconnectThoughtDockWallet();
-    return;
-  }
-
-  if (action === "copy_address" && walletState.address) {
-    void copyToClipboard(walletState.address).then((copied) => {
-      if (copied) {
-        setStatus("address copied.", { flashMs: NOTICE_FLASH_MS });
-      }
-    });
-  }
-};
-
-const walletStripActionLabel = (action: WalletAction) => {
-  if (action === "connect") {
-    return "connect wallet";
-  }
-  if (action === "switch_network") {
-    return "switch network";
-  }
-  if (action === "copy_address") {
-    return "copy address";
-  }
-  return action;
-};
-
-const renderWalletStripAction = (action: WalletAction) => {
-  const button = document.createElement("button");
-  button.className = "thought-dock-button thought-wallet-strip__button";
-  button.type = "button";
-  button.textContent = walletStripActionLabel(action);
-  button.addEventListener("click", () => {
-    handleWalletStripAction(action);
-  });
-  return button;
-};
-
-const renderWalletStrip = (state: ThoughtDockState) => {
-  const view = getWalletStageView(state);
-  thoughtWalletStrip.classList.toggle("is-hidden", !view.visible);
-  thoughtWalletStrip.dataset.tone = view.tone;
-  thoughtWalletStripTitle.textContent = view.title;
-  thoughtWalletStripDetail.textContent = view.detail;
-  thoughtWalletStripDetail.title = view.address ?? view.detail;
-  thoughtWalletStripMeta.textContent = view.meta ?? "";
-  thoughtWalletStripMeta.classList.toggle("is-hidden", !view.meta);
-  thoughtWalletStripActions.replaceChildren(
-    ...view.actions.map(renderWalletStripAction),
-  );
-};
-
 const renderThoughtDock = () => {
   const state = getResolvedThoughtDockState();
   const locked = isThoughtDockInputLockedState(state);
-  const panelStatus = getThoughtPanelStatusView(state);
   const mintPresentation = getCurrentMintPresentation();
 
   thoughtDockPrompt.readOnly = locked;
   if (thoughtDockPrompt.value !== sessionState.prompt) {
     thoughtDockPrompt.value = sessionState.prompt;
   }
-  thoughtPanel.dataset.mode = panelStatus.mode;
-  thoughtPanelStatusTitle.textContent = panelStatus.title;
-  thoughtPanelStatusDetail.textContent = panelStatus.detail;
-  const inRunLinkMode = IS_RUN_PAGE;
-  const shouldShowPromptComposer =
-    !inRunLinkMode ||
-    state.kind === "empty" ||
-    state.kind === "ready" ||
-    state.kind === "agent_select" ||
-    state.kind === "creating_run";
-  thoughtDock.hidden = !shouldShowPromptComposer;
-
   const rail = getThoughtDockRailView(state);
   if (IS_DEV_MODE) {
     assertDockRailView(rail);
   }
 
-  const railHidden = rail.actions.length === 0 && !rail.status;
+  const railHidden = rail.actions.length === 0;
   thoughtDock.dataset.rail = railHidden ? "hidden" : "visible";
   thoughtDockActionArea.hidden = railHidden;
-  thoughtDockActionArea.dataset.tone = rail.tone;
-  const railContent = rail.status && rail.actions.length > 0
-    ? "mixed"
-    : rail.status
-      ? "status"
-      : "actions";
-  const nextRailSignature = railHidden ? "hidden" : thoughtDockRailAnimationSignature(railContent, rail);
-  const shouldAnimateRail = nextRailSignature !== thoughtDockRailSignature;
+  const nextRailSignature = railHidden ? "hidden" : thoughtDockRailRenderSignature(rail);
+  const shouldRenderRail = nextRailSignature !== thoughtDockRailSignature;
   thoughtDockRailSignature = nextRailSignature;
-  thoughtDockActionArea.dataset.content = railContent;
+  thoughtDockActionArea.dataset.content = "actions";
   if (railHidden) {
     thoughtDockActionArea.replaceChildren();
-  } else if (shouldAnimateRail || thoughtDockActionArea.childElementCount === 0) {
-    const children: HTMLElement[] = [];
-    if (rail.status) {
-      children.push(thoughtDockStatusChip(rail.status, rail.tone));
-    }
-    if (rail.actions.length > 0) {
-      children.push(thoughtDockActions(...rail.actions.map(renderDockRailAction)));
-    }
-    thoughtDockActionArea.replaceChildren(...children);
-  if (shouldAnimateRail) {
-      animateThoughtDockRailEntry();
-    }
+  } else if (shouldRenderRail || thoughtDockActionArea.childElementCount === 0) {
+    thoughtDockActionArea.replaceChildren(
+      thoughtDockActions(...rail.actions.map(renderDockRailAction)),
+    );
   }
-  renderWalletStrip(state);
   syncMintDockPathPanel();
-  renderThoughtDockDetailTray({ kind: "none" });
+  syncWorkLibraryPanel();
   renderThoughtDockDetails(state, mintPresentation);
   syncThoughtDockRailInset();
 };
@@ -4468,17 +4419,102 @@ const launchThoughtDockAgentLink = (url: string) => {
   window.setTimeout(() => anchor.remove(), 1000);
 };
 
+const rejectInvalidThoughtDockPrompt = (prompt: string) => {
+  const measure = measureThoughtV2Line(prompt, "prompt");
+  const issue = describeThoughtTextPolicyIssue({
+    value: prompt,
+    line: "prompt",
+    measure,
+    maxBytes: THOUGHT_V2_PROTOCOL_RELEASE.limits.promptMaxBytes,
+  });
+  if (!issue) {
+    return false;
+  }
+  emitThoughtConsoleEvent({
+    kind: issue.title === "text too long" ? "work_prompt_too_long" : "work_prompt_invalid",
+    title: issue.title,
+    detail: issue.detail,
+    nextStep: issue.nextStep,
+    tone: "warning",
+    eventId: `prompt-validation:${hashText(prompt)}:${issue.detail}`,
+  });
+  setThoughtDockState({ kind: "ready", prompt });
+  focusThoughtDockPrompt();
+  return true;
+};
+
 const openThoughtDockAgentSelect = () => {
   if (blockPendingMintMutation()) {
     return;
   }
   const prompt = thoughtDockPrompt.value;
-  if (!prompt.trim()) {
-    setThoughtDockState({ kind: "failed", message: "Prompt is empty." });
-    thoughtDockPrompt.focus();
+  if (rejectInvalidThoughtDockPrompt(prompt)) {
     return;
   }
   setThoughtDockState({ kind: "agent_select", prompt });
+};
+
+const buildThoughtDockFixtureRun = async (
+  adapterId: ThoughtDockAgentAdapterId,
+  prompt: string,
+  agentLine: string,
+): Promise<AgentDemoRun> => {
+  const runId = `fixture_${adapterId}_${Date.now().toString(36)}_${agentDemoRandom(3)}`;
+  const result = IS_LOCAL_THOUGHT_V2
+    ? buildThoughtV2LocalAgentResult(agentLine, thoughtAgentProductLabel(adapterId))
+    : null;
+  const rawResponseSha256 = result
+    ? (await sha256Hex(JSON.stringify(result))).replace(THOUGHT_SHA256_PREFIX, "")
+    : "";
+
+  return {
+    runId,
+    prompt,
+    promptHash: await agentDemoSha256(prompt),
+    launchUri: "",
+    launchToken: "",
+    browserToken: "",
+    statusUrl: "",
+    claimUrl: "",
+    startUrl: "",
+    resultUrl: "",
+    codexUrl: "",
+    claudeUrl: "",
+    sealedTask: "",
+    candidate: agentLine,
+    remoteState: "returned",
+    ...(result
+      ? {
+          agentEvidence: {
+            result,
+            runId,
+            adapter: adapterId,
+            rawResponseSha256,
+          },
+        }
+      : {}),
+  };
+};
+
+const runThoughtDockFixtureAdapter = async (
+  adapterId: ThoughtDockAgentAdapterId,
+  prompt: string,
+  payload: ThoughtRunPayload,
+  runSessionId: number,
+) => {
+  const nonce = `${Date.now().toString(36)} ${agentDemoRandom(3)}`;
+  const agentLine = buildThoughtAgentFixtureLine(adapterId, nonce);
+  assertThoughtLine(agentLine, "agent");
+  const run = await buildThoughtDockFixtureRun(adapterId, prompt, agentLine);
+  thoughtDockRun = run;
+  emitThoughtConsoleEvent({
+    kind: "work_agent_fixture",
+    title: `${thoughtAgentProductLabel(adapterId)} fixture return`,
+    detail: "local dev Agent bypass",
+    tone: "neutral",
+    eventId: run.runId,
+  });
+  await handleThoughtDockReturnedWork(run, agentLine, payload, runSessionId);
 };
 
 const runThoughtDockAdapter = async (adapterId: ThoughtDockAgentAdapterId) => {
@@ -4493,7 +4529,11 @@ const runThoughtDockAdapter = async (adapterId: ThoughtDockAgentAdapterId) => {
   }
 
   const adapter = THOUGHT_DOCK_AGENT_ADAPTERS.find((candidate) => candidate.id === adapterId);
-  if (!adapter?.canDeepLink) {
+  if (!adapter) {
+    setThoughtDockState({ kind: "failed", message: "Agent adapter unavailable." });
+    return;
+  }
+  if (!THOUGHT_AGENT_FIXTURE_MODE && !adapter.canDeepLink) {
     setThoughtDockState({
       kind: "failed",
       message: `${thoughtAgentProductLabel(adapterId)} deep link unavailable.`,
@@ -4514,6 +4554,10 @@ const runThoughtDockAdapter = async (adapterId: ThoughtDockAgentAdapterId) => {
   try {
     const payload = await buildThoughtDockRunPayload(prompt);
     if (!isCurrentRunSession(runSessionId)) {
+      return;
+    }
+    if (THOUGHT_AGENT_FIXTURE_MODE) {
+      await runThoughtDockFixtureAdapter(adapterId, prompt, payload, runSessionId);
       return;
     }
     const run = await createThoughtDockRun(prompt, payload, adapterId);
@@ -4545,7 +4589,7 @@ const runThoughtDockAdapter = async (adapterId: ThoughtDockAgentAdapterId) => {
       : rawMessage.replace(/\bTHOUGHT Bridge\b/g, "Agent link") || "Could not create Agent run.";
     runState = "run_failed";
     runInFlight = false;
-    setThoughtDockState({ kind: "failed", message, details: "Try again." });
+    setThoughtDockState({ kind: "failed", message });
     syncInterface();
   }
 };
@@ -4855,7 +4899,13 @@ const handleThoughtDockReturnedWork = async (
     const message = error instanceof Error ? error.message : "Preview failed.";
     setThoughtDockState(
       isContractWorkPreviewError(error)
-        ? { kind: "preview_rejected", rawCandidate, reason: formatThoughtDockPreviewError(error) }
+        ? {
+            kind: "preview_rejected",
+            rawCandidate,
+            reason: formatThoughtDockPreviewError(error),
+            reasonCode: error.previewReasonCode,
+            ...(error.issue ? { issue: error.issue } : {}),
+          }
         : { kind: "failed", message },
     );
     syncInterface();
@@ -4864,7 +4914,13 @@ const handleThoughtDockReturnedWork = async (
 
 const formatThoughtDockPreviewError = (error: unknown) => {
   if (isContractWorkPreviewError(error)) {
+    if (error.issue) {
+      return error.issue.detail;
+    }
     if (typeof error.previewReasonCode === "number") {
+      if (error.previewReasonCode === 3 && error.byteLimit) {
+        return formatThoughtByteLimitUsage(error.byteLimit);
+      }
       return previewWorkReasonLabel(error.previewReasonCode);
     }
     const contractLine = error.cliLines?.find(
@@ -4920,6 +4976,8 @@ const retryThoughtDockPreview = async () => {
       kind: "preview_rejected",
       rawCandidate: candidate.rawModelReturn,
       reason: formatThoughtDockPreviewError(error),
+      reasonCode: isContractWorkPreviewError(error) ? error.previewReasonCode : undefined,
+      ...(isContractWorkPreviewError(error) && error.issue ? { issue: error.issue } : {}),
     });
   }
 };
@@ -4933,22 +4991,32 @@ const mintThoughtDockWork = async (options?: { attemptId?: string; pathId?: stri
     setThoughtDockState({ kind: "failed", message: "No accepted work to mint." });
     return false;
   }
-  if (!THOUGHT_V2_MINT_ENABLED) {
+  const readiness = getCurrentWorkMintReadiness();
+  if (!readiness.ready) {
     resetMintFlow({ preserveAttempt: true });
     mintAttemptId = options?.attemptId?.trim() || nextMintAttemptId("mint");
-    mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
-    setMintFlowError(THOUGHT_V2_MINT_UNAVAILABLE_COPY, "thought");
-    setThoughtDockState({ kind: "minting", work });
+    setThoughtDockState({ kind: "work_ready", work });
+    emitThoughtConsoleEvent({
+      kind: "work_blocked",
+      title: "work blocked",
+      detail: readiness.reason,
+      tone: "warning",
+      eventId: `work-blocked:${currentRunContext?.clientGeneratedAt ?? currentOutputText}`,
+    });
     syncInterface();
-    return true;
+    return false;
+  }
+  const mintWork = captureCurrentMintWork();
+  if (!mintWork) {
+    return false;
   }
 
-  // Enter a meaningful mint state before the Dock renders. Rendering `minting`
-  // while the flow is still `closed` records a duplicate work-ready entry.
+  // The Work Mint CTA owns disclosure; the mint flow only owns panel content.
   mintFlowState = "thought_checking";
-  setThoughtDockState({ kind: "minting", work });
+  setThoughtDockState({ kind: "work_ready", work });
   try {
-    await openMintFlow(THOUGHT_PANEL_MINT_UI_MODE, options);
+    await openMintFlow(THOUGHT_PANEL_MINT_UI_MODE, { ...options, work: mintWork });
+    await resumePendingPathAcquisition();
     syncInterface();
     return true;
   } catch (error) {
@@ -4967,7 +5035,7 @@ const connectThoughtDockWallet = async () => {
     return;
   }
 
-  setThoughtDockState({ kind: "minting", work });
+  setThoughtDockState({ kind: "work_ready", work });
   await requestWalletConnect();
 
   if (!walletState.address) {
@@ -5058,7 +5126,7 @@ const switchThoughtDockWalletNetwork = async () => {
     return;
   }
 
-  setThoughtDockState({ kind: "minting", work });
+  setThoughtDockState({ kind: "work_ready", work });
   await switchWalletChain();
 
   if (!walletState.address) {
@@ -5490,6 +5558,14 @@ const walletState: ThoughtWalletState = {
 let walletStateHydrated = false;
 let mintFlowState: MintFlowState = "closed";
 let mintFlowUiMode: MintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
+let mintDockRevealed = false;
+let thoughtExistenceCheckRequestId = 0;
+const revealMintDock = () => {
+  mintDockRevealed = true;
+  workLibraryRevealed = false;
+  writeCurrentOutputSession();
+};
+let activeMintWork: ThoughtMintWorkSnapshot | null = null;
 const mintFlowData: MintFlowData = {
   rawText: "",
   textHash: "",
@@ -5514,6 +5590,13 @@ let pathInventoryState: PathInventoryState = {
   items: [],
   error: "",
 };
+let pathAcquisitionState: ThoughtPathAcquisitionState = "idle";
+let pathAcquisitionPrice = 0n;
+let pathAcquisitionTxHash = "";
+let pathAcquisitionError = "";
+let pathAcquisitionCompletedForAttempt = false;
+let pathAcquisitionRequestId = 0;
+let pathAcquisitionReceiptMonitorHash = "";
 let pendingMintTransaction = readPendingMintTransaction();
 let conflictingMintTransactions = readConflictingMintTransactions();
 const conflictingMintReceiptMonitorHashes = new Set<string>();
@@ -5987,7 +6070,7 @@ const getActiveThoughtInstructionsLabel = () => {
     return `${activeThoughtSpec.ref} from chain`;
   }
   return THOUGHT_SPEC_REGISTRY_ADDRESS
-    ? "onchain THOUGHT.md"
+    ? "on-chain THOUGHT.md"
     : (thoughtInstructionsOverride?.name ?? "bundled THOUGHT.md");
 };
 
@@ -6345,6 +6428,8 @@ type ThoughtV2PreviewValidation = {
   agentLine: string;
   promptLine: string;
   reasonCode: number;
+  byteLimit?: ThoughtByteLimitUsage;
+  issue?: ThoughtTextPolicyIssue;
 };
 
 const deriveThoughtV2VisibleLine = (value: string): string => value;
@@ -6367,26 +6452,68 @@ const prevalidateThoughtV2Preview = (input: {
   const agentLine = deriveThoughtV2VisibleLine(input.rawReturn);
 
   if (byteLength(input.rawReturn) > MAX_RAW_RETURN_BYTES) {
-    return { ok: false, agentLine, promptLine, reasonCode: 2 };
+    return {
+      ok: false,
+      agentLine,
+      promptLine,
+      reasonCode: 2,
+      byteLimit: {
+        line: "model return",
+        usedBytes: byteLength(input.rawReturn),
+        maxBytes: MAX_RAW_RETURN_BYTES,
+      },
+    };
   }
 
   const promptMeasure = measureThoughtV2Line(promptLine, "prompt");
   if (promptMeasure.errors.length > 0) {
+    const issue = describeThoughtTextPolicyIssue({
+      value: promptLine,
+      line: "prompt",
+      measure: promptMeasure,
+      maxBytes: THOUGHT_V2_PROTOCOL_RELEASE.limits.promptMaxBytes,
+    });
     return {
       ok: false,
       agentLine,
       promptLine,
       reasonCode: thoughtV2ReasonCode("prompt", promptMeasure.errors),
+      ...(issue ? { issue } : {}),
+      ...(promptMeasure.errors.some((error) => /bytes/.test(error))
+        ? {
+            byteLimit: {
+              line: "prompt" as const,
+              usedBytes: promptMeasure.byteLength,
+              maxBytes: THOUGHT_V2_PROTOCOL_RELEASE.limits.promptMaxBytes,
+            },
+          }
+        : {}),
     };
   }
 
   const agentMeasure = measureThoughtV2Line(agentLine, "agent");
   if (agentMeasure.errors.length > 0) {
+    const issue = describeThoughtTextPolicyIssue({
+      value: agentLine,
+      line: "agent output",
+      measure: agentMeasure,
+      maxBytes: THOUGHT_V2_PROTOCOL_RELEASE.limits.agentMaxBytes,
+    });
     return {
       ok: false,
       agentLine,
       promptLine,
       reasonCode: thoughtV2ReasonCode("agent", agentMeasure.errors),
+      ...(issue ? { issue } : {}),
+      ...(agentMeasure.errors.some((error) => /bytes/.test(error))
+        ? {
+            byteLimit: {
+              line: "agent output" as const,
+              usedBytes: agentMeasure.byteLength,
+              maxBytes: THOUGHT_V2_PROTOCOL_RELEASE.limits.agentMaxBytes,
+            },
+          }
+        : {}),
     };
   }
 
@@ -6398,6 +6525,8 @@ type ContractWorkPreview = {
   text: string;
   svg: string;
   reasonCode: number;
+  byteLimit?: ThoughtByteLimitUsage;
+  issue?: ThoughtTextPolicyIssue;
 };
 
 type LastRejectedRun = {
@@ -6415,6 +6544,8 @@ type LastRejectedRun = {
   thoughtSpecRef: string;
   createdAt: string;
   repeatedCount: number;
+  byteLimit?: ThoughtByteLimitUsage;
+  issue?: ThoughtTextPolicyIssue;
 };
 
 type LastPreviewRetryContext = {
@@ -6424,6 +6555,8 @@ type LastPreviewRetryContext = {
 
 type ContractWorkPreviewError = Error & {
   previewReasonCode?: number;
+  byteLimit?: ThoughtByteLimitUsage;
+  issue?: ThoughtTextPolicyIssue;
   cliLines?: string[];
   kind?: "model-return-rejected" | "contract-preview-unavailable";
 };
@@ -6469,27 +6602,35 @@ const rememberRejectedRun = (
     thoughtSpecRef: payload.input.thoughtSpec.ref,
     createdAt: new Date().toISOString(),
     repeatedCount,
+    ...(preview.byteLimit ? { byteLimit: preview.byteLimit } : {}),
+    ...(preview.issue ? { issue: preview.issue } : {}),
   };
   lastRejectedRun = rejectedRun;
   return rejectedRun;
 };
 
 const rejectedRunReasonLines = (rejected: LastRejectedRun) => {
+  if (rejected.issue) {
+    return [rejected.issue.detail, "", `next: ${rejected.issue.nextStep}`];
+  }
   if (rejected.reasonCode === 1) {
     return ["canonical text is empty after normalization."];
   }
   if (rejected.reasonCode === 2) {
-    const rawLength = byteLength(rejected.modelReturn);
     return [
       "raw model return too large to process.",
-      `model return: ${rawLength} / ${MAX_RAW_RETURN_BYTES} bytes before normalization.`,
+      rejected.byteLimit
+        ? formatThoughtByteLimitUsage(rejected.byteLimit)
+        : `model return: ${byteLength(rejected.modelReturn)} / ${MAX_RAW_RETURN_BYTES} UTF-8 bytes`,
       "",
       "this model ignored the output rules.",
     ];
   }
   if (rejected.reasonCode === 3) {
     return [
-      `agent line: ${byteLength(rejected.normalizedCandidate ?? rejected.modelReturn)} / ${THOUGHT_V2_PROTOCOL_RELEASE.limits.agentMaxBytes} UTF-8 bytes.`,
+      rejected.byteLimit
+        ? formatThoughtByteLimitUsage(rejected.byteLimit)
+        : `Agent output: ${byteLength(rejected.normalizedCandidate ?? rejected.modelReturn)} / ${THOUGHT_V2_PROTOCOL_RELEASE.limits.agentMaxBytes} UTF-8 bytes`,
       "",
       "this Agent returned more bytes than THOUGHT V2 accepts.",
     ];
@@ -6542,6 +6683,12 @@ const createRejectedRunError = (
   const error = new Error(lines.join(" ")) as ContractWorkPreviewError;
   error.kind = "model-return-rejected";
   error.previewReasonCode = rejected.reasonCode;
+  if (rejected.byteLimit) {
+    error.byteLimit = rejected.byteLimit;
+  }
+  if (rejected.issue) {
+    error.issue = rejected.issue;
+  }
   error.cliLines = lines;
   return error;
 };
@@ -6571,6 +6718,8 @@ const previewWorkViaAllowedProvider = async (
         text: validation.agentLine,
         svg: "",
         reasonCode: validation.reasonCode,
+        ...(validation.byteLimit ? { byteLimit: validation.byteLimit } : {}),
+        ...(validation.issue ? { issue: validation.issue } : {}),
       };
     }
     const svg = await token.previewSvg(validation.promptLine, validation.agentLine) as string;
@@ -6636,6 +6785,8 @@ const createFrontendPreviewProvider = (): ThoughtPreviewProvider => ({
         text: validation.agentLine,
         svg: "",
         reasonCode: validation.reasonCode,
+        ...(validation.byteLimit ? { byteLimit: validation.byteLimit } : {}),
+        ...(validation.issue ? { issue: validation.issue } : {}),
       };
     }
 
@@ -6691,6 +6842,9 @@ const selectThoughtPreviewProvider = async () => {
   const mode = readPreviewMode();
   if (mode === "off") {
     return { provider: null, reason: "preview is off." };
+  }
+  if (THOUGHT_AGENT_FIXTURE_MODE) {
+    return { provider: createFrontendPreviewProvider(), reason: "" };
   }
   if (IS_LOCAL_THOUGHT_V2) {
     const provider = getReadProvider();
@@ -6929,6 +7083,8 @@ const attemptContractPreviewForCandidate = async (
       text: candidate.normalizedCandidate ?? "",
       svg: "",
       reasonCode: previewReasonCode,
+      ...(validation.byteLimit ? { byteLimit: validation.byteLimit } : {}),
+      ...(validation.issue ? { issue: validation.issue } : {}),
     };
     return {
       kind: "rejected",
@@ -7205,7 +7361,7 @@ const loadColorFontPage = async () => {
   try {
     const doc = await fetchColorFontDoc();
     renderColorFontPage({
-      source: "onchain ABI",
+      source: "on-chain ABI",
       id: doc.id,
       version: doc.version,
       chain: doc.chainName ? `${doc.chainName} (${doc.chainId})` : doc.chainId.toString(),
@@ -7224,7 +7380,7 @@ const loadColorFontPage = async () => {
       contract: "-",
       hash: keccak256(toUtf8Bytes(fallbackText)),
       data: fallbackText,
-      status: "onchain color font unavailable; showing bundled mirror.",
+      status: "on-chain color font unavailable; showing bundled mirror.",
     });
   }
 };
@@ -7454,7 +7610,7 @@ const openColorFontDocument = async (options?: {
     if (shouldAppendCliResult) {
       appendCliOutput([
         "opening Color Font v1.",
-        "source: onchain ABI.",
+        "source: on-chain ABI.",
         opened ? "" : "popup blocked. click color font title again.",
       ].filter(Boolean));
     }
@@ -7709,6 +7865,11 @@ const shouldUseBundledThoughtSpecFallback = () =>
   IS_DEV_MODE && LOCAL_BROWSER_HOSTS.has(window.location.hostname);
 
 const ensureThoughtDockActiveSpec = async () => {
+  if (THOUGHT_AGENT_FIXTURE_MODE && shouldUseBundledThoughtSpecFallback()) {
+    activeThoughtSpec = buildBundledActiveThoughtSpec();
+    activeThoughtSpecPromise = null;
+    return activeThoughtSpec;
+  }
   if (IS_LOCAL_THOUGHT_V2) {
     return ensureActiveThoughtSpec({ force: true });
   }
@@ -7846,13 +8007,14 @@ const buildProvenanceJson = (
     pathId: string | bigint;
     promptHash?: string;
   },
+  work?: ThoughtMintWorkSnapshot,
 ) => {
   const spec = activeThoughtSpec;
   if (!spec) {
     throw new Error("spec unavailable.");
   }
 
-  const context = currentRunContext ?? {
+  const context = work?.runContext ?? currentRunContext ?? {
     mode: sessionState.mode,
     provider: getCurrentProviderForProvenance(),
     model: getCurrentModelValue().trim(),
@@ -7860,14 +8022,14 @@ const buildProvenanceJson = (
     clientGeneratedAt: new Date().toISOString(),
   };
   if (IS_LOCAL_THOUGHT_V2 && mint) {
-    const agentLine = currentOutputText || context.returnedText || "";
+    const agentLine = work?.text || currentOutputText || context.returnedText || "";
     let process: ThoughtV2LocalProcess;
     if (context.mode === MY_BRAIN_MODE) {
       process = { kind: "manual" };
     } else {
       const evidence = context.agentEvidence;
       if (!evidence) {
-        throw new Error("This route has no validated THOUGHT V2 Agent result. Use Agent mode or My Brain to mint locally.");
+        throw new Error("This work has no current V2 Agent evidence. Run the work again before minting.");
       }
       process = buildThoughtV2LocalAgentProcess(evidence, agentLine);
     }
@@ -7895,9 +8057,10 @@ const buildProvenanceJson = (
     ref: spec.ref,
   };
   const promptHash = mint?.promptHash || hashText(context.prompt);
-  const returnedText = context.returnedText ?? currentOutputText;
+  const returnedText = context.returnedText ?? work?.text ?? currentOutputText;
   const returnedTextHash = hashText(returnedText);
-  const contractSvgHash = currentWorkSvg ? hashText(currentWorkSvg) : undefined;
+  const contractSvg = work?.svg ?? currentWorkSvg;
+  const contractSvgHash = contractSvg ? hashText(contractSvg) : undefined;
   const previewProvider = context.previewProvider;
   const frontendPreviewed = previewProvider?.method === "frontendRender";
   const chain = mint
@@ -8043,7 +8206,7 @@ const projectPendingMintTransaction = (
   mintFlowState = "minting";
   const work = getThoughtDockWorkView();
   if (work) {
-    setThoughtDockState({ kind: "minting", work });
+    setThoughtDockState({ kind: "work_ready", work });
   }
 };
 
@@ -8094,7 +8257,7 @@ const blockPendingMintMutation = (options?: { cli?: boolean }) => {
   } else {
     const work = getThoughtDockWorkView();
     if (work) {
-      setThoughtDockState({ kind: "minting", work });
+      setThoughtDockState({ kind: "work_ready", work });
     }
   }
   if (currentOutputText) {
@@ -8138,6 +8301,17 @@ function resetPathInventoryState() {
   };
 }
 
+const resetPathAcquisitionUiState = () => {
+  pathAcquisitionRequestId += 1;
+  pathAcquisitionReceiptMonitorHash = "";
+  const pending = readPendingPathAcquisition();
+  pathAcquisitionState = pending ? "submitted" : "idle";
+  pathAcquisitionPrice = 0n;
+  pathAcquisitionTxHash = pending?.txHash ?? "";
+  pathAcquisitionError = "";
+  pathAcquisitionCompletedForAttempt = false;
+};
+
 const resetMintFlow = (options?: { preserveAttempt?: boolean }) => {
   if (blockPendingMintMutation()) {
     return false;
@@ -8145,8 +8319,10 @@ const resetMintFlow = (options?: { preserveAttempt?: boolean }) => {
   if (!options?.preserveAttempt) {
     mintAttemptId = nextMintAttemptId("idle");
   }
+  thoughtExistenceCheckRequestId += 1;
   mintFlowState = "closed";
   mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
+  activeMintWork = null;
   mintFlowData.rawText = "";
   mintFlowData.textHash = "";
   mintFlowData.promptHash = "";
@@ -8161,6 +8337,7 @@ const resetMintFlow = (options?: { preserveAttempt?: boolean }) => {
   mintFlowData.errorKind = "none";
   clearMintAuthorization();
   resetPathInventoryState();
+  resetPathAcquisitionUiState();
   return true;
 };
 
@@ -8192,13 +8369,13 @@ const signPathConsumeAuthorization = async (
 ) => {
   const pathNft = getReadPathNft();
   if (!pathNft) {
-    throw new Error("PATH authorization unavailable.");
+    throw new Error("$PATH signature unavailable.");
   }
   onStage("nonce");
   const nonce = await withTimeout(
     pathNft.getConsumeNonce(claimer) as Promise<bigint>,
     PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
-    "PATH authorization request timed out.",
+    "$PATH signature request timed out.",
   );
   const deadline = BigInt(Math.floor(Date.now() / 1000)) + PATH_CONSUME_AUTH_TTL_SECONDS;
   onStage("digest");
@@ -8696,7 +8873,7 @@ const isPathInventoryManualFallbackState = () =>
 const shouldRevealManualPathInput = () =>
   isMintPathFieldVisible() &&
   isPathInventoryManualFallbackState() &&
-  !shouldUsePathInventorySelect();
+  !shouldUsePathInventoryPicker();
 
 const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean }) => {
   if (!walletState.address || walletState.chainId !== THOUGHT_CHAIN_ID) {
@@ -8753,20 +8930,19 @@ const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean 
         items: inventory.items,
         error: "",
       };
-      recordCurrentMintConsoleState();
       const availableItems = inventory.items.filter((item) => item.status === "available");
       if (availableItems.length === 0) {
         clearMintPathSelection();
         if (mintFlowState === "error" && isPathRecoveryError()) {
           mintFlowState = "path_required";
         }
-      } else if (
-        availableItems.length === 1 &&
-        !mintFlowData.pathIdInput &&
-        mintFlowState === "path_required"
-      ) {
-        applyMintPathInputValue(availableItems[0].pathId.toString());
-        await checkPathEligibility();
+        if (pathAcquisitionState === "idle") {
+          void handleMintPath();
+        } else {
+          recordCurrentMintConsoleState();
+        }
+      } else {
+        recordCurrentMintConsoleState();
       }
     }
   } catch (error) {
@@ -8843,10 +9019,9 @@ const isMintPathInputDisabled = () =>
   mintFlowState === "minting" ||
   mintFlowState === "minted";
 
-const shouldUsePathInventorySelect = () =>
+const shouldUsePathInventoryPicker = () =>
   hasAvailablePathInventory() &&
-  mintFlowState === "path_required" &&
-  mintFlowData.pathId === null;
+  mintFlowState === "path_required";
 
 const focusRestoredMintElement = (element: HTMLElement) => {
   thoughtDockPath.querySelectorAll<HTMLElement>(".is-focus-restored").forEach((item) => {
@@ -8866,24 +9041,8 @@ const focusMintDockStage = (preference: "action" | "path" = "action") => {
     }
 
     if (preference === "path") {
-      const selectedButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
-        '.thought-dock-path-token[aria-pressed="true"]',
-      );
-      const firstButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
-        ".thought-dock-path-token",
-      );
-      const pathButton = selectedButton ?? firstButton;
-      if (pathButton && !pathButton.disabled) {
-        focusRestoredMintElement(pathButton);
-        return;
-      }
-
-      if (
-        !thoughtDockPathField.classList.contains("is-hidden") &&
-        !thoughtDockPathBox.classList.contains("is-hidden") &&
-        !thoughtDockPathBox.disabled
-      ) {
-        focusRestoredMintElement(thoughtDockPathBox);
+      if (!thoughtDockPathInventorySelect.disabled) {
+        focusRestoredMintElement(thoughtDockPathInventorySelect);
         return;
       }
     }
@@ -8895,7 +9054,6 @@ const focusMintDockStage = (preference: "action" | "path" = "action") => {
       return;
     }
 
-    focusRestoredMintElement(thoughtDockPathTitle);
   });
 };
 
@@ -8905,7 +9063,7 @@ const focusMintPathInput = () => {
     return;
   }
 
-  const input = shouldUsePathInventorySelect() ? mintSheetPathSelect : mintSheetPathBox;
+  const input = shouldUsePathInventoryPicker() ? mintSheetPathSelect : mintSheetPathBox;
   requestAnimationFrame(() => {
     if (!input.disabled) {
       input.focus();
@@ -8969,7 +9127,7 @@ const getLegacyMintSheetActionConfigs = (): [
     if (hasLoadedPathInventoryWithoutAvailable()) {
       return [
         mintSheetAction("mint_path", "mint path"),
-        mintSheetAction("refresh", "refresh"),
+        hiddenMintSheetAction(),
         hiddenMintSheetAction(),
       ];
     }
@@ -8978,21 +9136,21 @@ const getLegacyMintSheetActionConfigs = (): [
       if (canContinueWithPathInput()) {
         return [
           mintSheetAction("continue", "continue"),
-          mintSheetAction("refresh", "refresh"),
           mintSheetAction("mint_path", "mint path"),
+          hiddenMintSheetAction(),
         ];
       }
       return [
-        mintSheetAction("refresh", "refresh"),
         mintSheetAction("enter_path_manually", "enter path manually"),
         mintSheetAction("mint_path", "mint path"),
+        hiddenMintSheetAction(),
       ];
     }
 
     if (hasAvailablePathInventory()) {
       return [
         mintSheetAction("continue", "continue", !canContinueWithPathInput()),
-        mintSheetAction("refresh", "refresh"),
+        hiddenMintSheetAction(),
         hiddenMintSheetAction(),
       ];
     }
@@ -9014,15 +9172,15 @@ const getLegacyMintSheetActionConfigs = (): [
 
   if (mintFlowState === "path_ready") {
     return [
-      mintSheetAction("authorize", "authorize"),
-      mintSheetAction("choose_another", "choose another"),
+      mintSheetAction("authorize", "sign"),
+      mintSheetAction("choose_another", "pick another"),
       hiddenMintSheetAction(),
     ];
   }
 
   if (mintFlowState === "authorizing") {
     return [
-      mintSheetAction("none", "authorizing", true),
+      mintSheetAction("none", "signing", true),
       hiddenMintSheetAction(),
       hiddenMintSheetAction(),
     ];
@@ -9031,7 +9189,7 @@ const getLegacyMintSheetActionConfigs = (): [
   if (mintFlowState === "authorized") {
     return [
       mintSheetAction("confirm_mint", "confirm mint"),
-      mintSheetAction("choose_another", "choose another"),
+      mintSheetAction("choose_another", "pick another"),
       hiddenMintSheetAction(),
     ];
   }
@@ -9065,26 +9223,26 @@ const getLegacyMintSheetActionConfigs = (): [
       if (hasLoadedPathInventoryWithoutAvailable()) {
         return [
           mintSheetAction("mint_path", "mint path"),
-          mintSheetAction("refresh", "refresh"),
+          hiddenMintSheetAction(),
           hiddenMintSheetAction(),
         ];
       }
       if (isPathInventoryManualFallbackState()) {
         return [
-          mintSheetAction("refresh", "refresh"),
           mintSheetAction("enter_path_manually", "enter path manually"),
           mintSheetAction("mint_path", "mint path"),
+          hiddenMintSheetAction(),
         ];
       }
       return [
-        mintSheetAction("choose_another", "choose another"),
-        mintSheetAction("refresh", "refresh"),
+        mintSheetAction("choose_another", "pick another"),
+        hiddenMintSheetAction(),
         hiddenMintSheetAction(),
       ];
     }
 
     return [
-      mintSheetAction("refresh", "refresh"),
+      hiddenMintSheetAction(),
       hiddenMintSheetAction(),
       hiddenMintSheetAction(),
     ];
@@ -9155,7 +9313,7 @@ const getLegacyMintSheetStatusCopy = () => {
     return "checking uniqueness and mint state.";
   }
   if (mintFlowState === "text_taken") {
-    return "PATH permission is not requested; this exact work already exists.";
+    return "This exact THOUGHT is already on-chain; your $PATH was not used.";
   }
   if (mintFlowState === "wallet_required") {
     if (isInjectedWalletMissing()) {
@@ -9168,23 +9326,23 @@ const getLegacyMintSheetStatusCopy = () => {
       return PUBLIC_NETWORK_CONFIG.switchNetworkNotice;
     }
     if (pathInventoryMatchesCurrentWallet() && pathInventoryState.status === "loading") {
-      return "reading wallet PATHs.";
+      return "reading wallet $PATH tokens.";
     }
     if (pathInventoryMatchesCurrentWallet() && (pathInventoryState.status === "unavailable" || pathInventoryState.status === "error")) {
-      return "refresh or enter PATH manually.";
+      return "refresh or enter $PATH manually.";
     }
     if (pathInventoryMatchesCurrentWallet() && pathInventoryState.status === "loaded") {
       return availablePathInventoryItems().length > 0
-        ? "choose one available PATH."
-        : "mint a PATH, then return here.";
+        ? "pick one available $PATH."
+        : "mint a $PATH, then return here.";
     }
     if (shouldAutoLoadPathInventory()) {
-      return "reading wallet PATHs.";
+      return "reading wallet $PATH tokens.";
     }
-    return "checking wallet PATHs.";
+    return "checking wallet $PATH tokens.";
   }
   if (mintFlowState === "path_checking") {
-    return selectedPathId ? `checking PATH #${selectedPathId}.` : "checking PATH.";
+    return selectedPathId ? `checking $PATH #${selectedPathId}.` : "checking $PATH.";
   }
   if (mintFlowState === "path_ready") {
     return "signature only. does not mint.";
@@ -9193,7 +9351,7 @@ const getLegacyMintSheetStatusCopy = () => {
     return "confirm signature in wallet.";
   }
   if (mintFlowState === "authorized") {
-    return selectedPathId ? `transaction will consume PATH #${selectedPathId}.` : "ready to mint.";
+    return selectedPathId ? `transaction will consume $PATH #${selectedPathId}.` : "ready to mint.";
   }
   if (mintFlowState === "minting") {
     return walletState.txState === "submitted" || walletState.txHash || mintFlowData.txHash
@@ -9245,7 +9403,7 @@ const getLegacyMintSheetCopy = () => {
     return "signature only. does not mint.";
   }
   if (mintFlowState === "authorized" || mintFlowState === "minting") {
-    return "mints THOUGHT and consumes PATH.";
+    return "mints THOUGHT and consumes $PATH.";
   }
   return "one THOUGHT needs one $PATH.";
 };
@@ -9279,7 +9437,7 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
         },
         {
           label: "signature",
-          value: "PATH mint permission",
+          value: "$PATH mint permission",
         },
         {
           label: "executor",
@@ -9291,8 +9449,8 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
         { label: "expires", value: `${Math.floor(Number(PATH_CONSUME_AUTH_TTL_SECONDS) / 3600)} hour` },
       ],
       note: selectedPathId
-        ? `sign PATH permission — 1 of 2\nallows the THOUGHT contract to use one THOUGHT mint from $PATH #${selectedPathId}.\nno transaction. no gas. does not mint yet.`
-        : "sign PATH permission — 1 of 2\nno transaction. no gas. does not mint yet.",
+        ? `sign $PATH permission — 1 of 2\nallows the THOUGHT contract to use one THOUGHT mint from $PATH #${selectedPathId}.\nno transaction. no gas. does not mint yet.`
+        : "sign $PATH permission — 1 of 2\nno transaction. no gas. does not mint yet.",
       verifyLink: true,
     };
   }
@@ -9313,7 +9471,7 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
         { label: "$PATH", value: `#${selectedPathId}` },
         { label: "uses", value: "1 THOUGHT mint" },
         { label: "ETH sent", value: "0 ETH" },
-        { label: "authorization", value: "PATH signature attached" },
+        { label: "signature", value: "$PATH signature attached" },
         { label: "network gas", value: "shown in wallet" },
       ],
       note: `mint THOUGHT — 2 of 2\ncreates the token using one THOUGHT mint from $PATH #${selectedPathId}.\nthe $PATH token stays in this wallet. network gas applies.`,
@@ -9409,7 +9567,8 @@ const syncPathInventorySelect = (select: HTMLSelectElement) => {
 
   const placeholder = document.createElement("option");
   placeholder.value = "";
-  placeholder.textContent = "choose available $PATH";
+  placeholder.disabled = true;
+  placeholder.textContent = "pick a $PATH";
   select.appendChild(placeholder);
 
   for (const item of available) {
@@ -9419,42 +9578,25 @@ const syncPathInventorySelect = (select: HTMLSelectElement) => {
     select.appendChild(option);
   }
 
-  select.value = available.some((item) => item.pathId.toString() === selectedValue) ? selectedValue : "";
+  select.value = available.some((item) => item.pathId.toString() === selectedValue)
+    ? selectedValue
+    : "";
+  placeholder.selected = select.value === "";
   select.disabled = isMintPathInputDisabled();
 };
 
 const syncThoughtDockPathInventory = () => {
   const available = availablePathInventoryItems();
-  const isVisible = shouldUsePathInventorySelect() && available.length > 0;
+  const isVisible = shouldUsePathInventoryPicker() && available.length > 0;
   thoughtDockPathInventory.classList.toggle("is-hidden", !isVisible);
 
   if (!isVisible) {
-    thoughtDockPathInventoryList.replaceChildren();
+    thoughtDockPathInventorySelect.replaceChildren();
     return false;
   }
 
   thoughtDockPathInventoryLabel.textContent = `available $PATH (${available.length})`;
-  const selectedPathId = mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim();
-  const disabled = isMintPathInputDisabled();
-  thoughtDockPathInventoryList.replaceChildren(
-    ...available.map((item) => {
-      const pathId = item.pathId.toString();
-      const button = document.createElement("button");
-      const isSelected = pathId === selectedPathId;
-      button.type = "button";
-      button.className = "thought-dock-button thought-dock-path-token";
-      button.textContent = `$PATH #${pathId} · 1 mint`;
-      button.disabled = disabled;
-      button.setAttribute("aria-pressed", isSelected ? "true" : "false");
-      button.title = isSelected
-        ? `$PATH #${pathId} selected for this THOUGHT`
-        : `Use $PATH #${pathId} for this THOUGHT`;
-      button.addEventListener("click", () => {
-        selectPathInventoryItem(item.pathId);
-      });
-      return button;
-    }),
-  );
+  syncPathInventorySelect(thoughtDockPathInventorySelect);
   return true;
 };
 
@@ -9487,15 +9629,15 @@ const renderPathInventoryContext = () => {
 
   const inventoryMatchesWallet = pathInventoryMatchesCurrentWallet();
   if (!inventoryMatchesWallet || pathInventoryState.status === "loading" || pathInventoryState.status === "idle") {
-    title.textContent = "checking PATH";
-    detail.textContent = "reading wallet PATHs.";
+    title.textContent = "checking $PATH";
+    detail.textContent = "reading wallet $PATH tokens.";
     inventory.append(title, detail);
     return inventory;
   }
 
   if (pathInventoryState.status === "unavailable" || pathInventoryState.status === "error") {
-    title.textContent = "PATH list unavailable";
-    detail.textContent = pathInventoryState.error || "refresh or enter PATH manually.";
+    title.textContent = "$PATH list unavailable";
+    detail.textContent = pathInventoryState.error || "refresh or enter $PATH manually.";
     inventory.append(title, detail);
     return inventory;
   }
@@ -9509,10 +9651,10 @@ const renderPathInventoryContext = () => {
     return null;
   }
 
-  title.textContent = available.length > 0 ? "PATH" : pathInventoryState.items.length ? "no available PATH" : "no PATH found";
+  title.textContent = available.length > 0 ? "$PATH" : pathInventoryState.items.length ? "no available $PATH" : "no $PATH found";
   detail.textContent = pathInventoryState.items.length
-    ? "wallet PATHs found, but none have an available THOUGHT unit. mint a PATH to get one."
-    : "mint a PATH first, then return here.";
+    ? "wallet $PATH tokens found, but none have an available THOUGHT mint. mint a $PATH to get one."
+    : "mint a $PATH first, then return here.";
   inventory.append(title, detail);
   return inventory;
 };
@@ -9531,52 +9673,6 @@ const renderMintContext = (container: HTMLElement, options: { includeWalletRevie
   }
 
   container.classList.toggle("is-hidden", container.childNodes.length === 0);
-};
-
-let thoughtDockReviewSignature = "";
-
-const syncMintDockReview = () => {
-  const reviewStage = mintFlowState === "path_ready" || mintFlowState === "authorizing"
-    ? "sign"
-    : mintFlowState === "authorized" || mintFlowState === "minting"
-      ? "mint"
-      : null;
-
-  if (!reviewStage) {
-    thoughtDockPathReview.classList.add("is-hidden");
-    thoughtDockPathReview.open = false;
-    thoughtDockPathReview.removeAttribute("data-stage");
-    thoughtDockPathContext.replaceChildren();
-    thoughtDockPathContext.classList.add("is-hidden");
-    thoughtDockReviewSignature = "";
-    return;
-  }
-
-  const config = getMintSheetReviewConfig();
-  const signature = JSON.stringify({ config, reviewStage });
-  const stageChanged = thoughtDockPathReview.dataset.stage !== reviewStage;
-  thoughtDockPathReview.dataset.stage = reviewStage;
-  thoughtDockPathReview.classList.remove("is-hidden");
-  thoughtDockPathReviewSummary.textContent = reviewStage === "sign"
-    ? "review signature request · 1 of 2"
-    : "review mint transaction · 2 of 2";
-
-  if (stageChanged) {
-    thoughtDockPathReview.open = false;
-  }
-  if (signature === thoughtDockReviewSignature) {
-    return;
-  }
-
-  thoughtDockPathContext.replaceChildren();
-  renderMintReviewContent(thoughtDockPathContext, config, {
-    link: "thought-dock-path-review__link",
-    note: "thought-dock-path-review__note",
-    review: "thought-dock-path-review__rows",
-    row: "thought-dock-path-review__row",
-  });
-  thoughtDockPathContext.classList.remove("is-hidden");
-  thoughtDockReviewSignature = signature;
 };
 
 const renderMintSheetContext = () => {
@@ -9600,21 +9696,18 @@ const syncMintSheetButton = (
   button.classList.toggle("is-hidden", !!config.hidden);
 };
 
-const isGlobalWalletAction = (action: MintSheetAction) =>
-  action === "connect_wallet" ||
-  action === "disconnect_wallet" ||
-  action === "switch_network";
-
 const getMintDockPathActionConfigs = (): [
   MintSheetActionConfig,
   MintSheetActionConfig,
   MintSheetActionConfig,
 ] => {
-  return getMintSheetActionConfigs();
-};
-
-const getMintDockPathStatusCopy = () => {
-  return getCurrentMintPresentation().stageCopy;
+  const actions = getMintSheetActionConfigs()
+    .filter((config) => config.action !== "enter_path_manually" && config.action !== "continue");
+  return [
+    actions[0] ?? hiddenMintSheetAction(),
+    actions[1] ?? hiddenMintSheetAction(),
+    actions[2] ?? hiddenMintSheetAction(),
+  ];
 };
 
 const syncMintSheet = () => {
@@ -9631,7 +9724,7 @@ const syncMintSheet = () => {
   syncMintSheetFlow();
 
   const pathInputVisible = isMintPathFieldVisible();
-  const pathSelectVisible = pathInputVisible && shouldUsePathInventorySelect();
+  const pathSelectVisible = pathInputVisible && shouldUsePathInventoryPicker();
   const manualPathVisible = pathInputVisible && shouldRevealManualPathInput();
   const pathFieldVisible = pathSelectVisible || manualPathVisible;
   mintSheetPathField.classList.toggle("is-hidden", !pathFieldVisible);
@@ -9659,40 +9752,27 @@ const syncMintSheet = () => {
 };
 
 const syncMintDockPathPanel = () => {
-  const pathInputVisible = isMintPathFieldVisible();
-  const isVisible = mintFlowUiMode === "dock" && mintFlowState !== "closed";
-  thoughtDockPath.classList.toggle("is-hidden", !isVisible);
+  const isVisible = mintDockRevealed;
 
   if (!isVisible) {
-    thoughtDockPathReview.classList.add("is-hidden");
-    thoughtDockPathReview.open = false;
-    thoughtDockPathContext.replaceChildren();
-    thoughtDockPathContext.classList.add("is-hidden");
-    thoughtDockReviewSignature = "";
+    thoughtDockPath.classList.add("is-hidden");
     return;
   }
 
   const presentation = getCurrentMintPresentation();
-  thoughtDockPathTitle.textContent = presentation.title;
-  thoughtDockPathDetail.textContent = presentation.detail;
+  thoughtDockPathTitle.dataset.tone = presentation.tone;
+  if (presentation.tone === "running") {
+    appendThoughtProgressEllipsis(thoughtDockPathTitle, presentation.title, true);
+  } else {
+    thoughtDockPathTitle.textContent = presentation.title;
+  }
 
   const pathInventoryVisible = syncThoughtDockPathInventory();
-  const manualPathVisible = pathInputVisible && shouldRevealManualPathInput();
-  const pathFieldVisible = !pathInventoryVisible && manualPathVisible;
-  thoughtDockPathField.classList.toggle("is-hidden", !pathFieldVisible);
-  thoughtDockPathBox.classList.toggle("is-hidden", !manualPathVisible);
-  thoughtDockPathSelect.classList.add("is-hidden");
-  thoughtDockPathBox.value = mintFlowData.pathIdInput;
-  thoughtDockPathBox.disabled = isMintPathInputDisabled();
-  syncPathInventoryOptions(thoughtDockPathOptions);
-  syncPathInventorySelect(thoughtDockPathSelect);
+  const hideRedundantPathStatus =
+    (mintFlowState === "path_required" && pathInventoryVisible) ||
+    mintFlowState === "path_ready";
+  thoughtDockMintStep.classList.toggle("is-hidden", hideRedundantPathStatus);
 
-  const provenanceCopy = pathInputVisible ? getMintSheetProvenanceCopy() : "";
-  thoughtDockPathProvenance.textContent = provenanceCopy;
-  thoughtDockPathProvenance.classList.toggle("is-hidden", !provenanceCopy);
-
-  thoughtDockPathStatus.textContent = getMintDockPathStatusCopy();
-  syncMintDockReview();
   maybeLoadPathInventory();
   syncMintFlowSteps(thoughtDockPathFlow);
 
@@ -9703,6 +9783,36 @@ const syncMintDockPathPanel = () => {
   syncMintSheetButton(thoughtDockPathPrimary, primary);
   syncMintSheetButton(thoughtDockPathSecondary, secondary);
   syncMintSheetButton(thoughtDockPathTertiary, tertiary);
+  thoughtDockPath.classList.remove("is-hidden");
+};
+
+const syncWorkLibraryPanel = () => {
+  if (!workLibraryRevealed) {
+    thoughtDockWorks.classList.add("is-hidden");
+    return;
+  }
+
+  const works = [...readStoredThoughtWorks()].reverse();
+  thoughtDockWorksLabel.textContent = "load a saved work";
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.disabled = true;
+  placeholder.textContent = works.length ? "load a saved work" : "no saved works";
+  const options = works.map((work) => {
+    const option = document.createElement("option");
+    option.value = String(work.id);
+    option.textContent = formatSavedWorkPromptLabel(work.prompt || work.runContext.prompt);
+    option.title = work.prompt || work.runContext.prompt;
+    return option;
+  });
+  thoughtDockWorksSelect.replaceChildren(placeholder, ...options);
+  const selectedId = currentWorkId === null ? "" : String(currentWorkId);
+  thoughtDockWorksSelect.value = works.some((work) => String(work.id) === selectedId)
+    ? selectedId
+    : "";
+  placeholder.selected = thoughtDockWorksSelect.value === "";
+  thoughtDockWorksSelect.disabled = works.length === 0;
+  thoughtDockWorks.classList.remove("is-hidden");
 };
 
 const syncWalletMenu = () => {};
@@ -9832,6 +9942,39 @@ const refreshWalletState = async () => {
   walletStateHydrated = true;
   await refreshMintPreflight();
 };
+
+async function refreshThoughtWalletFromShell() {
+  const shouldValidateSelectedPath =
+    mintFlowState === "path_required" ||
+    mintFlowState === "path_ready" ||
+    (mintFlowState === "error" && isPathRecoveryError());
+
+  await refreshWalletState();
+  syncMintFlowAfterWalletCommand();
+
+  const pathHandoff = readPathMintHandoff();
+  const pathReturn = pathHandoff
+    ? readPathMintReturnRecord(getPathMintReturnStorageHost(), pathHandoff.attemptId)
+    : null;
+  if (pathHandoff && (pathReturn || mintFlowData.errorKind === "wallet_account_mismatch")) {
+    await resumePathMintHandoff();
+    syncInterface();
+    return;
+  }
+
+  if (walletState.address && walletState.chainId === THOUGHT_CHAIN_ID) {
+    await refreshPathInventoryForCurrentWallet({ force: true });
+    if (shouldValidateSelectedPath && canContinueWithPathInput()) {
+      await checkPathEligibility();
+      return;
+    }
+    if (mintFlowState === "error" && isPathRecoveryError()) {
+      moveMintFlowToWalletOrPathSelection();
+    }
+  }
+
+  syncInterface();
+}
 
 const bindThoughtShellWallet = () => {
   if (thoughtShellWalletSubscribed) {
@@ -10272,6 +10415,46 @@ const lookupExistingThoughtToken = async (token: Contract, agentLineHash: string
     ? token.tokenOfAgentLineHash(agentLineHash) as Promise<bigint>
     : token.tokenOfThought(agentLineHash) as Promise<bigint>;
 
+const preflightCurrentThoughtExistence = async () => {
+  if (!currentOutputText || runState !== "output_ready") {
+    return;
+  }
+
+  const requestId = thoughtExistenceCheckRequestId + 1;
+  thoughtExistenceCheckRequestId = requestId;
+  const checkedText = currentOutputText;
+
+  try {
+    await verifyLocalThoughtV2Deployment();
+    const textHash = await textHashFromContract(checkedText);
+    const token = getReadThoughtNFT();
+    if (!token) return;
+    const existingTokenId = await lookupExistingThoughtToken(token, textHash);
+    if (
+      requestId !== thoughtExistenceCheckRequestId ||
+      currentOutputText !== checkedText ||
+      runState !== "output_ready" ||
+      mintFlowState !== "closed"
+    ) {
+      return;
+    }
+    if (existingTokenId === 0n) {
+      return;
+    }
+
+    mintFlowData.rawText = checkedText;
+    mintFlowData.textHash = textHash;
+    mintFlowData.existingTokenId = Number(existingTokenId);
+    mintFlowData.error = "";
+    mintFlowData.errorKind = "none";
+    mintFlowState = "text_taken";
+    recordCurrentMintConsoleState();
+    syncInterface();
+  } catch {
+    // Background verification is opportunistic. Mint click retries it before PICK.
+  }
+};
+
 const handlePendingTx = async () => {
   if (!walletState.txHash) {
     return;
@@ -10285,7 +10468,7 @@ const handlePendingTx = async () => {
 
 const openMintFlow = async (
   uiMode: MintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE,
-  options?: { attemptId?: string; pathId?: string },
+  options?: { attemptId?: string; pathId?: string; work?: ThoughtMintWorkSnapshot },
 ) => {
   const trackedMint = adoptDurablePendingMintTransaction();
   if (trackedMint) {
@@ -10299,7 +10482,12 @@ const openMintFlow = async (
     }
     return;
   }
+  const mintWork = options?.work ?? captureCurrentMintWork();
+  if (!mintWork) {
+    return;
+  }
   resetMintFlow({ preserveAttempt: true });
+  activeMintWork = mintWork;
   mintAttemptId = options?.attemptId?.trim() || nextMintAttemptId("mint");
   mintFlowData.pathIdInput = options?.pathId?.trim() ?? "";
   mintFlowUiMode = uiMode;
@@ -10315,18 +10503,14 @@ const openMintFlow = async (
     return;
   }
 
-  if (!currentOutputText) {
-    return;
-  }
-
-  if (!hasCurrentContractWorkSvg()) {
+  if (!mintWork.svg.trim().startsWith("<svg")) {
     setMintFlowError("contract SVG missing.", "thought");
     syncInterface();
     return;
   }
 
-  mintFlowData.rawText = currentOutputText;
-  mintFlowData.promptHash = currentRunContext?.prompt ? hashText(currentRunContext.prompt) : "";
+  mintFlowData.rawText = mintWork.text;
+  mintFlowData.promptHash = hashText(mintWork.runContext.prompt);
   mintFlowData.error = "";
   mintFlowData.errorKind = "none";
   mintFlowData.txHash = "";
@@ -10347,7 +10531,7 @@ const openMintFlow = async (
   }
 
   try {
-    mintFlowData.textHash = await textHashFromContract(currentOutputText);
+    mintFlowData.textHash = await textHashFromContract(mintWork.text);
   } catch {
     setMintFlowError("text preview unavailable.", "thought");
     syncInterface();
@@ -10376,7 +10560,7 @@ const openMintFlow = async (
   if (IS_LOCAL_THOUGHT_V2) {
     mintFlowData.provenanceJson = "";
   } else {
-    const provenanceJson = buildProvenanceJson(mintFlowData.textHash);
+    const provenanceJson = buildProvenanceJson(mintFlowData.textHash, undefined, mintWork);
     const provenanceBytes = byteLength(provenanceJson);
     if (provenanceBytes > MAX_PROVENANCE_BYTES) {
       setMintFlowError(provenanceTooLargeMessage(provenanceBytes), "thought");
@@ -10544,6 +10728,16 @@ const checkPathEligibility = async () => {
     return;
   }
 
+  try {
+    await rebuildFinalMintProvenance();
+  } catch (error) {
+    const presentation = formatThoughtAuthorizationError(error, "preparing");
+    setMintFlowError(presentation.message, presentation.kind);
+    syncInterface();
+    focusMintDockStage();
+    return;
+  }
+
   mintFlowState = "path_ready";
   mintFlowData.error = "";
   mintFlowData.errorKind = "none";
@@ -10572,7 +10766,7 @@ const authorizeMint = async () => {
   const expectedPathId = mintFlowData.pathId;
   const requestId = mintAuthorizationRequestId + 1;
   mintAuthorizationRequestId = requestId;
-  let authorizationStage: ThoughtAuthorizationStage = "preparing";
+  let authorizationStage: ThoughtAuthorizationStage = "wallet";
   mintFlowState = "authorizing";
   walletState.txError = "";
   mintFlowData.error = "";
@@ -10583,19 +10777,6 @@ const authorizeMint = async () => {
   setStatus("");
 
   try {
-    const eligibility = await readPathEligibility(expectedPathId, expectedAddress);
-    if (!eligibility.ok) {
-      setMintFlowError(eligibility.message, eligibility.kind);
-      syncInterface();
-      focusMintDockStage();
-      return;
-    }
-
-    await rebuildFinalMintProvenance();
-    if (requestId !== mintAuthorizationRequestId) return;
-    if (mintFlowData.pathId !== expectedPathId) return;
-
-    authorizationStage = "wallet";
     const ethereum = getEthereumProvider();
     if (!ethereum) {
       throw new Error("wallet not connected");
@@ -10694,10 +10875,10 @@ const mintErrorMessage = (error: unknown) => {
     return "this exact Agent line is already minted.";
   }
   if (errorName === "ThoughtAlreadyMinted" || /ThoughtAlreadyMinted/i.test(message)) {
-    return "this exact text is already minted.";
+    return "this exact THOUGHT is already on-chain.";
   }
   if (/expired/i.test(message)) {
-    return "authorization expired.";
+    return "$PATH signature expired.";
   }
   if (/eth_sendRawTransaction|RPC method is not allowed/i.test(message)) {
     return "wallet RPC is read-only. Update the current chain RPC in wallet and retry.";
@@ -10709,10 +10890,10 @@ const mintErrorMessage = (error: unknown) => {
     return "wallet transaction not submitted.";
   }
   if (/BAD_MOVEMENT_ORDER|QUOTA_EXHAUSTED/i.test(message)) {
-    return "$PATH has no THOUGHT unit available.";
+    return "$PATH has no THOUGHT mint available.";
   }
   if (/BAD_CONSUME_AUTH/i.test(message)) {
-    return "authorization expired.";
+    return "$PATH signature expired.";
   }
   if (/ERR_NOT_OWNER/i.test(message)) {
     return "wallet does not hold this $PATH.";
@@ -10930,7 +11111,7 @@ const recoverMintStateAfterRevert = async (
       appendCliOutput([
         "already minted.",
         `THOUGHT: #${existingTokenId}`,
-        consumedPathId ? `$PATH #${consumedPathId} THOUGHT unit already consumed.` : "",
+        consumedPathId ? `$PATH #${consumedPathId} THOUGHT mint already used.` : "",
         walletState.txHash || mintFlowData.txHash ? "use: view tx" : "",
         viewThoughtUseLine(existingTokenId),
         "use: gallery",
@@ -10951,7 +11132,7 @@ const recoverMintStateAfterRevert = async (
     }
     const pathId = selectedCliPathId();
     setMintFlowError(
-      pathId ? `$PATH #${pathId} has no THOUGHT unit available.` : "$PATH has no THOUGHT unit available.",
+      pathId ? `$PATH #${pathId} has no THOUGHT mint available.` : "$PATH has no THOUGHT mint available.",
       "path_consumed",
     );
     syncInterface();
@@ -11006,7 +11187,7 @@ const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliRe
       appendCliOutput([
         "minted.",
         mintedTokenId !== null ? `THOUGHT: #${mintedTokenId}` : "THOUGHT: minted",
-        consumedPathId ? `$PATH #${consumedPathId} THOUGHT unit consumed.` : "",
+        consumedPathId ? `$PATH #${consumedPathId} THOUGHT mint used.` : "",
         "use: view tx",
         viewThoughtUseLine(mintedTokenId),
         "use: gallery",
@@ -11186,7 +11367,7 @@ const finalizeSuccessfulKnownMint = async (
     appendCliOutput([
       "minted.",
       mintedTokenId !== null ? `THOUGHT: #${mintedTokenId}` : "THOUGHT: minted",
-      `$PATH #${transaction.pathId} THOUGHT unit consumed.`,
+      `$PATH #${transaction.pathId} THOUGHT mint used.`,
       "use: view tx",
       viewThoughtUseLine(mintedTokenId),
       "use: gallery",
@@ -11445,7 +11626,7 @@ const registerSubmittedMintTx = async (
         `tx: ${shortHex(tx.hash, 10, 8)}`,
         `wallet nonce: ${nonceGap.actual}`,
         `chain expects: ${nonceGap.expected}`,
-        "mint is not pending onchain yet.",
+        "mint is not pending on-chain yet.",
         "keep tracking this hash; do not submit a duplicate.",
         "check Rabby activity and nonce before taking wallet action.",
         "use: view tx",
@@ -11539,6 +11720,7 @@ const restorePathMintHandoffWork = (handoff: PathMintHandoff) => {
     currentRunContext = isThoughtRunContext(handoff.work.runContext) ? handoff.work.runContext : null;
     currentWorkId = handoff.work.workId;
     runState = "output_ready";
+    mintDockRevealed = true;
     writeCurrentOutputSession();
     syncCurrentWorkVisual({ suppressWarning: true });
     return true;
@@ -11653,7 +11835,7 @@ const resumePathMintHandoff = async () => {
   const showReturnError = (message: string, kind: MintFlowErrorKind) => {
     const work = getThoughtDockWorkView();
     if (work) {
-      setThoughtDockState({ kind: "minting", work });
+      setThoughtDockState({ kind: "work_ready", work });
     }
     setMintFlowError(message, kind);
     syncInterface();
@@ -11662,28 +11844,28 @@ const resumePathMintHandoff = async () => {
 
   if (submittedReturnOutcome === "reverted") {
     return showReturnError(
-      "PATH transaction reverted. Mint a PATH or choose one already in this wallet.",
+      "$PATH transaction reverted. Mint a $PATH or pick one already in this wallet.",
       "path_not_found",
     );
   }
 
   if (returnRecord?.status === "submitted" && returnRecord.chainId !== THOUGHT_CHAIN_ID) {
     return showReturnError(
-      `PATH transaction is on chain ${returnRecord.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
+      `$PATH transaction is on chain ${returnRecord.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
       "path_mint_chain_mismatch",
     );
   }
 
   if (returnRecord?.status === "submitted") {
     return showReturnError(
-      `PATH transaction ${shortHex(returnRecord.txHash, 10, 8)} is still confirming.`,
+      `$PATH transaction ${shortHex(returnRecord.txHash, 10, 8)} is still confirming.`,
       "path_mint_pending",
     );
   }
 
   if (confirmedReturn && confirmedReturn.chainId !== THOUGHT_CHAIN_ID) {
     return showReturnError(
-      `PATH was minted on chain ${confirmedReturn.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
+      `$PATH was minted on chain ${confirmedReturn.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
       "path_mint_chain_mismatch",
     );
   }
@@ -11693,7 +11875,7 @@ const resumePathMintHandoff = async () => {
     (!walletState.address || walletState.address.toLowerCase() !== confirmedReturn.account.toLowerCase())
   ) {
     return showReturnError(
-      `PATH was minted to ${shortHex(confirmedReturn.account)}; select that account in your wallet to continue.`,
+      `$PATH was minted to ${shortHex(confirmedReturn.account)}; select that account in your wallet to continue.`,
       "wallet_account_mismatch",
     );
   }
@@ -11704,8 +11886,8 @@ const resumePathMintHandoff = async () => {
 
   emitThoughtConsoleEvent({
     kind: "path_mint_returned",
-    title: "returned from PATH mint",
-    detail: "Rechecking wallet PATHs and resuming this THOUGHT mint.",
+    title: "returned from $PATH mint",
+    detail: "Refreshing wallet $PATH inventory and resuming this THOUGHT mint.",
     eventId: `path-return:${handoff.attemptId}`,
   });
   const resumed = await mintThoughtDockWork({
@@ -11754,8 +11936,11 @@ const resumePathMintHandoff = async () => {
 };
 
 const rebuildFinalMintProvenance = async () => {
-  if (!walletState.address || mintFlowData.pathId === null) {
+  if (!walletState.address || mintFlowData.pathId === null || !activeMintWork) {
     throw new Error("mint context unavailable.");
+  }
+  if (mintFlowData.rawText !== activeMintWork.text) {
+    throw new Error("mint work changed.");
   }
 
   const spec = await ensureActiveThoughtSpec();
@@ -11764,13 +11949,13 @@ const rebuildFinalMintProvenance = async () => {
   if (!mintFlowData.textHash) {
     mintFlowData.textHash = await textHashFromContract(mintFlowData.rawText);
   }
-  const promptHash = currentRunContext?.prompt ? hashText(currentRunContext.prompt) : hashText(sessionState.prompt);
+  const promptHash = hashText(activeMintWork.runContext.prompt);
   mintFlowData.promptHash = promptHash;
   const provenanceJson = buildProvenanceJson(mintFlowData.textHash, {
     minter: walletState.address,
     pathId: mintFlowData.pathId,
     promptHash,
-  });
+  }, activeMintWork);
   const provenanceBytes = byteLength(provenanceJson);
   if (provenanceBytes > MAX_PROVENANCE_BYTES) {
     throw new Error(provenanceTooLargeMessage(provenanceBytes));
@@ -11795,7 +11980,8 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
     !mintFlowData.thoughtSpecId ||
     !mintFlowData.thoughtSpecHash ||
     !mintFlowData.deadline ||
-    !mintFlowData.signature
+    !mintFlowData.signature ||
+    !activeMintWork
   ) {
     clearMintAuthorization();
     mintFlowState = "path_ready";
@@ -11805,7 +11991,7 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
   }
 
   if (mintFlowData.deadline <= BigInt(Math.floor(Date.now() / 1000))) {
-    setMintFlowError("authorization expired.", "signature");
+    setMintFlowError("$PATH signature expired.", "signature");
     syncInterface();
     trackThoughtAnalytics("mint_failed", {
       mintStage: "signature",
@@ -11851,7 +12037,7 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
     const payload = Object.freeze({
       attemptId: capturedAuthorization.attemptId,
       account: capturedAuthorization.account,
-      promptLine: currentRunContext?.prompt ?? sessionState.prompt,
+      promptLine: activeMintWork.runContext.prompt,
       agentLine: capturedAuthorization.rawText,
       pathId: capturedAuthorization.pathId,
       thoughtSpecId: mintFlowData.thoughtSpecId,
@@ -11871,6 +12057,19 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
     const eligibility = await readPathEligibility(payload.pathId, signerAddress);
     if (!eligibility.ok) {
       setMintFlowError(eligibility.message, eligibility.kind);
+      syncInterface();
+      return null;
+    }
+    const readToken = getReadThoughtNFT();
+    const existingTokenId = readToken
+      ? await lookupExistingThoughtToken(readToken, payload.workHash)
+      : 0n;
+    if (existingTokenId !== 0n) {
+      walletState.txState = "idle";
+      walletState.txError = "";
+      mintFlowData.existingTokenId = Number(existingTokenId);
+      mintFlowState = "text_taken";
+      recordCurrentMintConsoleState();
       syncInterface();
       return null;
     }
@@ -12256,63 +12455,362 @@ const recoverUnresolvedMintSubmission = async () => {
   syncInterface();
 };
 
-const pathMintUrl = () => {
-  try {
-    const url = new URL(PATH_MINT_URL, sameOriginAppOrigin());
-    const returnUrl = new URL(window.location.href);
-    returnUrl.searchParams.set("pathHandoff", mintAttemptId);
-    url.searchParams.set("intent", "mint-path");
-    url.searchParams.set("from", "thought");
-    url.searchParams.set(
-      "returnTo",
-      `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}` || thoughtRoutePath("/"),
-    );
-    url.searchParams.set("handoff", mintAttemptId);
-    if (walletState.address) {
-      url.searchParams.set("account", walletState.address);
-    }
-    url.searchParams.set("chainId", String(THOUGHT_CHAIN_ID));
-    url.searchParams.set("movement", "THOUGHT");
-    return url.toString();
-  } catch {
-    return PATH_MINT_URL;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const readPathAcquisitionQuote = async () => {
+  const provider = getPathReadProvider();
+  if (!provider || !PATH_AUCTION_ADDRESS || !PATH_PULSE_ADAPTER_ADDRESS || !PATH_NFT_ADDRESS) {
+    throw new Error("This V2 deployment has no in-place $PATH auction configured.");
   }
+
+  const auction = new Contract(PATH_AUCTION_ADDRESS, PATH_AUCTION_ABI, provider);
+  const adapter = new Contract(PATH_PULSE_ADAPTER_ADDRESS, PATH_PULSE_ADAPTER_ABI, provider);
+  const [auctionCode, adapterCode, pathCode] = await Promise.all([
+    provider.getCode(PATH_AUCTION_ADDRESS),
+    provider.getCode(PATH_PULSE_ADAPTER_ADDRESS),
+    provider.getCode(PATH_NFT_ADDRESS),
+  ]);
+  if (auctionCode === "0x" || adapterCode === "0x" || pathCode === "0x") {
+    throw new Error("The configured $PATH auction deployment is unavailable on this network.");
+  }
+
+  const [active, price, mintAdapter, paymentToken, adapterAuction, adapterPathNft, wiringFrozen] =
+    await Promise.all([
+      auction.curveActive() as Promise<boolean>,
+      auction.getCurrentPrice() as Promise<bigint>,
+      auction.mintAdapter() as Promise<string>,
+      auction.paymentToken() as Promise<string>,
+      adapter.auction() as Promise<string>,
+      adapter.pathNft() as Promise<string>,
+      adapter.wiringFrozen() as Promise<boolean>,
+    ]);
+
+  if (!active) throw new Error("The $PATH auction is not open yet.");
+  if (price <= 0n) throw new Error("The $PATH auction returned an invalid price.");
+  if (
+    mintAdapter.toLowerCase() !== PATH_PULSE_ADAPTER_ADDRESS.toLowerCase() ||
+    adapterAuction.toLowerCase() !== PATH_AUCTION_ADDRESS.toLowerCase() ||
+    adapterPathNft.toLowerCase() !== PATH_NFT_ADDRESS.toLowerCase() ||
+    !wiringFrozen
+  ) {
+    throw new Error("The $PATH auction is not wired to this THOUGHT V2 deployment.");
+  }
+  if (paymentToken.toLowerCase() !== ZERO_ADDRESS) {
+    throw new Error("This $PATH auction uses a token approval flow that is not supported here yet.");
+  }
+
+  return { price };
 };
 
-const handleMintPath = () => {
+const pathAcquisitionFailureCopy = (error: unknown) => {
+  const message = String(
+    (error as { shortMessage?: unknown; message?: unknown })?.shortMessage ??
+      (error as Error)?.message ??
+      error ??
+      "",
+  );
+  const code = String((error as { code?: unknown })?.code ?? "");
+  if (code === "4001" || /reject|denied|cancel/i.test(message)) {
+    return "$PATH transaction rejected in wallet.";
+  }
+  if (code === "-32002" || /already.*(?:pending|open)|request.*pending/i.test(message)) {
+    return "A wallet request is already open.";
+  }
+  if (/insufficient funds|exceeds balance/i.test(message)) {
+    return `Insufficient ${THOUGHT_CURRENCY_LABEL} for the $PATH price and gas.`;
+  }
+  return message || "$PATH mint failed.";
+};
+
+const setPathAcquisitionError = (error: unknown) => {
+  pathAcquisitionRequestId += 1;
+  pathAcquisitionState = "error";
+  pathAcquisitionError = pathAcquisitionFailureCopy(error);
+  emitThoughtConsoleEvent({
+    kind: "path_acquisition_failed",
+    title: "$PATH mint unavailable",
+    detail: pathAcquisitionError,
+    nextStep: "retry here, or explore $PATH at /path",
+    tone: "warning",
+    eventId: `path-acquisition-failed:${mintAttemptId}:${pathAcquisitionError}`,
+  });
+  syncInterface();
+  focusMintDockStage();
+};
+
+const handleMintPath = async (options?: { submit?: boolean }) => {
   if (!currentOutputText) {
-    setMintFlowError("No accepted work to preserve for PATH mint.", "thought");
+    setMintFlowError("No accepted work to preserve for $PATH mint.", "thought");
     syncInterface();
     return;
   }
-  if (mintFlowData.errorKind === "path_mint_chain_mismatch") {
-    // Keep the mismatched return record as diagnostics, but never send PATH
-    // back into that completed handoff. The URL and new stored handoff must
-    // share one fresh ID.
-    mintAttemptId = nextMintAttemptId("path");
+  if (!walletState.address) {
+    mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
+    syncInterface();
+    return;
   }
-  const workHash = keccak256(toUtf8Bytes(currentOutputText));
-  writePathMintHandoff({
-    version: 1,
-    attemptId: mintAttemptId,
-    workHash,
+  if (walletState.chainId !== THOUGHT_CHAIN_ID) {
+    setMintFlowError("wrong network.", "wrong_network");
+    syncInterface();
+    return;
+  }
+  if (readPendingPathAcquisition()) {
+    await resumePendingPathAcquisition();
+    return;
+  }
+
+  const requestId = pathAcquisitionRequestId + 1;
+  pathAcquisitionRequestId = requestId;
+  pathAcquisitionState = "quoting";
+  pathAcquisitionError = "";
+  pathAcquisitionTxHash = "";
+  syncInterface();
+
+  try {
+    const quote = await readPathAcquisitionQuote();
+    if (requestId !== pathAcquisitionRequestId) return;
+    pathAcquisitionPrice = quote.price;
+    pathAcquisitionState = "review";
+    emitThoughtConsoleEvent({
+      kind: "path_acquisition_quote",
+      title: "$PATH quote ready",
+      detail: `${formatPathAcquisitionPrice(quote.price)} ${THOUGHT_CURRENCY_LABEL} at the current auction price.`,
+      nextStep: "mint here, or explore $PATH at /path",
+      eventId: `path-acquisition-quote:${mintAttemptId}:${quote.price}`,
+    });
+    syncInterface();
+    focusMintDockStage();
+    if (options?.submit) {
+      await confirmPathAcquisition();
+    }
+  } catch (error) {
+    if (requestId !== pathAcquisitionRequestId) return;
+    setPathAcquisitionError(error);
+  }
+};
+
+const finishPathAcquisitionReceipt = async (
+  pending: PendingThoughtPathAcquisition,
+  receipt: { status?: unknown; logs?: readonly { address?: string; topics?: readonly string[] }[] },
+) => {
+  const outcome = mintReceiptStatusOutcome(receipt.status);
+  if (outcome === "unknown") return false;
+  pathAcquisitionReceiptMonitorHash = "";
+  if (outcome === "reverted") {
+    writePendingPathAcquisition(null);
+    setPathAcquisitionError("$PATH transaction reverted on-chain.");
+    return true;
+  }
+
+  const tokenId = pathTokenIdFromMintReceipt(receipt, pending.account);
+  writePendingPathAcquisition(null);
+  pathAcquisitionState = "idle";
+  pathAcquisitionError = "";
+  pathAcquisitionTxHash = pending.txHash;
+  pathAcquisitionCompletedForAttempt = true;
+  emitThoughtConsoleEvent({
+    kind: "path_acquisition_confirmed",
+    title: "$PATH minted",
+    detail: tokenId
+      ? `$PATH #${tokenId} confirmed. Picking it for this THOUGHT.`
+      : "$PATH confirmed. Refreshing inventory for this THOUGHT.",
+    eventId: `path-acquisition-confirmed:${pending.txHash}`,
+    tone: "success",
+  });
+
+  await refreshPathInventoryForCurrentWallet({ force: true });
+  if (tokenId) {
+    applyMintPathInputValue(tokenId);
+    syncInterface();
+    await checkPathEligibility();
+    return true;
+  }
+
+  const available = availablePathInventoryItems();
+  if (available.length === 1) {
+    selectPathInventoryItem(available[0].pathId);
+    return true;
+  }
+
+  setPathAcquisitionError(
+    available.length > 1
+      ? "$PATH confirmed, but the minted token could not be identified. Pick it from the updated list."
+      : "$PATH confirmed, but the updated token is not visible in inventory yet. Refresh wallet from the shell bar.",
+  );
+  return true;
+};
+
+const monitorPendingPathAcquisition = async (pending: PendingThoughtPathAcquisition) => {
+  if (pathAcquisitionReceiptMonitorHash === pending.txHash) return;
+  pathAcquisitionReceiptMonitorHash = pending.txHash;
+  while (pathAcquisitionReceiptMonitorHash === pending.txHash) {
+    for (const provider of getMintReceiptMonitoringProviders()) {
+      try {
+        const receipt = await provider.getTransactionReceipt(pending.txHash);
+        if (receipt && await finishPathAcquisitionReceipt(pending, receipt)) return;
+      } catch {
+        // Keep the durable hash and retry through the available providers.
+      }
+    }
+    await sleep(MINT_RECEIPT_POLL_MS);
+  }
+};
+
+const resumePendingPathAcquisition = async () => {
+  const pending = readPendingPathAcquisition();
+  if (!pending) return false;
+  const workHash = currentOutputText ? keccak256(toUtf8Bytes(currentOutputText)) : "";
+  const expected = {
     account: walletState.address,
     chainId: THOUGHT_CHAIN_ID,
-    work: {
-      output: currentOutputText,
-      svg: currentWorkSvg,
-      runContext: currentRunContext,
-      workId: currentWorkId,
-    },
-    createdAt: Date.now(),
-  });
+    auction: PATH_AUCTION_ADDRESS,
+    pathNft: PATH_NFT_ADDRESS,
+    workHash,
+  };
+  if (!pendingThoughtPathAcquisitionMatches(pending, expected)) {
+    pathAcquisitionState = "error";
+    pathAcquisitionTxHash = pending.txHash;
+    pathAcquisitionError = "A pending $PATH transaction belongs to another wallet, work, or V2 deployment.";
+    emitThoughtConsoleEvent({
+      kind: "path_acquisition_context_mismatch",
+      title: "$PATH mint context changed",
+      detail: "The retained transaction hash will not be applied to this THOUGHT.",
+      nextStep: "restore the original wallet and work",
+      tone: "warning",
+      eventId: `path-acquisition-mismatch:${pending.txHash}`,
+    });
+    syncInterface();
+    return true;
+  }
+
+  pathAcquisitionState = "submitted";
+  pathAcquisitionTxHash = pending.txHash;
+  pathAcquisitionError = "";
+  syncInterface();
+  void monitorPendingPathAcquisition(pending);
+  return true;
+};
+
+const blockPendingPathAcquisitionMutation = () => {
+  const pending = readPendingPathAcquisition();
+  if (!pending && pathAcquisitionState !== "awaiting_signature") return false;
+  if (pending) {
+    void resumePendingPathAcquisition();
+  }
   emitThoughtConsoleEvent({
-    kind: "path_mint_handoff",
-    title: "opening PATH mint",
-    detail: "Your THOUGHT work and mint history are preserved for the return.",
-    eventId: `path-handoff:${mintAttemptId}`,
+    kind: "path_acquisition_preserved",
+    title: pending ? "$PATH mint still pending" : "$PATH wallet request still open",
+    detail: pending
+      ? `${shortHex(pending.txHash, 10, 8)} remains attached to this work.`
+      : "Resolve or reject the wallet request before changing this work.",
+    eventId: pending
+      ? `path-acquisition-preserved:${pending.txHash}`
+      : `path-acquisition-wallet-preserved:${mintAttemptId}`,
+    tone: "warning",
+    nextStep: pending ? "wait for confirmation" : "resolve the wallet request",
   });
-  window.location.assign(pathMintUrl());
+  syncInterface();
+  return true;
+};
+
+const confirmPathAcquisition = async () => {
+  if (pathAcquisitionState !== "review" || pathAcquisitionPrice <= 0n) return;
+  const ethereum = getEthereumProvider();
+  if (!ethereum || !walletState.address || walletState.chainId !== THOUGHT_CHAIN_ID) {
+    setPathAcquisitionError("Connect the correct wallet and network before minting $PATH.");
+    return;
+  }
+
+  const requestId = pathAcquisitionRequestId + 1;
+  pathAcquisitionRequestId = requestId;
+  const expectedAccount = walletState.address;
+  const workHash = keccak256(toUtf8Bytes(currentOutputText));
+  pathAcquisitionState = "awaiting_signature";
+  pathAcquisitionError = "";
+  emitThoughtConsoleEvent({
+    kind: "path_acquisition_wallet",
+    title: "confirm $PATH mint",
+    detail: "Wallet request 1 of 3 for the complete THOUGHT flow.",
+    eventId: `path-acquisition-wallet:${mintAttemptId}`,
+  });
+  syncInterface();
+
+  try {
+    const lockResult = await withThoughtPathAcquisitionLock(
+      typeof navigator.locks?.request === "function"
+        ? navigator.locks as unknown as Parameters<typeof withThoughtPathAcquisitionLock>[0]
+        : null,
+      async () => {
+        if (readPendingPathAcquisition()) {
+          throw new Error("A $PATH mint transaction is already pending.");
+        }
+        const [accounts, chainHex] = await Promise.all([
+          ethereum.request({ method: "eth_accounts" }),
+          ethereum.request({ method: "eth_chainId" }),
+        ]);
+        const liveAccount = extractPrimaryAccount(accounts);
+        const liveChainId = typeof chainHex === "string" ? Number(BigInt(chainHex)) : null;
+        if (liveAccount.toLowerCase() !== expectedAccount.toLowerCase()) {
+          throw new Error("Wallet account changed before $PATH mint.");
+        }
+        if (liveChainId !== THOUGHT_CHAIN_ID) {
+          throw new Error("Wrong network for $PATH mint.");
+        }
+
+        const quote = await readPathAcquisitionQuote();
+        pathAcquisitionPrice = quote.price;
+        const browserProvider = new BrowserProvider(ethereum);
+        const signer = await browserProvider.getSigner(expectedAccount);
+        const auction = new Contract(PATH_AUCTION_ADDRESS, PATH_AUCTION_ABI, signer);
+        const tx = await auction.bid(quote.price, { value: quote.price }) as { hash: string };
+        const pending: PendingThoughtPathAcquisition = Object.freeze({
+          version: 1,
+          account: expectedAccount.toLowerCase(),
+          chainId: THOUGHT_CHAIN_ID,
+          auction: PATH_AUCTION_ADDRESS.toLowerCase(),
+          pathNft: PATH_NFT_ADDRESS.toLowerCase(),
+          workHash: workHash.toLowerCase(),
+          txHash: tx.hash.toLowerCase(),
+          updatedAt: Date.now(),
+        });
+        writePendingPathAcquisition(pending);
+        return pending;
+      },
+    );
+
+    if (requestId !== pathAcquisitionRequestId) return;
+    if (!lockResult.acquired) {
+      throw new Error(
+        lockResult.reason === "busy"
+          ? "This $PATH mint is already open in another tab."
+          : "$PATH minting requires browser tab coordination (Web Locks).",
+      );
+    }
+    pathAcquisitionState = "submitted";
+    pathAcquisitionTxHash = lockResult.value.txHash;
+    emitThoughtConsoleEvent({
+      kind: "path_acquisition_submitted",
+      title: "$PATH mint submitted",
+      detail: `${shortHex(lockResult.value.txHash, 10, 8)} · waiting for confirmation.`,
+      eventId: `path-acquisition-submitted:${lockResult.value.txHash}`,
+    });
+    syncInterface();
+    void monitorPendingPathAcquisition(lockResult.value);
+  } catch (error) {
+    if (requestId !== pathAcquisitionRequestId) return;
+    setPathAcquisitionError(error);
+  }
+};
+
+const viewPathAcquisitionTx = async () => {
+  if (!pathAcquisitionTxHash) return;
+  const txUrl = thoughtTxUrl(pathAcquisitionTxHash);
+  if (txUrl) {
+    window.open(txUrl, "_blank", "noopener,noreferrer");
+    return;
+  }
+  await copyToClipboard(pathAcquisitionTxHash);
 };
 
 const chooseAnotherPath = () => {
@@ -12328,38 +12826,6 @@ const chooseAnotherPath = () => {
   if (pathSelectionReady) {
     focusMintPathInput();
   }
-};
-
-const refreshMintSheetPath = async () => {
-  walletState.txState = "idle";
-  walletState.txError = "";
-  await refreshWalletState();
-
-  if (!walletState.address) {
-    mintFlowState = "wallet_required";
-    mintFlowData.error = "";
-    mintFlowData.errorKind = "none";
-    recordCurrentMintConsoleState();
-    syncInterface();
-    focusMintDockStage();
-    return;
-  }
-
-  if (walletState.chainId !== THOUGHT_CHAIN_ID) {
-    setMintFlowError("wrong network.", "wrong_network");
-    syncInterface();
-    focusMintDockStage();
-    return;
-  }
-
-  if (canContinueWithPathInput()) {
-    await checkPathEligibility();
-    return;
-  }
-
-  moveMintFlowToWalletOrPathSelection();
-  syncInterface();
-  focusMintDockStage("path");
 };
 
 const handleMintSheetAction = async (action: MintSheetAction) => {
@@ -12441,22 +12907,17 @@ const handleMintSheetAction = async (action: MintSheetAction) => {
   }
 
   if (action === "mint_path") {
-    handleMintPath();
+    await handleMintPath({ submit: true });
     return;
   }
 
-  if (action === "refresh") {
-    const pathHandoff = readPathMintHandoff();
-    const pathReturn = pathHandoff
-      ? readPathMintReturnRecord(getPathMintReturnStorageHost(), pathHandoff.attemptId)
-      : null;
-    if (pathHandoff && (pathReturn || mintFlowData.errorKind === "wallet_account_mismatch")) {
-      await refreshWalletState();
-      await resumePathMintHandoff();
-      syncInterface();
-      return;
-    }
-    await refreshMintSheetPath();
+  if (action === "confirm_path_mint") {
+    await confirmPathAcquisition();
+    return;
+  }
+
+  if (action === "view_path_tx") {
+    await viewPathAcquisitionTx();
     return;
   }
 
@@ -13041,7 +13502,7 @@ const renderGalleryCard = (thought: GalleryThought) => {
   tipBreak.className = "thought-gallery__tip-break";
   tipBreak.setAttribute("aria-hidden", "true");
   const tipPath = document.createElement("span");
-  tipPath.textContent = `$PATH #${thought.pathId} THOUGHT unit consumed`;
+  tipPath.textContent = `$PATH #${thought.pathId} THOUGHT mint used`;
   const tipMinted = document.createElement("span");
   tipMinted.textContent = `minted ${galleryTipTime(thought.mintedAt)}`;
   const tipMinter = document.createElement("span");
@@ -13682,7 +14143,6 @@ const getThoughtDockViewportReserve = () => {
   return (
     railMargin +
     railHeight +
-    visibleBlockOuterHeight(thoughtDockExpanded) +
     visibleBlockOuterHeight(thoughtDockDetails)
   );
 };
@@ -13882,15 +14342,16 @@ const syncOutputToCanvas = (raw: string, options?: { suppressWarning?: boolean }
   renderCanvas(raw);
 };
 
-const setAgentOutput = (text: string, rawOutput: string, svg: string) => {
-  if (blockPendingMintMutation()) {
+const setAgentOutput = (text: string, _rawOutput: string, svg: string) => {
+  if (blockPendingMintMutation() || blockPendingPathAcquisitionMutation()) {
     return false;
   }
   resetMintRuntimeState();
+  mintDockRevealed = false;
   currentOutputText = text;
   currentWorkSvg = svg;
   showContractSvgPreview(svg);
-  currentWorkId = recordCurrentWork(rawOutput);
+  currentWorkId = null;
   writeCurrentOutputSession();
   return true;
 };
@@ -13946,19 +14407,56 @@ const recordCurrentWork = (rawOutput: string) => {
   return result.work.id;
 };
 
+const saveCurrentWorkFromDock = () => {
+  if (blockPendingMintMutation()) {
+    return;
+  }
+  if (currentWorkId !== null && getWorkById(readStoredThoughtWorks(), currentWorkId)) {
+    syncInterface();
+    return;
+  }
+  const savedId = recordCurrentWork(currentRunContext?.returnedText ?? currentOutputText);
+  if (savedId === null) {
+    emitThoughtConsoleEvent({
+      kind: "work_save_failed",
+      title: "work not saved",
+      detail: "current work is incomplete",
+      tone: "warning",
+    });
+    syncInterface();
+    return;
+  }
+  currentWorkId = savedId;
+  writeCurrentOutputSession();
+  emitThoughtConsoleEvent({
+    kind: "work_saved",
+    title: "work saved",
+    detail: currentRunContext?.prompt ?? "",
+    tone: "success",
+    eventId: `work-saved:${savedId}`,
+  });
+  syncInterface();
+};
+
 const loadWorkRecord = (work: ThoughtWorkRecord) => {
-  if (blockPendingMintMutation({ cli: true })) {
+  if (blockPendingMintMutation({ cli: true }) || blockPendingPathAcquisitionMutation()) {
     return false;
   }
   resetMintRuntimeState();
+  mintDockRevealed = false;
   currentOutputText = thoughtProtocolText(work.text || work.title, IS_LOCAL_THOUGHT_V2);
   currentWorkSvg = work.svg ?? "";
   currentRunContext = workRunContextToThoughtRunContext(work);
   currentWorkId = work.id;
+  sessionState.prompt = work.prompt || work.runContext.prompt;
+  promptBox.value = sessionState.prompt;
+  thoughtDockPrompt.value = sessionState.prompt;
+  writeSessionState();
   runState = "output_ready";
   syncCurrentWorkVisual({ suppressWarning: true });
   writeCurrentOutputSession();
   syncInterface();
+  void preflightCurrentThoughtExistence();
   return true;
 };
 
@@ -14018,7 +14516,13 @@ const readCurrentOutputSession = () => {
       return null;
     }
 
-    const candidate = parsed as { output?: unknown; svg?: unknown; runContext?: unknown; workId?: unknown };
+    const candidate = parsed as {
+      output?: unknown;
+      svg?: unknown;
+      runContext?: unknown;
+      workId?: unknown;
+      mintDockRevealed?: unknown;
+    };
     const output = typeof candidate.output === "string"
       ? thoughtProtocolText(candidate.output, IS_LOCAL_THOUGHT_V2)
       : "";
@@ -14036,6 +14540,7 @@ const readCurrentOutputSession = () => {
       workId: Number.isSafeInteger(candidate.workId) && Number(candidate.workId) > 0
         ? Number(candidate.workId)
         : null,
+      mintDockRevealed: candidate.mintDockRevealed === true,
     };
   } catch {
     return null;
@@ -14055,6 +14560,7 @@ const writeCurrentOutputSession = () => {
       svg: currentWorkSvg,
       runContext: currentRunContext,
       workId: currentWorkId,
+      mintDockRevealed,
     }),
   );
 };
@@ -14069,11 +14575,13 @@ const restoreCurrentOutputSession = () => {
   currentWorkSvg = stored.svg;
   currentRunContext = stored.runContext;
   currentWorkId = stored.workId;
+  mintDockRevealed = stored.mintDockRevealed;
   runState = "output_ready";
   if (stored.migrated) {
     writeCurrentOutputSession();
   }
   syncCurrentWorkVisual({ suppressWarning: true });
+  void preflightCurrentThoughtExistence();
 };
 
 const recordThoughtRun = (
@@ -14123,7 +14631,7 @@ const recordThoughtRun = (
 };
 
 const resetThought = (options?: { preserveStoredOutput?: boolean }) => {
-  if (blockPendingMintMutation()) {
+  if (blockPendingMintMutation() || blockPendingPathAcquisitionMutation()) {
     return false;
   }
   runState = "idle";
@@ -14133,6 +14641,8 @@ const resetThought = (options?: { preserveStoredOutput?: boolean }) => {
   currentWorkSvg = "";
   currentRunContext = null;
   currentWorkId = null;
+  mintDockRevealed = false;
+  workLibraryRevealed = false;
   if (!options?.preserveStoredOutput) {
     clearCurrentCandidate();
   }
@@ -14431,7 +14941,7 @@ const fetchAgentRequest = async (url: string, init: RequestInit) => {
       throw new Error("refresh stopped the request.");
     }
     if (error instanceof DOMException && error.name === "AbortError") {
-      throw new Error("agent request timed out.");
+      throw new Error("Agent request timed out.");
     }
     throw error;
   } finally {
@@ -14674,7 +15184,7 @@ const requestOllama = async (payload: ThoughtRunPayload) => {
     if (
       error instanceof Error &&
       (error.message === "refresh stopped the request." ||
-        error.message === "agent request timed out.")
+        error.message === "Agent request timed out.")
     ) {
       throw error;
     }
@@ -15544,6 +16054,7 @@ const promotePreviewedCandidateToWork = (
   walletState.txHash = "";
   walletState.mintedTokenId = null;
   syncCtaState();
+  void preflightCurrentThoughtExistence();
   void refreshWalletState().then(() => {
     syncInterface();
   });
@@ -15745,7 +16256,7 @@ const runAgent = async (options?: { forceGenerate?: boolean; cli?: boolean }) =>
       return;
     }
     runState = "run_failed";
-    const message = error instanceof Error ? error.message : "agent request failed.";
+    const message = error instanceof Error ? error.message : "Agent request failed.";
     lastRunErrorCliLines = message === THOUGHT_BRIDGE_NOT_CONNECTED_MESSAGE
       ? thoughtBridgeNotConnectedLines()
       : isContractWorkPreviewError(error)
@@ -17014,7 +17525,7 @@ const cliPromptValue = () => {
 const cliPathState = () => {
   const path = mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim();
   if (!path) {
-    return "not selected";
+    return "not picked";
   }
 
   if (mintFlowState === "minted" || mintFlowData.errorKind === "path_consumed") {
@@ -17024,7 +17535,7 @@ const cliPathState = () => {
     return `#${path} authorized`;
   }
   if (mintFlowState === "path_ready" || mintFlowState === "authorizing") {
-    return `#${path} selected`;
+    return `#${path} picked`;
   }
 
   return `#${path}`;
@@ -17139,7 +17650,7 @@ const buildCliCurrentLines = () => {
       currentCandidate && runState === "candidate_ready"
         ? "no"
         : hasCurrentContractWorkSvg()
-          ? "yes, after PATH selection and wallet confirmation"
+          ? "yes, after picking a $PATH and wallet confirmation"
           : "no"
     }`,
     `provenance: ${provenance ? `${provenance.bytes} bytes` : "empty"}`,
@@ -17968,7 +18479,7 @@ const outputCliThoughtWorks = async (topic: string) => {
     if (!thoughts.length) {
       appendCliOutput([
         "minted THOUGHTs.",
-        "kept onchain.",
+        "kept on-chain.",
         "empty.",
         "use: mint",
         "use: gallery",
@@ -17978,7 +18489,7 @@ const outputCliThoughtWorks = async (topic: string) => {
 
     appendCliOutput([
       "minted THOUGHTs.",
-      "kept onchain.",
+      "kept on-chain.",
       ...thoughts.map(formatMintedThoughtLine),
       "",
       "use: gallery",
@@ -18509,7 +19020,7 @@ const resumePendingThoughtAgentRun = () => {
       }
       appendCliRunCompletionLines();
     } catch (error) {
-      const message = error instanceof Error ? error.message : "agent request failed.";
+      const message = error instanceof Error ? error.message : "Agent request failed.";
       const shouldKeepPendingRun = pageUnloading && message === "refresh stopped the request.";
       if (!shouldKeepPendingRun) {
         clearPendingThoughtAgentRun(pendingRun.runId);
@@ -18681,7 +19192,7 @@ const cliVerifyLines = () => [
   "",
   "wallet actions:",
   "connect wallet reads selected address and public ownership state.",
-  `mint ${SURFACE_TERMINOLOGY.thoughtToken} submits a wallet-confirmed transaction using selected ${SURFACE_TERMINOLOGY.pathToken}.`,
+  `mint ${SURFACE_TERMINOLOGY.thoughtToken} submits a wallet-confirmed transaction using picked ${SURFACE_TERMINOLOGY.pathToken}.`,
   "funds or tokens move only after wallet transaction confirmation.",
   "",
   `open: ${PATH_VERIFY_CONTRACTS_URL}`,
@@ -18713,7 +19224,7 @@ const cliPathRecoveryErrorLines = (fallbackPathId = "") => {
   }
   if (mintFlowData.errorKind === "path_consumed") {
     return [
-      pathId ? `$PATH #${pathId} has no THOUGHT unit available.` : "$PATH has no THOUGHT unit available.",
+      pathId ? `$PATH #${pathId} has no THOUGHT mint available.` : "$PATH has no THOUGHT mint available.",
       ...useLines,
     ];
   }
@@ -18746,7 +19257,7 @@ const buildCliMintStateLines = () => {
   if (mintFlowState === "path_required") {
     return [
       walletState.address ? `wallet: connected ${formatCliAddress(walletState.address)}` : "wallet: not connected",
-      "select $PATH.",
+      "pick $PATH.",
       "use: path <id>",
       "use: path list",
       "need $PATH: mint-path",
@@ -18756,7 +19267,7 @@ const buildCliMintStateLines = () => {
     return [`checking $PATH #${pathId || "?"}...`];
   }
   if (mintFlowState === "path_ready") {
-    return [`$PATH #${pathId || "?"} selected.`, "THOUGHT unit available.", "use: authorize"];
+    return [`$PATH #${pathId || "?"} picked.`, "THOUGHT mint available.", "use: authorize"];
   }
   if (mintFlowState === "authorizing") {
     return ["wallet authorization pending..."];
@@ -18770,7 +19281,7 @@ const buildCliMintStateLines = () => {
   if (mintFlowState === "minted") {
     return [
       "minted.",
-      pathId ? `$PATH #${pathId} THOUGHT unit consumed.` : "",
+      pathId ? `$PATH #${pathId} THOUGHT mint used.` : "",
       "use: view tx",
       viewThoughtUseLine(walletState.mintedTokenId),
     ].filter(Boolean);
@@ -18851,9 +19362,9 @@ const startCliMint = async () => {
 
   appendCliOutput([
     "mint THOUGHT.",
-    "keeps current work onchain.",
+    "keeps current work on-chain.",
     "one THOUGHT needs one usable $PATH.",
-    "select $PATH / authorize / confirm.",
+    "pick $PATH / authorize / confirm.",
   ]);
   await withCliLoading("loading...", () => openMintFlow("cli"), MINT_PREP_LOADING_DETAILS);
   appendCliMintState();
@@ -18903,9 +19414,9 @@ const cliPathHelpLines = () => {
     "$PATH is mint permission.",
     "",
     "one THOUGHT needs one usable $PATH.",
-    "select $PATH / authorize / confirm.",
+    "pick $PATH / authorize / confirm.",
     "",
-    `current: ${currentPath ? `#${currentPath}` : "not selected"}`,
+    `current: ${currentPath ? `#${currentPath}` : "not picked"}`,
     "",
     "use:",
     "path list",
@@ -18983,12 +19494,12 @@ const fetchPathTokenIdsForWalletFromApi = async (walletAddress: string) => {
     cache: "default",
   });
   if (!response.ok) {
-    throw new Error(`PATH token API unavailable: ${response.status}`);
+    throw new Error(`$PATH token API unavailable: ${response.status}`);
   }
 
   const payload = (await response.json()) as { items?: unknown };
   if (!Array.isArray(payload.items)) {
-    throw new Error("PATH token API returned invalid payload.");
+    throw new Error("$PATH token API returned invalid payload.");
   }
 
   const wallet = walletAddress.toLowerCase();
@@ -19102,7 +19613,7 @@ const readWalletPathInventory = async (walletAddress: string): Promise<PathInven
 
 const appendCliPathInventory = (ownedPaths: Array<{ pathId: bigint; status: string }>) => {
   appendCliOutput([
-    "wallet $PATHs for THOUGHT mint.",
+    "wallet $PATH tokens for THOUGHT mint.",
     `wallet: ${formatCliAddress(walletState.address ?? "")}`,
     "",
     ...(ownedPaths.length
@@ -19120,7 +19631,7 @@ const listCliPaths = async () => {
 
     if (!walletState.address) {
       appendCliOutput([
-        "wallet $PATHs for THOUGHT mint.",
+        "wallet $PATH tokens for THOUGHT mint.",
         "",
         "wallet not connected.",
         "use: wallet connect",
@@ -19129,7 +19640,7 @@ const listCliPaths = async () => {
     }
 
     if (walletState.chainId !== THOUGHT_CHAIN_ID) {
-      appendCliError(["wallet $PATHs for THOUGHT mint.", "", ...cliWrongNetworkLines()]);
+      appendCliError(["wallet $PATH tokens for THOUGHT mint.", "", ...cliWrongNetworkLines()]);
       return;
     }
 
@@ -19137,7 +19648,7 @@ const listCliPaths = async () => {
       const inventory = await readWalletPathInventory(walletState.address);
       if (inventory.kind === "unavailable") {
         appendCliOutput([
-          "wallet $PATHs for THOUGHT mint.",
+          "wallet $PATH tokens for THOUGHT mint.",
           "",
           inventory.message,
           "need $PATH: mint-path",
@@ -19148,7 +19659,7 @@ const listCliPaths = async () => {
       appendCliPathInventory(inventory.items);
     } catch {
       appendCliOutput([
-        "wallet $PATHs for THOUGHT mint.",
+        "wallet $PATH tokens for THOUGHT mint.",
         "",
         "path list unavailable.",
         "use: path <id>",
@@ -19196,8 +19707,8 @@ const checkCliPath = async (pathInput: string) => {
 
   if (mintFlowState === "path_ready") {
     appendCliOutput([
-      `$PATH #${mintFlowData.pathId?.toString() ?? trimmed} selected.`,
-      "THOUGHT unit available.",
+      `$PATH #${mintFlowData.pathId?.toString() ?? trimmed} picked.`,
+      "THOUGHT mint available.",
       "use: authorize",
     ]);
   } else if (mintFlowState === "wallet_required") {
@@ -19228,13 +19739,13 @@ const authorizeFromCli = async () => {
 
   const pathId = selectedCliPathId() || "?";
   appendCliOutput([
-    "authorize PATH for THOUGHT.",
+    "authorize $PATH for THOUGHT.",
     "review before opening your wallet.",
     "",
     ...cliNetworkReviewRows(),
     cliReviewRow("$PATH", `#${pathId}`),
     cliReviewRow("contract", cliReviewContract("PathNFT", PATH_NFT_ADDRESS)),
-    cliReviewRow("signature", "PATH consume authorization"),
+    cliReviewRow("signature", "$PATH consume authorization"),
     cliReviewRow("executor", cliReviewContract("ThoughtNFT", THOUGHT_NFT_ADDRESS)),
     cliReviewRow("ETH sent", "0 ETH"),
     cliReviewRow("network gas", "none"),
@@ -19281,9 +19792,9 @@ const cliConfirmPreviewLines = async () => {
     cliReviewRow("contract", cliReviewContract("ThoughtNFT", THOUGHT_NFT_ADDRESS)),
     cliReviewRow("function", "mint(string,uint256,bytes32,bytes32,bytes32,string,uint256,bytes)"),
     cliReviewRow("$PATH", `#${pathId}`),
-    cliReviewRow("consumes", "1 THOUGHT unit"),
+    cliReviewRow("uses", "1 THOUGHT mint"),
     cliReviewRow("ETH sent", "0 ETH"),
-    cliReviewRow("authorization", "PATH signature attached"),
+    cliReviewRow("authorization", "$PATH signature attached"),
     cliReviewRow("network gas", "shown in wallet"),
     "",
     `work: ${quoteCliFullText(text)}`,
@@ -19478,7 +19989,7 @@ const cliHelpLines = (topic = "") => {
       "prompt   write intention",
       "run      one model round",
       "preview  validate candidate through contract",
-      "mint     keep the work onchain",
+      "mint     keep the work on-chain",
       "",
       "my-brain:",
       "return   enter the model return",
@@ -19551,7 +20062,7 @@ const cliHelpLines = (topic = "") => {
       "",
       "5 mint",
       "  one THOUGHT needs one $PATH.",
-      "  select $PATH / authorize / confirm.",
+      "  pick $PATH / authorize / confirm.",
       "",
       "my-brain route:",
       "  return enters the model return.",
@@ -19806,9 +20317,9 @@ const cliHelpLines = (topic = "") => {
   if (normalizedTopic === "mint") {
     return [
       "mint THOUGHT.",
-      "keeps current work onchain.",
+      "keeps current work on-chain.",
       "one THOUGHT needs one $PATH.",
-      "select $PATH / authorize / confirm.",
+      "pick $PATH / authorize / confirm.",
       "",
       "use:",
       "mint",
@@ -20075,7 +20586,7 @@ const executeCliCommand = async (rawCommand: string) => {
       await startCliMint();
     } else if (lowerHead === "mint-path") {
       appendCliOutput("opening $PATH...");
-      handleMintPath();
+      await handleMintPath({ submit: true });
     } else if (lowerHead === "path") {
       await checkCliPath(rest);
     } else if (lowerHead === "authorize") {
@@ -20299,6 +20810,26 @@ thoughtDockPrompt.addEventListener("keydown", (event) => {
   }
 });
 
+thoughtDockWorksSelect.addEventListener("change", () => {
+  const id = parseWorkId(thoughtDockWorksSelect.value);
+  const work = id === null ? null : getWorkById(readStoredThoughtWorks(), id);
+  if (!work || !loadWorkRecord(work)) {
+    return;
+  }
+  emitThoughtConsoleEvent({
+    kind: "work_loaded",
+    title: "work loaded",
+    detail: work.prompt || work.runContext.prompt,
+    tone: "success",
+    eventId: `work-loaded:${work.id}:${Date.now()}`,
+  });
+  syncInterface();
+});
+
+thoughtDockPathInventorySelect.addEventListener("change", () => {
+  handlePathInventorySelectChange(thoughtDockPathInventorySelect);
+});
+
 promptBox.addEventListener("keydown", (event) => {
   if (event.key === "Enter" && !event.isComposing) {
     event.preventDefault();
@@ -20333,27 +20864,11 @@ mintSheetPathBox.addEventListener("input", () => {
   syncInterface();
 });
 
-thoughtDockPathBox.addEventListener("input", () => {
-  applyMintPathInputValue(thoughtDockPathBox.value);
-  syncInterface();
-});
-
 mintSheetPathSelect.addEventListener("change", () => {
   handlePathInventorySelectChange(mintSheetPathSelect);
 });
 
-thoughtDockPathSelect.addEventListener("change", () => {
-  handlePathInventorySelectChange(thoughtDockPathSelect);
-});
-
 mintSheetPathBox.addEventListener("keydown", (event) => {
-  if (event.key === "Enter" && !event.isComposing) {
-    event.preventDefault();
-    void handleMintSheetAction(mintSheetPrimaryAction);
-  }
-});
-
-thoughtDockPathBox.addEventListener("keydown", (event) => {
   if (event.key === "Enter" && !event.isComposing) {
     event.preventDefault();
     void handleMintSheetAction(mintSheetPrimaryAction);
@@ -20728,7 +21243,11 @@ const initFrontpage = async () => {
     resumedPathMint = await resumePathMintHandoff();
   }
   if (!resumedPendingMint && !resumedPathMint) {
-    recordCurrentMintConsoleState();
+    if (mintDockRevealed) {
+      await mintThoughtDockWork();
+    } else {
+      recordCurrentMintConsoleState();
+    }
   }
   syncInterface();
 

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -37,7 +37,11 @@ import {
   buildContractStatusSections,
   findContractStatusRow,
   installInshellAnonymousAnalytics,
+  isPathMintHandoffId,
   maybeInstallCloudflareWebAnalytics,
+  readPathMintReturnRecord,
+  removePathMintReturnRecord,
+  writePathMintReturnRecord,
   resolveWalletChainRpcUrls,
   shouldShowPreviewWatermark,
   trackInshellAnonymousAnalytics,
@@ -120,7 +124,45 @@ import {
   type MintFlowUiMode,
   type ThoughtAuthorizationStage,
 } from "./thought-mint-ui";
-import { buildThoughtConsoleLines } from "./thought-console";
+import {
+  THOUGHT_CONSOLE_HISTORY_STORAGE_KEY,
+  appendThoughtConsoleContextBoundary,
+  appendThoughtConsoleEvent,
+  buildThoughtConsoleLines,
+  createThoughtConsoleHistory,
+  parseThoughtConsoleHistory,
+  serializeThoughtConsoleHistory,
+  type ThoughtConsoleContext,
+  type ThoughtConsoleTone,
+} from "./thought-console";
+import {
+  presentThoughtMint,
+  type ThoughtMintPresentation,
+} from "./thought-mint-presentation";
+import {
+  THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY,
+  THOUGHT_PENDING_MINT_TX_STORAGE_KEY,
+  classifyMintTrackingFailure,
+  createMintSubmissionContext,
+  createPendingMintTransaction,
+  mintReceiptStatusOutcome,
+  parsePendingMintTransaction,
+  parseConflictingMintTransactions,
+  parseMintTransactionReplacement,
+  pendingMintTransactionMatches,
+  planPendingMintRestore,
+  replacePendingMintTransactionHash,
+  serializePendingMintTransaction,
+  serializeConflictingMintTransactions,
+  type MintSubmissionContext,
+  type PendingMintTransaction,
+} from "./thought-mint-transaction";
+import {
+  createMintAttemptId,
+  waitForMintSubmissionOrRelease,
+  withMintSubmissionLock,
+  type MintSubmissionLockEnvironment,
+} from "./thought-mint-submission-lock";
 import { canonicalThoughtTitle, thoughtProtocolText } from "./thought-display-text";
 import {
   THOUGHT_V2_LOCAL_MAX_PROVENANCE_BYTES,
@@ -340,6 +382,9 @@ type MintFlowErrorKind =
   | "path_consumed"
   | "path_not_ready"
   | "path_unknown"
+  | "path_mint_pending"
+  | "path_mint_chain_mismatch"
+  | "wallet_account_mismatch"
   | "wrong_network"
   | "funds"
   | "signature"
@@ -439,6 +484,7 @@ type MintSheetAction =
   | "enter_path_manually"
   | "mint_path"
   | "refresh"
+  | "recover_submission"
   | "reset"
   | "switch_network";
 
@@ -518,6 +564,21 @@ type MintFlowData = {
   txHash: string;
   error: string;
   errorKind: MintFlowErrorKind;
+};
+
+type PathMintHandoff = {
+  version: 1;
+  attemptId: string;
+  workHash: string;
+  account: string;
+  chainId?: number | null;
+  work?: {
+    output: string;
+    svg: string;
+    runContext: ThoughtRunContext | null;
+    workId: number | null;
+  };
+  createdAt: number;
 };
 
 type PathInventoryItem = {
@@ -823,6 +884,7 @@ const THOUGHT_CLI_TRANSCRIPT_STORAGE_KEY = "thought-cli-transcript";
 const THOUGHT_OUTPUT_STORAGE_KEY = "thought-current-output";
 const THOUGHT_INSTRUCTIONS_OVERRIDE_KEY = "thought-instructions-override";
 const THOUGHT_AGENT_PENDING_RUN_STORAGE_KEY = "thought-agent-pending-run";
+const THOUGHT_PATH_MINT_HANDOFF_STORAGE_KEY = "thought-path-mint-handoff-v1";
 const ENABLE_THOUGHT_UPLOAD = window.location.port === "5188";
 const OPENROUTER_PKCE_VERIFIER_KEY = "thought-openrouter-pkce-verifier";
 const OPENROUTER_AUTH_URL = "https://openrouter.ai/auth";
@@ -854,46 +916,185 @@ const getStorageOrNull = (storage: () => Storage | null | undefined) => {
   }
 };
 
-const getSharedBrowserStorage = () =>
-  getStorageOrNull(() => window.localStorage) ??
-  getStorageOrNull(() => window.sessionStorage);
-
 const getSessionStorage = () => getStorageOrNull(() => window.sessionStorage);
 
+const mintSubmissionLockEnvironment = (): MintSubmissionLockEnvironment => ({
+  locks: typeof navigator.locks?.request === "function"
+    ? navigator.locks as unknown as MintSubmissionLockEnvironment["locks"]
+    : null,
+  crypto: window.crypto,
+});
+
+const safeStorageGet = (storage: Storage | null, key: string) => {
+  try {
+    return storage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const safeStorageSet = (storage: Storage | null, key: string, value: string) => {
+  try {
+    if (!storage) return false;
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const safeStorageRemove = (storage: Storage | null, key: string) => {
+  try {
+    storage?.removeItem(key);
+  } catch {
+    // Browser storage is only the durable copy; live state remains in memory.
+  }
+};
+
+const getPathMintReturnStorageHost = () => ({
+  localStorage: getStorageOrNull(() => window.localStorage),
+  sessionStorage: getSessionStorage(),
+});
+
 const readSharedBrowserItem = (key: string) => {
-  const shared = getSharedBrowserStorage();
-  const raw = shared?.getItem(key) ?? null;
+  const local = getStorageOrNull(() => window.localStorage);
+  const session = getSessionStorage();
+  const raw = safeStorageGet(local, key);
   if (raw !== null) {
     return raw;
   }
 
-  const session = getSessionStorage();
-  const legacy = session?.getItem(key) ?? null;
-  if (legacy !== null && shared && shared !== session) {
-    shared.setItem(key, legacy);
+  const legacy = safeStorageGet(session, key);
+  if (legacy !== null && safeStorageSet(local, key, legacy)) {
+    safeStorageRemove(session, key);
   }
   return legacy;
 };
 
 const writeSharedBrowserItem = (key: string, value: string) => {
-  const shared = getSharedBrowserStorage();
-  if (!shared) return;
-  shared.setItem(key, value);
+  const local = getStorageOrNull(() => window.localStorage);
   const session = getSessionStorage();
-  if (session && shared !== session) {
-    session.removeItem(key);
+  if (safeStorageSet(local, key, value)) {
+    safeStorageRemove(session, key);
+    return;
   }
+  safeStorageSet(session, key, value);
 };
 
 const removeSharedBrowserItem = (key: string) => {
-  getSharedBrowserStorage()?.removeItem(key);
-  getSessionStorage()?.removeItem(key);
+  safeStorageRemove(getStorageOrNull(() => window.localStorage), key);
+  safeStorageRemove(getSessionStorage(), key);
 };
 
 const thoughtBrowserStorage: WorkStorage = {
   getItem: readSharedBrowserItem,
   setItem: writeSharedBrowserItem,
   removeItem: removeSharedBrowserItem,
+};
+
+const readPendingMintTransaction = (): PendingMintTransaction | null => {
+  const local = getStorageOrNull(() => window.localStorage);
+  const session = getSessionStorage();
+  const plan = planPendingMintRestore({
+    currentRaw: safeStorageGet(local, THOUGHT_PENDING_MINT_TX_STORAGE_KEY),
+    legacySessionRaw: safeStorageGet(session, THOUGHT_PENDING_MINT_TX_STORAGE_KEY),
+  });
+
+  if (plan.persistedRaw) {
+    writeSharedBrowserItem(THOUGHT_PENDING_MINT_TX_STORAGE_KEY, plan.persistedRaw);
+  } else if (!plan.transaction) {
+    removeSharedBrowserItem(THOUGHT_PENDING_MINT_TX_STORAGE_KEY);
+  }
+  return plan.transaction;
+};
+
+const writePendingMintTransaction = (transaction: PendingMintTransaction | null) => {
+  if (!transaction) {
+    removeSharedBrowserItem(THOUGHT_PENDING_MINT_TX_STORAGE_KEY);
+    return;
+  }
+  writeSharedBrowserItem(
+    THOUGHT_PENDING_MINT_TX_STORAGE_KEY,
+    serializePendingMintTransaction(transaction),
+  );
+};
+
+const readConflictingMintTransactions = () =>
+  [...parseConflictingMintTransactions(
+    readSharedBrowserItem(THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY),
+  )];
+
+const writeConflictingMintTransactions = (
+  transactions: readonly PendingMintTransaction[],
+) => {
+  if (transactions.length === 0) {
+    removeSharedBrowserItem(THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY);
+    return;
+  }
+  writeSharedBrowserItem(
+    THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY,
+    serializeConflictingMintTransactions(transactions),
+  );
+};
+
+const pathMintHandoffStorageKey = (attemptId: string) =>
+  `${THOUGHT_PATH_MINT_HANDOFF_STORAGE_KEY}:${attemptId}`;
+
+const writePathMintHandoff = (handoff: PathMintHandoff) => {
+  writeSharedBrowserItem(
+    pathMintHandoffStorageKey(handoff.attemptId),
+    JSON.stringify(handoff),
+  );
+};
+
+const removePathMintHandoff = (attemptId: string) => {
+  removeSharedBrowserItem(pathMintHandoffStorageKey(attemptId));
+  removeSharedBrowserItem(THOUGHT_PATH_MINT_HANDOFF_STORAGE_KEY);
+};
+
+const readPathMintHandoff = (): PathMintHandoff | null => {
+  const handoffId = new URLSearchParams(window.location.search).get("pathHandoff")?.trim() ?? "";
+  if (handoffId && !isPathMintHandoffId(handoffId)) {
+    return null;
+  }
+  const storageKey = handoffId
+    ? pathMintHandoffStorageKey(handoffId)
+    : THOUGHT_PATH_MINT_HANDOFF_STORAGE_KEY;
+  const raw = readSharedBrowserItem(storageKey);
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw) as Partial<PathMintHandoff>;
+    const work = value.work as Partial<NonNullable<PathMintHandoff["work"]>> | undefined;
+    if (
+      value.version !== 1 ||
+      !isPathMintHandoffId(value.attemptId) ||
+      typeof value.workHash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(value.workHash) ||
+      typeof value.account !== "string" ||
+      (value.account !== "" && !/^0x[0-9a-fA-F]{40}$/.test(value.account)) ||
+      (value.chainId !== undefined && value.chainId !== null && typeof value.chainId !== "number") ||
+      (work !== undefined && (
+        typeof work.output !== "string" ||
+        !work.output ||
+        typeof work.svg !== "string" ||
+        (work.workId !== null && work.workId !== undefined &&
+          (!Number.isSafeInteger(work.workId) || Number(work.workId) <= 0))
+      )) ||
+      typeof value.createdAt !== "number" ||
+      Date.now() - value.createdAt > 86_400_000
+    ) {
+      removeSharedBrowserItem(storageKey);
+      return null;
+    }
+    if (handoffId && value.attemptId !== handoffId) {
+      removeSharedBrowserItem(storageKey);
+      return null;
+    }
+    return value as PathMintHandoff;
+  } catch {
+    removeSharedBrowserItem(storageKey);
+    return null;
+  }
 };
 
 const readStoredThoughtWorks = () => readThoughtWorks(thoughtBrowserStorage);
@@ -980,7 +1181,10 @@ const PREFLIGHT_REQUEST_TIMEOUT_MS = 15000;
 const PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS = 15000;
 const WALLET_TX_SUBMIT_TIMEOUT_MS = 60000;
 const MINT_RECEIPT_TIMEOUT_MS = 120000;
+const MINT_RECEIPT_WAIT_TIMEOUT_MS = 15000;
 const MINT_RECEIPT_POLL_MS = 1000;
+const MINT_RECOVERY_NONCE_RECHECK_MS = 1200;
+const MINT_RECEIPT_MONITOR_TIMEOUT_MESSAGE = "mint receipt monitoring timed out.";
 const CHAIN_LOADING_DETAIL_MS = 1400;
 const CLI_PROGRESS_DETAIL_ROTATE_TICKS = 3;
 const CLI_COMMAND_HISTORY_LIMIT = 80;
@@ -1747,8 +1951,12 @@ const thoughtDockPathOptions = document.getElementById("thought-dock-path-option
 const thoughtDockPathSelect = document.getElementById("thought-dock-path-select") as HTMLSelectElement | null;
 const thoughtDockPathProvenance = document.getElementById("thought-dock-path-provenance") as HTMLElement | null;
 const thoughtDockPathStatus = document.getElementById("thought-dock-path-status") as HTMLElement | null;
+const thoughtDockPathReview = document.getElementById("thought-dock-path-review") as (HTMLElement & { open: boolean }) | null;
+const thoughtDockPathReviewSummary = document.getElementById("thought-dock-path-review-summary") as HTMLElement | null;
 const thoughtDockPathContext = document.getElementById("thought-dock-path-context") as HTMLElement | null;
 const thoughtDockPathFlow = document.getElementById("thought-dock-path-flow") as HTMLElement | null;
+const thoughtDockPathTitle = document.getElementById("thought-dock-path-title") as HTMLElement | null;
+const thoughtDockPathDetail = document.getElementById("thought-dock-path-detail") as HTMLElement | null;
 const thoughtDockPathPrimary = document.getElementById("thought-dock-path-primary") as HTMLButtonElement | null;
 const thoughtDockPathSecondary = document.getElementById("thought-dock-path-secondary") as HTMLButtonElement | null;
 const thoughtDockPathTertiary = document.getElementById("thought-dock-path-tertiary") as HTMLButtonElement | null;
@@ -1939,8 +2147,12 @@ if (
   !thoughtDockPathSelect ||
   !thoughtDockPathProvenance ||
   !thoughtDockPathStatus ||
+  !thoughtDockPathReview ||
+  !thoughtDockPathReviewSummary ||
   !thoughtDockPathContext ||
   !thoughtDockPathFlow ||
+  !thoughtDockPathTitle ||
+  !thoughtDockPathDetail ||
   !thoughtDockPathPrimary ||
   !thoughtDockPathSecondary ||
   !thoughtDockPathTertiary ||
@@ -2235,7 +2447,14 @@ const refreshThoughtDockPolling = () => {
   thoughtDockPollWakeScheduler.pollNow();
 };
 let thoughtDockRailSignature = "";
-let thoughtDockConsoleSignature = "";
+let thoughtConsoleHistory = parseThoughtConsoleHistory(
+  getSessionStorage()?.getItem(THOUGHT_CONSOLE_HISTORY_STORAGE_KEY) ?? "",
+);
+const nextMintAttemptId = (prefix = "mint") =>
+  createMintAttemptId(prefix, window.crypto);
+let mintAttemptId = nextMintAttemptId("idle");
+let mintErrorSequence = 0;
+let mintTransactionRequestId = 0;
 let thoughtDockRailInsetFrame = 0;
 
 const AGENT_DEMO_GLYPH_COLORS = [
@@ -3111,65 +3330,217 @@ const thoughtDockConsoleTime = () =>
     second: "2-digit",
   });
 
-const thoughtDockConsoleTitle = (
-  rail: DockRailView,
-  panelStatus: ThoughtPanelStatusView,
-) => {
-  if (rail.detail.kind !== "error") {
-    return panelStatus.title;
-  }
+const currentThoughtConsoleWorkHash = () =>
+  pendingMintTransaction?.workHash ||
+  mintFlowData.textHash ||
+  (currentOutputText ? keccak256(toUtf8Bytes(currentOutputText)) : "");
 
-  const detailTitle = rail.detail.title.trim();
-  return detailTitle && detailTitle.toLowerCase() !== "error"
-    ? detailTitle
-    : panelStatus.title;
+const currentThoughtConsoleContext = (): ThoughtConsoleContext => ({
+  attemptId: mintAttemptId,
+  ...(currentThoughtConsoleWorkHash()
+    ? { workHash: currentThoughtConsoleWorkHash() }
+    : {}),
+  ...((pendingMintTransaction?.account || walletState.address)
+    ? { account: pendingMintTransaction?.account || walletState.address }
+    : {}),
+  ...((pendingMintTransaction?.chainId ?? walletState.chainId) !== null
+    ? { chainId: pendingMintTransaction?.chainId ?? walletState.chainId ?? undefined }
+    : {}),
+  deploymentFingerprint: [
+    THOUGHT_CHAIN_ID,
+    PATH_NFT_ADDRESS.toLowerCase(),
+    THOUGHT_NFT_ADDRESS.toLowerCase(),
+    EVM_ADDRESSES.protocolRelease?.id?.trim().toLowerCase() ?? "",
+  ].join(":"),
+});
+
+const writeThoughtConsoleHistory = () => {
+  try {
+    getSessionStorage()?.setItem(
+      THOUGHT_CONSOLE_HISTORY_STORAGE_KEY,
+      serializeThoughtConsoleHistory(thoughtConsoleHistory),
+    );
+  } catch {
+    // The console remains available in memory when browser storage is denied.
+  }
 };
 
-const thoughtDockConsoleDetail = (
-  rail: DockRailView,
-  panelStatus: ThoughtPanelStatusView,
+const emitThoughtConsoleEvent = (input: {
+  kind: string;
+  title: string;
+  detail?: string;
+  eventId?: string;
+  tone?: ThoughtConsoleTone;
+  transient?: boolean;
+}) => {
+  const next = appendThoughtConsoleEvent(thoughtConsoleHistory, {
+    ...input,
+    time: thoughtDockConsoleTime(),
+    context: currentThoughtConsoleContext(),
+  });
+  if (next === thoughtConsoleHistory) {
+    return;
+  }
+  thoughtConsoleHistory = next;
+  writeThoughtConsoleHistory();
+};
+
+const recordThoughtConsoleContextBoundary = (input?: {
+  kind?: string;
+  title?: string;
+  detail?: string;
+  tone?: ThoughtConsoleTone;
+}) => {
+  const next = appendThoughtConsoleContextBoundary(thoughtConsoleHistory, {
+    ...input,
+    time: thoughtDockConsoleTime(),
+    context: currentThoughtConsoleContext(),
+  });
+  if (next === thoughtConsoleHistory) return;
+  thoughtConsoleHistory = next;
+  writeThoughtConsoleHistory();
+};
+
+const thoughtConsoleToneForPresentation = (
+  presentation: ThoughtMintPresentation,
+): ThoughtConsoleTone => {
+  if (presentation.tone === "error") return "error";
+  if (presentation.tone === "warning") return "warning";
+  if (presentation.tone === "success") return "success";
+  return "neutral";
+};
+
+const recordMintConsoleState = (
+  state: ThoughtDockState,
+  presentation: ThoughtMintPresentation,
 ) => {
-  if (rail.detail.kind === "error") {
-    return rail.detail.body;
+  if (state.kind === "work_ready" && mintFlowState === "closed") {
+    emitThoughtConsoleEvent({
+      kind: "work_ready",
+      title: "work ready",
+      detail: presentation.detail,
+      eventId: `work-ready:${currentRunContext?.clientGeneratedAt ?? currentOutputText}`,
+    });
+    return;
   }
-  if (rail.detail.kind === "wallet" || rail.detail.kind === "path") {
-    return rail.detail.message;
+
+  if (mintFlowState === "closed") {
+    return;
   }
-  return panelStatus.detail;
+
+  const base = {
+    title: presentation.title,
+    detail: presentation.detail,
+    tone: thoughtConsoleToneForPresentation(presentation),
+  };
+
+  if (mintFlowState === "thought_checking" || mintFlowState === "path_checking") {
+    return;
+  }
+  if (mintFlowState === "wallet_required") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "wallet_needed",
+      eventId: `wallet-needed:${mintAttemptId}`,
+    });
+    return;
+  }
+  if (mintFlowState === "path_required") {
+    if (!pathInventoryMatchesCurrentWallet() || pathInventoryState.status === "idle" || pathInventoryState.status === "loading") {
+      return;
+    }
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: pathInventoryState.status === "loaded" ? "path_inventory_loaded" : "path_inventory_unavailable",
+      eventId: `path-inventory:${pathInventoryState.status}:${pathInventoryState.items.map((item) => `${item.pathId.toString()}:${item.status}`).join(",")}:${pathInventoryState.error}`,
+    });
+    return;
+  }
+  if (mintFlowState === "path_ready") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "path_selected",
+      detail: mintFlowData.pathId ? `PATH #${mintFlowData.pathId.toString()} · 1 THOUGHT mint available` : base.detail,
+    });
+    return;
+  }
+  if (mintFlowState === "authorizing") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "authorization_requested",
+      detail: "wallet request 1 of 2 · no transaction · no gas",
+      eventId: `authorization-requested:${mintAuthorizationRequestId}`,
+    });
+    return;
+  }
+  if (mintFlowState === "authorized") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "authorization_signed",
+      detail: mintFlowData.pathId
+        ? `PATH #${mintFlowData.pathId.toString()} · valid until ${new Date(Number(mintFlowData.deadline ?? 0n) * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+        : base.detail,
+      eventId: `authorization-signed:${mintAuthorizationRequestId}`,
+    });
+    return;
+  }
+  if (mintFlowState === "minting") {
+    const txHash = walletState.txHash || mintFlowData.txHash;
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: txHash ? "transaction_submitted" : "transaction_requested",
+      detail: txHash ? `${shortHex(txHash, 10, 8)} · waiting for confirmation` : "wallet request 2 of 2 · transaction · gas applies",
+      eventId: txHash ? `transaction:${txHash.toLowerCase()}` : `transaction-requested:${mintTransactionRequestId}`,
+    });
+    return;
+  }
+  if (mintFlowState === "minted" || state.kind === "minted") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "transaction_confirmed",
+      eventId: `minted:${walletState.mintedTokenId ?? mintFlowData.existingTokenId ?? walletState.txHash ?? mintFlowData.txHash}`,
+    });
+    return;
+  }
+  if (mintFlowState === "text_taken") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: "thought_exists",
+      eventId: `existing:${mintFlowData.existingTokenId ?? mintFlowData.textHash}`,
+    });
+    return;
+  }
+  if (mintFlowState === "error") {
+    emitThoughtConsoleEvent({
+      ...base,
+      kind: `${mintFlowData.errorKind || "mint"}_failed`,
+      eventId: `mint-error:${mintErrorSequence}`,
+    });
+  }
+};
+
+const renderThoughtConsoleHistory = () => {
+  const entries = [...thoughtConsoleHistory.entries].reverse().map((entry) => {
+    const tone: DockRailTone = entry.tone === "neutral" ? "idle" : entry.tone;
+    const lines = buildThoughtConsoleLines(entry).map((line, index) => statusScreenLine(line, {
+      heading: index === 0,
+      tone: index < 2 ? tone : undefined,
+    }));
+    const element = statusScreenEntry(lines);
+    element.dataset.attemptId = entry.context.attemptId;
+    element.classList.toggle("is-boundary", entry.boundary);
+    element.classList.toggle("is-current-attempt", entry.context.attemptId === mintAttemptId);
+    return element;
+  });
+  thoughtDockDetailsBody.replaceChildren(...entries);
+  thoughtDockDetails.hidden = false;
 };
 
 const renderThoughtDockDetails = (
-  rail: DockRailView,
-  panelStatus: ThoughtPanelStatusView,
+  _state: ThoughtDockState,
+  _presentation: ThoughtMintPresentation,
 ) => {
-  const title = thoughtDockConsoleTitle(rail, panelStatus);
-  const detail = thoughtDockConsoleDetail(rail, panelStatus);
-  const actions = rail.actions
-    .filter((action) => !action.disabled)
-    .map((action) => action.label);
-  const signature = JSON.stringify({ actions, detail, title, tone: rail.tone });
-  if (signature === thoughtDockConsoleSignature) {
-    thoughtDockDetails.hidden = false;
-    return;
-  }
-  thoughtDockConsoleSignature = signature;
-
-  const consoleLines = buildThoughtConsoleLines({
-    time: thoughtDockConsoleTime(),
-    title,
-    detail,
-    actions,
-  });
-  const lines = consoleLines.map((line, index) => statusScreenLine(line, {
-    heading: index === 0,
-    tone: index < 2 ? rail.tone : undefined,
-  }));
-
-  thoughtDockDetails.hidden = false;
-  thoughtDockDetailsBody.prepend(statusScreenEntry(lines));
-  requestAnimationFrame(() => {
-    thoughtDockDetails.scrollTop = 0;
-  });
+  renderThoughtConsoleHistory();
 };
 
 const getResolvedThoughtDockState = (): ThoughtDockState => {
@@ -3390,13 +3761,12 @@ const getThoughtDockRailView = (state: ThoughtDockState): DockRailView => {
     return { actions: [mintResetAction()] };
   };
   const mintFlowRail = (): DockRailView => {
-    const { actions, maxActions } = mintFlowActions();
+    const presentation = getCurrentMintPresentation();
     return {
-      status: mintFlowStatus(),
-      tone: mintFlowTone(),
-      actions,
-      detail: mintFlowDetail(),
-      maxActions,
+      status: "",
+      tone: presentation.tone,
+      actions: [],
+      detail: { kind: "none" },
     };
   };
 
@@ -3605,6 +3975,45 @@ const shortRunId = (runId: string) =>
 
 const isInjectedWalletMissing = () => !walletState.detected && !getEthereumProvider();
 
+const getCurrentMintPresentation = () => presentThoughtMint({
+  state: mintFlowState,
+  mintEnabled: THOUGHT_V2_MINT_ENABLED,
+  providerDetected: !isInjectedWalletMissing(),
+  walletRequestPending: walletConnectInFlight,
+  address: walletState.address,
+  chainId: walletState.chainId,
+  requiredChainId: THOUGHT_CHAIN_ID,
+  chainName: THOUGHT_CHAIN_NAME,
+  inventory: {
+    status: pathInventoryState.status,
+    matchesWallet: pathInventoryMatchesCurrentWallet(),
+    held: pathInventoryState.items.length,
+    available: availablePathInventoryItems().length,
+    error: pathInventoryState.error,
+  },
+  pathId: mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim(),
+  existingTokenId: walletState.mintedTokenId ?? mintFlowData.existingTokenId,
+  authorization: {
+    signed: Boolean(mintFlowData.signature && mintFlowData.deadline),
+    deadline: mintFlowData.deadline,
+  },
+  transaction: {
+    state: walletState.txState,
+    hash: walletState.txHash || mintFlowData.txHash,
+  },
+  error: {
+    kind: mintFlowData.errorKind,
+    message: mintFlowData.error,
+  },
+});
+
+const recordCurrentMintConsoleState = () => {
+  recordMintConsoleState(
+    getResolvedThoughtDockState(),
+    getCurrentMintPresentation(),
+  );
+};
+
 const visibleMintErrorCopy = () => {
   if (mintFlowData.errorKind === "wrong_network") {
     return "wrong network.";
@@ -3634,82 +4043,12 @@ const visibleMintErrorCopy = () => {
 };
 
 const thoughtPanelStatusForMintFlow = (): ThoughtPanelStatusView => {
-  const selectedPathId = mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim();
-
-  if (mintFlowState === "closed") {
-    const workReady = getThoughtWorkReadyPresentation({
-      mintEnabled: THOUGHT_V2_MINT_ENABLED,
-      walletConnected: Boolean(walletState.address),
-    });
-    return { mode: "ready_to_mint", title: "work ready", detail: workReady.detail };
-  }
-  if (mintFlowState === "thought_checking") {
-    return { mode: "minting", title: "checking THOUGHT", detail: "checking uniqueness and mint state" };
-  }
-  if (mintFlowState === "text_taken") {
-    return {
-      mode: "failed",
-      title: "already minted",
-      detail: "PATH permission is for new THOUGHTs only",
-    };
-  }
-  if (mintFlowState === "wallet_required") {
-    if (isInjectedWalletMissing()) {
-      return { mode: "wallet_needed", title: "no wallet", detail: "install or enable wallet" };
-    }
-    return { mode: "wallet_needed", title: "wallet needed", detail: "connect reads address only" };
-  }
-  if (mintFlowState === "path_required") {
-    if (isPathInventoryReadPending()) {
-      return { mode: "path_needed", title: "checking PATH", detail: "reading wallet PATHs" };
-    }
-    if (pathInventoryMatchesCurrentWallet()) {
-      if (pathInventoryState.status === "unavailable" || pathInventoryState.status === "error") {
-        return { mode: "path_needed", title: "PATH list unavailable", detail: "refresh or enter PATH manually" };
-      }
-      if (pathInventoryState.status === "loaded") {
-        return availablePathInventoryItems().length > 0
-          ? { mode: "path_needed", title: "select PATH", detail: "choose one available PATH" }
-          : { mode: "path_needed", title: "PATH needed", detail: "mint a PATH, then return here" };
-      }
-    }
-    return { mode: "path_needed", title: "checking PATH", detail: "reading wallet PATHs" };
-  }
-  if (mintFlowState === "path_checking") {
-    return {
-      mode: "path_needed",
-      title: "checking PATH",
-      detail: selectedPathId ? `checking PATH #${selectedPathId}` : "checking PATH",
-    };
-  }
-  if (mintFlowState === "path_ready") {
-    return { mode: "path_needed", title: "authorize PATH", detail: "signature only. does not mint" };
-  }
-  if (mintFlowState === "authorizing") {
-    return { mode: "path_needed", title: "authorize PATH", detail: "confirm signature in wallet" };
-  }
-  if (mintFlowState === "authorized") {
-    return {
-      mode: "minting",
-      title: "ready to mint",
-      detail: selectedPathId ? `transaction will consume PATH #${selectedPathId}` : "transaction will consume PATH",
-    };
-  }
-  if (mintFlowState === "minting") {
-    return walletState.txHash || mintFlowData.txHash
-      ? { mode: "minting", title: "minting", detail: "waiting for chain confirmation" }
-      : { mode: "minting", title: "confirm mint", detail: "confirm transaction in wallet" };
-  }
-  if (mintFlowState === "minted") {
-    return { mode: "minted", title: "minted", detail: "official token created" };
-  }
-  if (mintFlowState === "error") {
-    if (mintFlowData.errorKind === "wrong_network") {
-      return { mode: "failed", title: "wrong network", detail: "switch network to continue" };
-    }
-    return { mode: "failed", title: "mint error", detail: visibleMintErrorCopy() };
-  }
-  return { mode: "minting", title: "minting", detail: "waiting for wallet" };
+  const presentation = getCurrentMintPresentation();
+  return {
+    mode: presentation.panelMode,
+    title: presentation.title,
+    detail: presentation.detail,
+  };
 };
 
 const getThoughtPanelStatusView = (state: ThoughtDockState): ThoughtPanelStatusView => {
@@ -3853,7 +4192,7 @@ const getWalletStageView = (state: ThoughtDockState): WalletStripView => {
       detail: "no supported wallet found",
       meta: "install or enable an injected wallet, then refresh.",
       tone: "warning",
-      actions: ["refresh"],
+      actions: [],
     };
   }
 
@@ -3866,7 +4205,7 @@ const getWalletStageView = (state: ThoughtDockState): WalletStripView => {
         ? "disconnected in THOUGHT. to fully remove site access, disconnect this site in your wallet."
         : "read only. no signature. no tx.",
       tone: walletConnectInFlight ? "running" : "idle",
-      actions: walletConnectInFlight ? ["refresh"] : ["connect"],
+      actions: [],
     };
   }
 
@@ -3879,7 +4218,7 @@ const getWalletStageView = (state: ThoughtDockState): WalletStripView => {
       chainLabel: getWalletNetworkLabel(),
       meta: `${shortHex(walletState.address)} · ${getWalletNetworkLabel().toLowerCase()}`,
       tone: "warning",
-      actions: ["switch_network", "disconnect"],
+      actions: [],
     };
   }
 
@@ -3891,7 +4230,7 @@ const getWalletStageView = (state: ThoughtDockState): WalletStripView => {
     chainLabel: getWalletNetworkLabel(),
     meta: pathInventorySummary() || "PATH: not checked",
     tone: walletState.preflightLoading ? "running" : "ready",
-    actions: ["disconnect", "refresh"],
+    actions: [],
   };
 };
 
@@ -3940,15 +4279,24 @@ const renderWalletStripAction = (action: WalletAction) => {
 };
 
 const renderWalletStrip = (state: ThoughtDockState) => {
-  void state;
-  thoughtWalletStrip.classList.add("is-hidden");
-  thoughtWalletStripActions.replaceChildren();
+  const view = getWalletStageView(state);
+  thoughtWalletStrip.classList.toggle("is-hidden", !view.visible);
+  thoughtWalletStrip.dataset.tone = view.tone;
+  thoughtWalletStripTitle.textContent = view.title;
+  thoughtWalletStripDetail.textContent = view.detail;
+  thoughtWalletStripDetail.title = view.address ?? view.detail;
+  thoughtWalletStripMeta.textContent = view.meta ?? "";
+  thoughtWalletStripMeta.classList.toggle("is-hidden", !view.meta);
+  thoughtWalletStripActions.replaceChildren(
+    ...view.actions.map(renderWalletStripAction),
+  );
 };
 
 const renderThoughtDock = () => {
   const state = getResolvedThoughtDockState();
   const locked = isThoughtDockInputLockedState(state);
   const panelStatus = getThoughtPanelStatusView(state);
+  const mintPresentation = getCurrentMintPresentation();
 
   thoughtDockPrompt.readOnly = locked;
   if (thoughtDockPrompt.value !== sessionState.prompt) {
@@ -4002,7 +4350,7 @@ const renderThoughtDock = () => {
   renderWalletStrip(state);
   syncMintDockPathPanel();
   renderThoughtDockDetailTray({ kind: "none" });
-  renderThoughtDockDetails(rail, panelStatus);
+  renderThoughtDockDetails(state, mintPresentation);
   syncThoughtDockRailInset();
 };
 
@@ -4121,6 +4469,9 @@ const launchThoughtDockAgentLink = (url: string) => {
 };
 
 const openThoughtDockAgentSelect = () => {
+  if (blockPendingMintMutation()) {
+    return;
+  }
   const prompt = thoughtDockPrompt.value;
   if (!prompt.trim()) {
     setThoughtDockState({ kind: "failed", message: "Prompt is empty." });
@@ -4131,6 +4482,9 @@ const openThoughtDockAgentSelect = () => {
 };
 
 const runThoughtDockAdapter = async (adapterId: ThoughtDockAgentAdapterId) => {
+  if (blockPendingMintMutation()) {
+    return;
+  }
   const prompt = thoughtDockPrompt.value;
   if (!prompt) {
     setThoughtDockState({ kind: "failed", message: "Prompt is empty." });
@@ -4451,6 +4805,9 @@ const handleThoughtDockReturnedWork = async (
   if (!isCurrentRunSession(runSessionId)) {
     return;
   }
+  if (blockPendingMintMutation()) {
+    return;
+  }
   thoughtDockRun = {
     ...run,
     candidate: rawCandidate,
@@ -4480,9 +4837,14 @@ const handleThoughtDockReturnedWork = async (
       syncInterface();
       return;
     }
+    if (result.kind === "pending_mint") {
+      blockPendingMintMutation();
+      return;
+    }
     runInFlight = false;
     const work = getThoughtDockWorkView();
     setThoughtDockState(work ? { kind: "work_ready", work } : { kind: "failed", message: "Preview accepted no work." });
+    if (work) recordCurrentMintConsoleState();
     syncInterface();
   } catch (error) {
     if (!isCurrentRunSession(runSessionId)) {
@@ -4517,6 +4879,9 @@ const formatThoughtDockPreviewError = (error: unknown) => {
 };
 
 const retryThoughtDockPreview = async () => {
+  if (blockPendingMintMutation()) {
+    return;
+  }
   if (!currentCandidate && !lastPreviewRetryContext) {
     setThoughtDockState({ kind: "failed", message: "No candidate to preview." });
     return;
@@ -4543,9 +4908,12 @@ const retryThoughtDockPreview = async () => {
     if (attempt.kind === "rejected") {
       throw attempt.error;
     }
-    promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace);
+    if (!promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace)) {
+      return;
+    }
     const work = getThoughtDockWorkView();
     setThoughtDockState(work ? { kind: "work_ready", work } : { kind: "failed", message: "Preview accepted no work." });
+    if (work) recordCurrentMintConsoleState();
     syncInterface();
   } catch (error) {
     setThoughtDockState({
@@ -4556,19 +4924,23 @@ const retryThoughtDockPreview = async () => {
   }
 };
 
-const mintThoughtDockWork = async () => {
+const mintThoughtDockWork = async (options?: { attemptId?: string; pathId?: string }) => {
+  if (blockPendingMintMutation()) {
+    return true;
+  }
   const work = getThoughtDockWorkView();
   if (!work) {
     setThoughtDockState({ kind: "failed", message: "No accepted work to mint." });
-    return;
+    return false;
   }
   if (!THOUGHT_V2_MINT_ENABLED) {
-    resetMintFlow();
+    resetMintFlow({ preserveAttempt: true });
+    mintAttemptId = options?.attemptId?.trim() || nextMintAttemptId("mint");
     mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
     setMintFlowError(THOUGHT_V2_MINT_UNAVAILABLE_COPY, "thought");
     setThoughtDockState({ kind: "minting", work });
     syncInterface();
-    return;
+    return true;
   }
 
   // Enter a meaningful mint state before the Dock renders. Rendering `minting`
@@ -4576,13 +4948,15 @@ const mintThoughtDockWork = async () => {
   mintFlowState = "thought_checking";
   setThoughtDockState({ kind: "minting", work });
   try {
-    await openMintFlow(THOUGHT_PANEL_MINT_UI_MODE);
+    await openMintFlow(THOUGHT_PANEL_MINT_UI_MODE, options);
     syncInterface();
+    return true;
   } catch (error) {
     setThoughtDockState({
       kind: "failed",
       message: error instanceof Error ? error.message : "Mint unavailable.",
     });
+    return false;
   }
 };
 
@@ -4598,13 +4972,16 @@ const connectThoughtDockWallet = async () => {
 
   if (!walletState.address) {
     mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
   if (walletState.chainId !== THOUGHT_CHAIN_ID) {
     setMintFlowError("wrong network.", "wrong_network");
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
@@ -4612,12 +4989,14 @@ const connectThoughtDockWallet = async () => {
     mintFlowState = "path_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
+    recordCurrentMintConsoleState();
   }
   syncInterface();
+  focusMintDockStage("path");
 };
 
 const syncMintFlowAfterWalletCommand = () => {
-  if (mintFlowState === "closed" || mintFlowState === "minted") {
+  if (mintFlowState === "closed" || mintFlowState === "minted" || pendingMintTransaction) {
     return;
   }
 
@@ -4625,6 +5004,7 @@ const syncMintFlowAfterWalletCommand = () => {
     mintFlowState = "wallet_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
+    recordCurrentMintConsoleState();
     return;
   }
 
@@ -4632,6 +5012,7 @@ const syncMintFlowAfterWalletCommand = () => {
     mintFlowState = "error";
     mintFlowData.error = "wrong network.";
     mintFlowData.errorKind = "wrong_network";
+    recordCurrentMintConsoleState();
     return;
   }
 
@@ -4639,6 +5020,7 @@ const syncMintFlowAfterWalletCommand = () => {
     mintFlowState = "path_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
+    recordCurrentMintConsoleState();
   }
 };
 
@@ -4681,6 +5063,7 @@ const switchThoughtDockWalletNetwork = async () => {
 
   if (!walletState.address) {
     mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
     syncInterface();
     return;
   }
@@ -4688,6 +5071,7 @@ const switchThoughtDockWalletNetwork = async () => {
   mintFlowState = walletState.chainId === THOUGHT_CHAIN_ID ? "path_required" : "error";
   mintFlowData.error = walletState.chainId === THOUGHT_CHAIN_ID ? "" : "wrong network.";
   mintFlowData.errorKind = walletState.chainId === THOUGHT_CHAIN_ID ? "none" : "wrong_network";
+  recordCurrentMintConsoleState();
   syncInterface();
 };
 
@@ -4713,6 +5097,9 @@ function cancelThoughtDockRun(run?: AgentDemoRun | null, options?: { clearPrompt
 }
 
 const resetThoughtDock = (options?: { clearPrompt?: boolean; focusPrompt?: boolean }) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   thoughtDockPollGeneration += 1;
   thoughtDockPollWakeScheduler.clearImmediatePoll();
   thoughtDockPollWakeScheduler.wake();
@@ -4733,6 +5120,7 @@ const resetThoughtDock = (options?: { clearPrompt?: boolean; focusPrompt?: boole
   if (options?.focusPrompt) {
     focusThoughtDockPrompt({ preventScroll: true });
   }
+  return true;
 };
 
 const resumeThoughtDockPendingRun = () => {
@@ -5099,6 +5487,7 @@ const walletState: ThoughtWalletState = {
   preflightError: "",
   mintedTokenId: null,
 };
+let walletStateHydrated = false;
 let mintFlowState: MintFlowState = "closed";
 let mintFlowUiMode: MintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
 const mintFlowData: MintFlowData = {
@@ -5125,6 +5514,23 @@ let pathInventoryState: PathInventoryState = {
   items: [],
   error: "",
 };
+let pendingMintTransaction = readPendingMintTransaction();
+let conflictingMintTransactions = readConflictingMintTransactions();
+const conflictingMintReceiptMonitorHashes = new Set<string>();
+let pendingMintReceiptMonitorHash = "";
+let pendingMintReceiptMonitorGeneration = 0;
+let mintAuthorizationInFlight = false;
+let mintTransactionInFlight = false;
+let walletMintSubmitPromiseUnresolved = false;
+let unresolvedMintSubmission: Readonly<{
+  requestId: number;
+  submission: MintSubmissionContext;
+  provider: JsonRpcProvider | BrowserProvider | null;
+  releaseLockAfterRecovery: () => void;
+  releaseCompleted: Promise<void>;
+}> | null = null;
+let activeMintTransactionRequestId = 0;
+let pendingMintStorageListenerBound = false;
 let currentRunContext: ThoughtRunContext | null = null;
 let currentCandidate: ThoughtCandidate | null = null;
 let activeThoughtSpec: ActiveThoughtSpec | null = null;
@@ -5134,6 +5540,8 @@ let thoughtDetailColorFontUrl = "";
 let thoughtDetailProvenanceJsonUrl = "";
 let colorFontPageRawUrl = "";
 let readProvider: JsonRpcProvider | null = null;
+let mintReceiptBrowserProvider: BrowserProvider | null = null;
+let mintReceiptBrowserProviderSource: EthereumProvider | null = null;
 let pathReadProvider: JsonRpcProvider | null = null;
 let readThoughtNFT: Contract | null = null;
 let readColorFontV1: Contract | null = null;
@@ -5698,6 +6106,28 @@ const getReadProvider = () => {
   }
 
   return readProvider;
+};
+
+const getWalletMintReceiptProvider = () => {
+  const ethereum = getEthereumProvider();
+  if (!ethereum) {
+    mintReceiptBrowserProvider = null;
+    mintReceiptBrowserProviderSource = null;
+    return null;
+  }
+  if (!mintReceiptBrowserProvider || mintReceiptBrowserProviderSource !== ethereum) {
+    mintReceiptBrowserProvider = new BrowserProvider(ethereum);
+    mintReceiptBrowserProviderSource = ethereum;
+  }
+  return mintReceiptBrowserProvider;
+};
+
+const getMintReceiptMonitoringProviders = () => {
+  const read = getReadProvider();
+  const wallet = getWalletMintReceiptProvider();
+  return read && wallet
+    ? [read, wallet]
+    : [read ?? wallet].filter(Boolean) as Array<JsonRpcProvider | BrowserProvider>;
 };
 
 const getPathReadProvider = () => {
@@ -7583,6 +8013,120 @@ const clearMintPathSelection = () => {
   clearMintAuthorization();
 };
 
+const isPendingMintDeploymentCompatible = (pending: PendingMintTransaction) =>
+  pending.chainId === THOUGHT_CHAIN_ID &&
+  pending.thoughtNft.toLowerCase() === THOUGHT_NFT_ADDRESS.toLowerCase();
+
+const projectPendingMintTransaction = (
+  pending: PendingMintTransaction,
+  options?: { deploymentWarning?: boolean },
+) => {
+  mintAttemptId = pending.attemptId?.trim() || mintAttemptId || nextMintAttemptId("resume");
+  mintFlowData.textHash = pending.workHash;
+  mintFlowData.pathIdInput = pending.pathId;
+  mintFlowData.pathId = BigInt(pending.pathId);
+  mintFlowData.txHash = pending.hash;
+  walletState.txHash = pending.hash;
+  walletState.txState = "submitted";
+  const deploymentWarning = options?.deploymentWarning === true;
+  const conflictingHashes = conflictingMintTransactions
+    .filter((transaction) => transaction.hash !== pending.hash)
+    .map((transaction) => shortHex(transaction.hash, 10, 8));
+  const trackingWarning = deploymentWarning
+    ? `Automatic confirmation monitoring is unavailable: this hash belongs to chain ${pending.chainId} and contract ${shortHex(pending.thoughtNft)}. Hash retained; do not submit a duplicate.`
+    : conflictingHashes.length > 0
+      ? `Multiple transaction hashes returned (${shortHex(pending.hash, 10, 8)}, ${conflictingHashes.join(", ")}). Tracking all known hashes; do not submit a duplicate.`
+      : "";
+  walletState.txError = trackingWarning;
+  mintFlowData.error = trackingWarning;
+  mintFlowData.errorKind = trackingWarning ? "mint" : "none";
+  mintFlowState = "minting";
+  const work = getThoughtDockWorkView();
+  if (work) {
+    setThoughtDockState({ kind: "minting", work });
+  }
+};
+
+const adoptDurablePendingMintTransaction = () => {
+  if (pendingMintTransaction) {
+    return pendingMintTransaction;
+  }
+  const durable = readPendingMintTransaction();
+  if (!durable) {
+    const retainedConflicts = [
+      ...readConflictingMintTransactions(),
+      ...conflictingMintTransactions,
+    ].filter((transaction, index, all) =>
+      all.findIndex((candidate) => candidate.hash === transaction.hash) === index
+    );
+    const promoted = retainedConflicts[0] ?? null;
+    if (!promoted) {
+      return null;
+    }
+    pendingMintTransaction = promoted;
+    conflictingMintTransactions = retainedConflicts
+      .filter((transaction) => transaction.hash !== promoted.hash);
+    writePendingMintTransaction(promoted);
+    writeConflictingMintTransactions(conflictingMintTransactions);
+    projectPendingMintTransaction(promoted, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(promoted),
+    });
+    return promoted;
+  }
+  pendingMintTransaction = durable;
+  projectPendingMintTransaction(durable, {
+    deploymentWarning: !isPendingMintDeploymentCompatible(durable),
+  });
+  return durable;
+};
+
+const blockPendingMintMutation = (options?: { cli?: boolean }) => {
+  const pending = adoptDurablePendingMintTransaction();
+  const submissionUnresolved = mintTransactionInFlight || walletMintSubmitPromiseUnresolved;
+  if (!pending && !submissionUnresolved) {
+    return false;
+  }
+
+  if (pending) {
+    projectPendingMintTransaction(pending, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(pending),
+    });
+  } else {
+    const work = getThoughtDockWorkView();
+    if (work) {
+      setThoughtDockState({ kind: "minting", work });
+    }
+  }
+  if (currentOutputText) {
+    runState = "output_ready";
+  }
+  runInFlight = false;
+  emitThoughtConsoleEvent({
+    kind: pending ? "pending_mint_preserved" : "wallet_mint_request_preserved",
+    title: pending ? "mint still pending" : "wallet mint request still open",
+    detail: pending
+      ? `Keep tracking ${shortHex(pending.hash, 10, 8)} before changing this work.`
+      : "Resolve or cancel the wallet request before changing this work.",
+    eventId: pending
+      ? `pending-preserved:${pending.hash.toLowerCase()}`
+      : `wallet-request-preserved:${activeMintTransactionRequestId}`,
+  });
+  recordCurrentMintConsoleState();
+  syncInterface();
+  if (options?.cli) {
+    appendCliOutput([
+      pending ? "mint still pending." : "wallet mint request still unresolved.",
+      pending ? `tx: ${shortHex(pending.hash, 10, 8)}` : "resolve or cancel it in your wallet.",
+      "do not submit a duplicate.",
+      pending ? "use: view tx" : "use: current",
+    ]);
+  }
+  if (pending && isPendingMintDeploymentCompatible(pending)) {
+    resumePendingMintReceiptMonitoring();
+  }
+  return true;
+};
+
 function resetPathInventoryState() {
   pathInventoryRequestId += 1;
   pathInventoryState = {
@@ -7594,7 +8138,13 @@ function resetPathInventoryState() {
   };
 }
 
-const resetMintFlow = () => {
+const resetMintFlow = (options?: { preserveAttempt?: boolean }) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
+  if (!options?.preserveAttempt) {
+    mintAttemptId = nextMintAttemptId("idle");
+  }
   mintFlowState = "closed";
   mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
   mintFlowData.rawText = "";
@@ -7611,17 +8161,25 @@ const resetMintFlow = () => {
   mintFlowData.errorKind = "none";
   clearMintAuthorization();
   resetPathInventoryState();
+  return true;
 };
 
 const resetMintRuntimeState = () => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   resetMintFlow();
   walletState.txState = "idle";
   walletState.txError = "";
   walletState.txHash = "";
   walletState.mintedTokenId = null;
+  return true;
 };
 
 const closeMintSheet = () => {
+  if (blockPendingMintMutation()) {
+    return;
+  }
   resetMintFlow();
   syncInterface();
 };
@@ -8034,13 +8592,23 @@ const syncWarningBox = () => {
   updateNotice(warningBox, warningCopy);
 };
 
-const setMintFlowError = (message: string, kind: MintFlowErrorKind = "mint") => {
+const setMintFlowError = (
+  message: string,
+  kind: MintFlowErrorKind = "mint",
+  options: { preserveAuthorization?: boolean; preserveSubmittedTransaction?: boolean } = {},
+) => {
+  mintErrorSequence += 1;
   mintFlowState = "error";
   mintFlowData.error = message;
   mintFlowData.errorKind = kind;
-  clearMintAuthorization();
-  walletState.txState = "failed";
+  if (!options.preserveAuthorization) {
+    clearMintAuthorization();
+  }
+  if (!options.preserveSubmittedTransaction) {
+    walletState.txState = "failed";
+  }
   walletState.txError = message;
+  recordCurrentMintConsoleState();
 };
 
 const hiddenMintSheetAction = (): MintSheetActionConfig => ({
@@ -8174,6 +8742,8 @@ const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean 
       };
       if (IS_LOCAL_THOUGHT_V2 && isThoughtV2LocalDeploymentError(inventory.message)) {
         setMintFlowError(inventory.message, "thought");
+      } else {
+        recordCurrentMintConsoleState();
       }
     } else {
       pathInventoryState = {
@@ -8183,11 +8753,20 @@ const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean 
         items: inventory.items,
         error: "",
       };
-      if (inventory.items.every((item) => item.status !== "available")) {
+      recordCurrentMintConsoleState();
+      const availableItems = inventory.items.filter((item) => item.status === "available");
+      if (availableItems.length === 0) {
         clearMintPathSelection();
         if (mintFlowState === "error" && isPathRecoveryError()) {
           mintFlowState = "path_required";
         }
+      } else if (
+        availableItems.length === 1 &&
+        !mintFlowData.pathIdInput &&
+        mintFlowState === "path_required"
+      ) {
+        applyMintPathInputValue(availableItems[0].pathId.toString());
+        await checkPathEligibility();
       }
     }
   } catch (error) {
@@ -8201,6 +8780,7 @@ const refreshPathInventoryForCurrentWallet = async (options?: { force?: boolean 
       items: [],
       error: error instanceof Error ? error.message : "path list unavailable.",
     };
+    recordCurrentMintConsoleState();
   }
 
   syncInterface();
@@ -8211,6 +8791,7 @@ const moveMintFlowToWalletOrPathSelection = () => {
     mintFlowState = "wallet_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
+    recordCurrentMintConsoleState();
     return false;
   }
 
@@ -8222,6 +8803,7 @@ const moveMintFlowToWalletOrPathSelection = () => {
   mintFlowState = "path_required";
   mintFlowData.error = "";
   mintFlowData.errorKind = "none";
+  recordCurrentMintConsoleState();
   return true;
 };
 
@@ -8237,6 +8819,7 @@ const maybeLoadPathInventory = () => {
 const selectPathInventoryItem = (pathId: bigint) => {
   applyMintPathInputValue(pathId.toString());
   syncInterface();
+  focusMintDockStage();
   void checkPathEligibility();
 };
 
@@ -8262,37 +8845,67 @@ const isMintPathInputDisabled = () =>
 
 const shouldUsePathInventorySelect = () =>
   hasAvailablePathInventory() &&
-  (
-    mintFlowState === "path_required" ||
-    mintFlowState === "path_checking" ||
-    mintFlowState === "path_ready" ||
-    mintFlowState === "authorizing" ||
-    mintFlowState === "authorized" ||
-    (mintFlowState === "error" && isPathRecoveryError())
-  );
+  mintFlowState === "path_required" &&
+  mintFlowData.pathId === null;
+
+const focusRestoredMintElement = (element: HTMLElement) => {
+  thoughtDockPath.querySelectorAll<HTMLElement>(".is-focus-restored").forEach((item) => {
+    item.classList.remove("is-focus-restored");
+  });
+  element.classList.add("is-focus-restored");
+  element.addEventListener("blur", () => {
+    element.classList.remove("is-focus-restored");
+  }, { once: true });
+  element.focus({ preventScroll: true });
+};
+
+const focusMintDockStage = (preference: "action" | "path" = "action") => {
+  requestAnimationFrame(() => {
+    if (mintFlowUiMode !== "dock" || thoughtDockPath.classList.contains("is-hidden")) {
+      return;
+    }
+
+    if (preference === "path") {
+      const selectedButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
+        '.thought-dock-path-token[aria-pressed="true"]',
+      );
+      const firstButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
+        ".thought-dock-path-token",
+      );
+      const pathButton = selectedButton ?? firstButton;
+      if (pathButton && !pathButton.disabled) {
+        focusRestoredMintElement(pathButton);
+        return;
+      }
+
+      if (
+        !thoughtDockPathField.classList.contains("is-hidden") &&
+        !thoughtDockPathBox.classList.contains("is-hidden") &&
+        !thoughtDockPathBox.disabled
+      ) {
+        focusRestoredMintElement(thoughtDockPathBox);
+        return;
+      }
+    }
+
+    const action = [thoughtDockPathPrimary, thoughtDockPathSecondary, thoughtDockPathTertiary]
+      .find((button) => !button.disabled && !button.classList.contains("is-hidden"));
+    if (action) {
+      focusRestoredMintElement(action);
+      return;
+    }
+
+    focusRestoredMintElement(thoughtDockPathTitle);
+  });
+};
 
 const focusMintPathInput = () => {
-  if (shouldUsePathInventorySelect() && mintFlowUiMode === "dock") {
-    const selectedButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
-      '.thought-dock-path-token[aria-pressed="true"]',
-    );
-    const firstButton = thoughtDockPathInventoryList.querySelector<HTMLButtonElement>(
-      ".thought-dock-path-token",
-    );
-    const button = selectedButton ?? firstButton;
-    requestAnimationFrame(() => {
-      if (button && !button.disabled) {
-        button.focus();
-      }
-    });
+  if (mintFlowUiMode === "dock") {
+    focusMintDockStage("path");
     return;
   }
 
-  const input = shouldUsePathInventorySelect()
-    ? mintSheetPathSelect
-    : mintFlowUiMode === "dock"
-      ? thoughtDockPathBox
-      : mintSheetPathBox;
+  const input = shouldUsePathInventorySelect() ? mintSheetPathSelect : mintSheetPathBox;
   requestAnimationFrame(() => {
     if (!input.disabled) {
       input.focus();
@@ -8300,7 +8913,7 @@ const focusMintPathInput = () => {
   });
 };
 
-const getMintSheetActionConfigs = (): [
+const getLegacyMintSheetActionConfigs = (): [
   MintSheetActionConfig,
   MintSheetActionConfig,
   MintSheetActionConfig,
@@ -8484,24 +9097,50 @@ const getMintSheetActionConfigs = (): [
   ];
 };
 
+const getMintSheetActionConfigs = (): [
+  MintSheetActionConfig,
+  MintSheetActionConfig,
+  MintSheetActionConfig,
+] => {
+  // Keep the legacy mapper referenced until the CLI-only mint commands move to
+  // the same presentation model in a follow-up deletion pass.
+  void getLegacyMintSheetActionConfigs;
+  const actions = getCurrentMintPresentation().actions
+    .filter((item) => item.id !== "none")
+    .slice(0, 3)
+    .map((item): MintSheetActionConfig => ({
+      action: item.id,
+      label: item.label,
+      disabled: item.disabled,
+    }));
+
+  return [
+    actions[0] ?? hiddenMintSheetAction(),
+    actions[1] ?? hiddenMintSheetAction(),
+    actions[2] ?? hiddenMintSheetAction(),
+  ];
+};
+
 const syncMintFlowSteps = (container: HTMLElement) => {
-  const activeStep =
-    mintFlowState === "authorized" || mintFlowState === "minting" || mintFlowState === "minted"
-      ? "confirm"
-      : mintFlowState === "path_ready" || mintFlowState === "authorizing"
-        ? "authorize"
-        : "select";
-  const completedSteps =
-    activeStep === "authorize"
-      ? new Set(["select"])
-      : activeStep === "confirm"
-        ? new Set(["select", "authorize"])
-        : new Set<string>();
+  const presentation = getCurrentMintPresentation();
+  const stepMap = {
+    select: "path",
+    authorize: "sign",
+    confirm: "mint",
+  } as const;
+  const completedSteps = new Set(presentation.completedSteps);
 
   container.querySelectorAll<HTMLElement>("[data-step]").forEach((step) => {
     const stepId = step.dataset.step ?? "";
-    step.classList.toggle("is-active", stepId === activeStep);
-    step.classList.toggle("is-complete", completedSteps.has(stepId) || mintFlowState === "minted");
+    const canonicalStep = stepMap[stepId as keyof typeof stepMap];
+    const isActive = canonicalStep === presentation.activeStep;
+    step.classList.toggle("is-active", isActive);
+    step.classList.toggle("is-complete", Boolean(canonicalStep && completedSteps.has(canonicalStep)));
+    if (isActive) {
+      step.setAttribute("aria-current", "step");
+    } else {
+      step.removeAttribute("aria-current");
+    }
   });
 };
 
@@ -8509,7 +9148,7 @@ const syncMintSheetFlow = () => {
   syncMintFlowSteps(mintSheetFlow);
 };
 
-const getMintSheetStatusCopy = () => {
+const getLegacyMintSheetStatusCopy = () => {
   const selectedPathId = mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim();
 
   if (mintFlowState === "thought_checking") {
@@ -8573,6 +9212,11 @@ const getMintSheetStatusCopy = () => {
   return "";
 };
 
+const getMintSheetStatusCopy = () => {
+  void getLegacyMintSheetStatusCopy;
+  return getCurrentMintPresentation().stageCopy;
+};
+
 const mintReviewNetworkRows = () => [
   { label: "network", value: THOUGHT_ENVIRONMENT_LABEL },
   { label: "chain", value: THOUGHT_CHAIN_NAME },
@@ -8590,7 +9234,7 @@ const cliNetworkReviewRows = () => [
 const mintReviewContractValue = (label: string, address: string) =>
   address ? `${label} ${shortHex(address, 6, 4)}` : `${label} unavailable`;
 
-const getMintSheetCopy = () => {
+const getLegacyMintSheetCopy = () => {
   if (mintFlowState === "wallet_required") {
     if (isInjectedWalletMissing()) {
       return "install or enable an injected wallet.";
@@ -8604,6 +9248,11 @@ const getMintSheetCopy = () => {
     return "mints THOUGHT and consumes PATH.";
   }
   return "one THOUGHT needs one $PATH.";
+};
+
+const getMintSheetCopy = () => {
+  void getLegacyMintSheetCopy;
+  return getCurrentMintPresentation().detail;
 };
 
 const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
@@ -8630,7 +9279,7 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
         },
         {
           label: "signature",
-          value: "PATH consume authorization",
+          value: "PATH mint permission",
         },
         {
           label: "executor",
@@ -8642,8 +9291,8 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
         { label: "expires", value: `${Math.floor(Number(PATH_CONSUME_AUTH_TTL_SECONDS) / 3600)} hour` },
       ],
       note: selectedPathId
-        ? `authorize PATH\nthis signature lets THOUGHT consume $PATH #${selectedPathId}.\nit sends 0 ETH and does not mint yet.`
-        : "authorize PATH\nsignature only. does not mint.",
+        ? `sign PATH permission — 1 of 2\nallows the THOUGHT contract to use one THOUGHT mint from $PATH #${selectedPathId}.\nno transaction. no gas. does not mint yet.`
+        : "sign PATH permission — 1 of 2\nno transaction. no gas. does not mint yet.",
       verifyLink: true,
     };
   }
@@ -8662,12 +9311,12 @@ const getMintSheetReviewConfig = (): MintSheetReviewConfig => {
           value: "mint(string,uint256,bytes32,bytes32,bytes32,string,uint256,bytes)",
         },
         { label: "$PATH", value: `#${selectedPathId}` },
-        { label: "consumes", value: "1 THOUGHT unit" },
+        { label: "uses", value: "1 THOUGHT mint" },
         { label: "ETH sent", value: "0 ETH" },
         { label: "authorization", value: "PATH signature attached" },
         { label: "network gas", value: "shown in wallet" },
       ],
-      note: `confirm mint\nthis transaction mints THOUGHT and consumes $PATH #${selectedPathId}.`,
+      note: `mint THOUGHT — 2 of 2\ncreates the token using one THOUGHT mint from $PATH #${selectedPathId}.\nthe $PATH token stays in this wallet. network gas applies.`,
       verifyLink: true,
     };
   }
@@ -8794,10 +9443,12 @@ const syncThoughtDockPathInventory = () => {
       const isSelected = pathId === selectedPathId;
       button.type = "button";
       button.className = "thought-dock-button thought-dock-path-token";
-      button.textContent = `$PATH #${pathId}`;
+      button.textContent = `$PATH #${pathId} · 1 mint`;
       button.disabled = disabled;
       button.setAttribute("aria-pressed", isSelected ? "true" : "false");
-      button.title = isSelected ? `$PATH #${pathId} selected` : `select $PATH #${pathId}`;
+      button.title = isSelected
+        ? `$PATH #${pathId} selected for this THOUGHT`
+        : `Use $PATH #${pathId} for this THOUGHT`;
       button.addEventListener("click", () => {
         selectPathInventoryItem(item.pathId);
       });
@@ -8882,6 +9533,52 @@ const renderMintContext = (container: HTMLElement, options: { includeWalletRevie
   container.classList.toggle("is-hidden", container.childNodes.length === 0);
 };
 
+let thoughtDockReviewSignature = "";
+
+const syncMintDockReview = () => {
+  const reviewStage = mintFlowState === "path_ready" || mintFlowState === "authorizing"
+    ? "sign"
+    : mintFlowState === "authorized" || mintFlowState === "minting"
+      ? "mint"
+      : null;
+
+  if (!reviewStage) {
+    thoughtDockPathReview.classList.add("is-hidden");
+    thoughtDockPathReview.open = false;
+    thoughtDockPathReview.removeAttribute("data-stage");
+    thoughtDockPathContext.replaceChildren();
+    thoughtDockPathContext.classList.add("is-hidden");
+    thoughtDockReviewSignature = "";
+    return;
+  }
+
+  const config = getMintSheetReviewConfig();
+  const signature = JSON.stringify({ config, reviewStage });
+  const stageChanged = thoughtDockPathReview.dataset.stage !== reviewStage;
+  thoughtDockPathReview.dataset.stage = reviewStage;
+  thoughtDockPathReview.classList.remove("is-hidden");
+  thoughtDockPathReviewSummary.textContent = reviewStage === "sign"
+    ? "review signature request · 1 of 2"
+    : "review mint transaction · 2 of 2";
+
+  if (stageChanged) {
+    thoughtDockPathReview.open = false;
+  }
+  if (signature === thoughtDockReviewSignature) {
+    return;
+  }
+
+  thoughtDockPathContext.replaceChildren();
+  renderMintReviewContent(thoughtDockPathContext, config, {
+    link: "thought-dock-path-review__link",
+    note: "thought-dock-path-review__note",
+    review: "thought-dock-path-review__rows",
+    row: "thought-dock-path-review__row",
+  });
+  thoughtDockPathContext.classList.remove("is-hidden");
+  thoughtDockReviewSignature = signature;
+};
+
 const renderMintSheetContext = () => {
   renderMintContext(mintSheetContext);
 };
@@ -8913,34 +9610,11 @@ const getMintDockPathActionConfigs = (): [
   MintSheetActionConfig,
   MintSheetActionConfig,
 ] => {
-  const visibleActions = getMintSheetActionConfigs().filter(
-    (config) => !config.hidden && config.action !== "none" && !isGlobalWalletAction(config.action),
-  );
-
-  return [
-    visibleActions[0] ?? hiddenMintSheetAction(),
-    visibleActions[1] ?? hiddenMintSheetAction(),
-    visibleActions[2] ?? hiddenMintSheetAction(),
-  ];
+  return getMintSheetActionConfigs();
 };
 
 const getMintDockPathStatusCopy = () => {
-  const selectedPathId = mintFlowData.pathId?.toString() ?? mintFlowData.pathIdInput.trim();
-
-  if (mintFlowState === "path_ready") {
-    return selectedPathId ? `PATH #${selectedPathId} selected.` : "PATH selected.";
-  }
-  if (mintFlowState === "authorizing") {
-    return "PATH authorization pending.";
-  }
-  if (mintFlowState === "authorized") {
-    return selectedPathId ? `PATH #${selectedPathId} authorized.` : "PATH authorized.";
-  }
-  if (mintFlowState === "minting") {
-    return "THOUGHT mint pending.";
-  }
-
-  return getMintSheetStatusCopy();
+  return getCurrentMintPresentation().stageCopy;
 };
 
 const syncMintSheet = () => {
@@ -8986,13 +9660,21 @@ const syncMintSheet = () => {
 
 const syncMintDockPathPanel = () => {
   const pathInputVisible = isMintPathFieldVisible();
-  const isVisible = mintFlowUiMode === "dock" && mintFlowState !== "closed" && pathInputVisible;
+  const isVisible = mintFlowUiMode === "dock" && mintFlowState !== "closed";
   thoughtDockPath.classList.toggle("is-hidden", !isVisible);
 
   if (!isVisible) {
+    thoughtDockPathReview.classList.add("is-hidden");
+    thoughtDockPathReview.open = false;
     thoughtDockPathContext.replaceChildren();
+    thoughtDockPathContext.classList.add("is-hidden");
+    thoughtDockReviewSignature = "";
     return;
   }
+
+  const presentation = getCurrentMintPresentation();
+  thoughtDockPathTitle.textContent = presentation.title;
+  thoughtDockPathDetail.textContent = presentation.detail;
 
   const pathInventoryVisible = syncThoughtDockPathInventory();
   const manualPathVisible = pathInputVisible && shouldRevealManualPathInput();
@@ -9010,7 +9692,7 @@ const syncMintDockPathPanel = () => {
   thoughtDockPathProvenance.classList.toggle("is-hidden", !provenanceCopy);
 
   thoughtDockPathStatus.textContent = getMintDockPathStatusCopy();
-  renderMintContext(thoughtDockPathContext, { includeWalletReview: false });
+  syncMintDockReview();
   maybeLoadPathInventory();
   syncMintFlowSteps(thoughtDockPathFlow);
 
@@ -9111,26 +9793,43 @@ const refreshWalletState = async () => {
     }
   }
 
-  if (walletState.address !== previousAddress || walletState.chainId !== previousChainId) {
+  if (
+    walletStateHydrated &&
+    (walletState.address !== previousAddress || walletState.chainId !== previousChainId)
+  ) {
     resetPathInventoryState();
-    clearMintPathSelection();
-    if (mintFlowState !== "closed" && mintFlowState !== "wallet_required") {
-      if (!walletState.address) {
-        mintFlowState = "wallet_required";
-        mintFlowData.error = "";
-        mintFlowData.errorKind = "none";
-      } else if (walletState.chainId !== THOUGHT_CHAIN_ID) {
-        mintFlowState = "error";
-        mintFlowData.error = "wrong network.";
-        mintFlowData.errorKind = "wrong_network";
-      } else {
-        mintFlowState = "path_required";
-        mintFlowData.error = "";
-        mintFlowData.errorKind = "none";
+    if (pendingMintTransaction) {
+      emitThoughtConsoleEvent({
+        kind: "wallet_changed_after_submission",
+        title: "wallet changed",
+        detail: `Active wallet: ${walletState.address ? shortHex(walletState.address) : "disconnected"} on chain ${walletState.chainId ?? "none"}. Mint from ${shortHex(pendingMintTransaction.account)} keeps tracking.`,
+      });
+    } else {
+      mintAttemptId = nextMintAttemptId("wallet");
+      clearMintPathSelection();
+      if (mintFlowState !== "closed" && mintFlowState !== "wallet_required") {
+        if (!walletState.address) {
+          mintFlowState = "wallet_required";
+          mintFlowData.error = "";
+          mintFlowData.errorKind = "none";
+        } else if (walletState.chainId !== THOUGHT_CHAIN_ID) {
+          mintFlowState = "error";
+          mintFlowData.error = "wrong network.";
+          mintFlowData.errorKind = "wrong_network";
+        } else {
+          mintFlowState = "path_required";
+          mintFlowData.error = "";
+          mintFlowData.errorKind = "none";
+        }
+      }
+      recordThoughtConsoleContextBoundary();
+      if (mintFlowState !== "closed") {
+        recordCurrentMintConsoleState();
       }
     }
   }
 
+  walletStateHydrated = true;
   await refreshMintPreflight();
 };
 
@@ -9182,6 +9881,87 @@ const bindWalletProviderEvents = () => {
   walletListenersBound = true;
 };
 
+const pendingMintIdentityMatches = (
+  left: PendingMintTransaction,
+  right: PendingMintTransaction,
+) =>
+  left.account === right.account &&
+  left.chainId === right.chainId &&
+  left.thoughtNft === right.thoughtNft &&
+  left.workHash === right.workHash &&
+  left.pathId === right.pathId &&
+  left.nonce === right.nonce;
+
+const bindPendingMintStorageEvents = () => {
+  if (pendingMintStorageListenerBound) {
+    return;
+  }
+  pendingMintStorageListenerBound = true;
+  window.addEventListener("storage", (event) => {
+    if (event.key === THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY) {
+      conflictingMintTransactions = [
+        ...parseConflictingMintTransactions(event.newValue),
+      ];
+      if (pendingMintTransaction) {
+        projectPendingMintTransaction(pendingMintTransaction, {
+          deploymentWarning: !isPendingMintDeploymentCompatible(pendingMintTransaction),
+        });
+      }
+      resumeConflictingMintReceiptMonitoring();
+      recordCurrentMintConsoleState();
+      syncInterface();
+      return;
+    }
+    if (event.key !== THOUGHT_PENDING_MINT_TX_STORAGE_KEY || event.newValue === null) {
+      // A different tab may clear storage after confirmation; this tab keeps its live
+      // hash until its own receipt monitor verifies the terminal receipt.
+      return;
+    }
+    const incoming = parsePendingMintTransaction(event.newValue);
+    if (!incoming) {
+      return;
+    }
+    if (
+      pendingMintTransaction &&
+      !pendingMintTransactionMatches(pendingMintTransaction, incoming.hash) &&
+      !pendingMintIdentityMatches(pendingMintTransaction, incoming)
+    ) {
+      return;
+    }
+    if (
+      pendingMintTransaction &&
+      !pendingMintTransactionMatches(pendingMintTransaction, incoming.hash)
+    ) {
+      appendConflictingMintTransaction(pendingMintTransaction);
+    }
+    pendingMintTransaction = incoming;
+    projectPendingMintTransaction(incoming, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(incoming),
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    if (isPendingMintDeploymentCompatible(incoming)) {
+      resumePendingMintReceiptMonitoring();
+    }
+    resumeConflictingMintReceiptMonitoring();
+  });
+};
+
+const walletConnectionConsoleFailure = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : "";
+  if (code === "4001" || /reject|denied|cancel/i.test(message)) {
+    return { title: "wallet connection canceled", detail: "nothing changed" };
+  }
+  if (code === "-32002" || /already.*(?:pending|open)|request.*pending/i.test(message)) {
+    return { title: "wallet request already open", detail: "finish or cancel it in your wallet" };
+  }
+  return { title: "wallet not connected", detail: "try connecting again" };
+};
+
 const requestWalletConnect = async () => {
   const sharedWallet = getThoughtShellWallet();
   if (sharedWallet.ready) {
@@ -9192,6 +9972,13 @@ const requestWalletConnect = async () => {
     walletDisconnectedByUser = false;
     setWarning("");
     walletConnectInFlight = true;
+    if (mintFlowState !== "closed") {
+      emitThoughtConsoleEvent({
+        kind: "wallet_connection_requested",
+        title: "wallet connection requested",
+        detail: "finish or cancel the request in your wallet",
+      });
+    }
     syncInterface();
 
     try {
@@ -9217,8 +10004,17 @@ const requestWalletConnect = async () => {
         walletStage: "connector",
         errorCategory: thoughtAnalyticsErrorCategory(error),
       });
-      setWarning(error instanceof Error ? error.message : "wallet connect failed.");
+      const message = error instanceof Error ? error.message : "wallet connect failed.";
+      setWarning(message);
       setStatus("");
+      if (mintFlowState !== "closed") {
+        const consoleFailure = walletConnectionConsoleFailure(error);
+        emitThoughtConsoleEvent({
+          kind: "wallet_connection_failed",
+          ...consoleFailure,
+          tone: "warning",
+        });
+      }
     } finally {
       walletConnectInFlight = false;
       syncInterface();
@@ -9245,6 +10041,13 @@ const requestWalletConnect = async () => {
   walletDisconnectedByUser = false;
   setWarning("");
   walletConnectInFlight = true;
+  if (mintFlowState !== "closed") {
+    emitThoughtConsoleEvent({
+      kind: "wallet_connection_requested",
+      title: "wallet connection requested",
+      detail: "finish or cancel the request in your wallet",
+    });
+  }
   syncInterface();
 
   try {
@@ -9294,6 +10097,14 @@ const requestWalletConnect = async () => {
     const message = error instanceof Error ? error.message : "wallet connect failed.";
     setWarning(message);
     setStatus("");
+    if (mintFlowState !== "closed") {
+      const consoleFailure = walletConnectionConsoleFailure(error);
+      emitThoughtConsoleEvent({
+        kind: "wallet_connection_failed",
+        ...consoleFailure,
+        tone: "warning",
+      });
+    }
   } finally {
     walletConnectInFlight = false;
     syncInterface();
@@ -9353,6 +10164,8 @@ const switchWalletChain = async () => {
 };
 
 const disconnectThoughtDockWallet = (options?: { appendCli?: boolean }) => {
+  const trackedMint = adoptDurablePendingMintTransaction();
+  const keepsSubmittedMint = Boolean(trackedMint);
   const sharedWallet = getThoughtShellWallet();
   if (sharedWallet.ready) {
     void sharedWallet.disconnect();
@@ -9363,10 +10176,16 @@ const disconnectThoughtDockWallet = (options?: { appendCli?: boolean }) => {
   walletState.balance = null;
   walletState.preflightLoading = false;
   walletState.preflightError = "";
-  resetPathInventoryState();
-  clearMintPathSelection();
+  if (!trackedMint) {
+    resetPathInventoryState();
+    clearMintPathSelection();
+  }
 
-  if (mintFlowState !== "closed" && mintFlowState !== "minted") {
+  if (!keepsSubmittedMint) {
+    mintAttemptId = nextMintAttemptId("wallet");
+  }
+
+  if (!trackedMint && mintFlowState !== "closed" && mintFlowState !== "minted") {
     mintFlowState = "wallet_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
@@ -9380,6 +10199,20 @@ const disconnectThoughtDockWallet = (options?: { appendCli?: boolean }) => {
     ]);
   } else {
     setStatus("wallet disconnected.", { flashMs: NOTICE_FLASH_MS });
+  }
+
+  if (keepsSubmittedMint && trackedMint) {
+    projectPendingMintTransaction(trackedMint, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(trackedMint),
+    });
+    emitThoughtConsoleEvent({
+      kind: "wallet_changed_after_submission",
+      title: "wallet disconnected",
+      detail: `Mint from ${shortHex(trackedMint.account)} on chain ${trackedMint.chainId} keeps tracking.`,
+    });
+  } else {
+    recordThoughtConsoleContextBoundary();
+    if (mintFlowState !== "closed") recordCurrentMintConsoleState();
   }
 
   syncInterface();
@@ -9452,8 +10285,23 @@ const handlePendingTx = async () => {
 
 const openMintFlow = async (
   uiMode: MintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE,
+  options?: { attemptId?: string; pathId?: string },
 ) => {
-  resetMintFlow();
+  const trackedMint = adoptDurablePendingMintTransaction();
+  if (trackedMint) {
+    projectPendingMintTransaction(trackedMint, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(trackedMint),
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    if (isPendingMintDeploymentCompatible(trackedMint)) {
+      resumePendingMintReceiptMonitoring();
+    }
+    return;
+  }
+  resetMintFlow({ preserveAttempt: true });
+  mintAttemptId = options?.attemptId?.trim() || nextMintAttemptId("mint");
+  mintFlowData.pathIdInput = options?.pathId?.trim() ?? "";
   mintFlowUiMode = uiMode;
 
   if (!THOUGHT_V2_MINT_ENABLED) {
@@ -9556,6 +10404,7 @@ const openMintFlow = async (
     if (existingTokenId !== 0n) {
       mintFlowData.existingTokenId = Number(existingTokenId);
       mintFlowState = "text_taken";
+      recordCurrentMintConsoleState();
       syncInterface();
       return;
     }
@@ -9577,6 +10426,64 @@ const openMintFlow = async (
   }
 };
 
+type PathEligibilityResult =
+  | { ok: true }
+  | { ok: false; kind: MintFlowErrorKind; message: string };
+
+const readPathEligibility = async (
+  pathId: bigint,
+  address: string,
+): Promise<PathEligibilityResult> => {
+  const pathNft = getReadPathNft();
+  if (!pathNft) {
+    return { ok: false, kind: "thought", message: "mint unavailable." };
+  }
+
+  try {
+    const owner = (await pathNft.ownerOf(pathId)) as string;
+    const [authorizedMinter, stage, stageMinted, movementQuota] = await Promise.all([
+      pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
+      pathNft.getStage(pathId) as Promise<bigint>,
+      pathNft.getStageMinted(pathId) as Promise<bigint>,
+      pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
+    ]);
+    if (owner.toLowerCase() !== address.toLowerCase()) {
+      return {
+        ok: false,
+        kind: "path_not_found",
+        message: `wallet does not hold $PATH #${pathId.toString()}.`,
+      };
+    }
+    if (
+      authorizedMinter.toLowerCase() !== THOUGHT_NFT_ADDRESS.toLowerCase() ||
+      movementQuota === 0n
+    ) {
+      return {
+        ok: false,
+        kind: "path_not_ready",
+        message: `$PATH #${pathId.toString()} not ready for THOUGHT.`,
+      };
+    }
+    if (stage !== 0n || stageMinted >= movementQuota) {
+      return {
+        ok: false,
+        kind: "path_consumed",
+        message: `$PATH #${pathId.toString()} has no THOUGHT mint available.`,
+      };
+    }
+    return { ok: true };
+  } catch (error) {
+    const notFound = error instanceof Error && /invalid token|nonexistent|erc721|owner query/i.test(error.message);
+    return {
+      ok: false,
+      kind: notFound ? "path_not_found" : "path_unknown",
+      message: notFound
+        ? `wallet does not hold $PATH #${pathId.toString()}.`
+        : `$PATH #${pathId.toString()} status unknown.`,
+    };
+  }
+};
+
 const checkPathEligibility = async () => {
   clearMintAuthorization();
   walletState.txState = "idle";
@@ -9585,13 +10492,16 @@ const checkPathEligibility = async () => {
   if (!PATH_NFT_ADDRESS || !THOUGHT_NFT_ADDRESS) {
     setMintFlowError("mint unavailable.", "thought");
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
   const ethereum = getEthereumProvider();
   if (!ethereum) {
     mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
@@ -9599,13 +10509,16 @@ const checkPathEligibility = async () => {
 
   if (!walletState.address) {
     mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
   if (walletState.chainId !== THOUGHT_CHAIN_ID) {
     setMintFlowError("wrong network.", "wrong_network");
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
@@ -9613,13 +10526,7 @@ const checkPathEligibility = async () => {
   if (pathId === null) {
     setMintFlowError("enter a valid $PATH #.", "path_invalid");
     syncInterface();
-    return;
-  }
-
-  const pathNft = getReadPathNft();
-  if (!pathNft) {
-    setMintFlowError("mint unavailable.", "thought");
-    syncInterface();
+    focusMintDockStage();
     return;
   }
 
@@ -9629,82 +10536,60 @@ const checkPathEligibility = async () => {
   mintFlowData.errorKind = "none";
   syncInterface();
 
-  try {
-    const owner = (await pathNft.ownerOf(pathId)) as string;
-    const [authorizedMinter, stage, stageMinted, movementQuota] =
-      await Promise.all([
-        pathNft.getAuthorizedMinter(PATH_MOVEMENT_THOUGHT) as Promise<string>,
-        pathNft.getStage(pathId) as Promise<bigint>,
-        pathNft.getStageMinted(pathId) as Promise<bigint>,
-        pathNft.getMovementQuota(PATH_MOVEMENT_THOUGHT) as Promise<bigint>,
-      ]);
-    const wallet = walletState.address.toLowerCase();
-    if (owner.toLowerCase() !== wallet) {
-      setMintFlowError(`wallet does not hold $PATH #${pathId.toString()}.`, "path_not_found");
-      syncInterface();
-      return;
-    }
-
-    if (authorizedMinter.toLowerCase() !== THOUGHT_NFT_ADDRESS.toLowerCase()) {
-      setMintFlowError(`$PATH #${pathId.toString()} not ready for THOUGHT.`, "path_not_ready");
-      syncInterface();
-      return;
-    }
-
-    if (movementQuota === 0n) {
-      setMintFlowError(`$PATH #${pathId.toString()} not ready for THOUGHT.`, "path_not_ready");
-      syncInterface();
-      return;
-    }
-
-    if (stage !== 0n || stageMinted >= movementQuota) {
-      setMintFlowError(
-        `$PATH #${pathId.toString()} has no THOUGHT unit available.`,
-        "path_consumed",
-      );
-      syncInterface();
-      return;
-    }
-
-    mintFlowState = "path_ready";
-    mintFlowData.error = "";
-    mintFlowData.errorKind = "none";
+  const eligibility = await readPathEligibility(pathId, walletState.address);
+  if (!eligibility.ok) {
+    setMintFlowError(eligibility.message, eligibility.kind);
     syncInterface();
-  } catch (error) {
-    const notFound = error instanceof Error && /invalid token|nonexistent|erc721|owner query/i.test(error.message);
-    setMintFlowError(
-      notFound ? `wallet does not hold $PATH #${pathId.toString()}.` : `$PATH #${pathId.toString()} status unknown.`,
-      notFound ? "path_not_found" : "path_unknown",
-    );
-    syncInterface();
+    focusMintDockStage();
+    return;
   }
+
+  mintFlowState = "path_ready";
+  mintFlowData.error = "";
+  mintFlowData.errorKind = "none";
+  recordCurrentMintConsoleState();
+  syncInterface();
+  focusMintDockStage();
 };
 
 const authorizeMint = async () => {
+  if (mintAuthorizationInFlight) {
+    return;
+  }
+  if (blockPendingMintMutation()) {
+    return;
+  }
   if (!getEthereumProvider() || !walletState.address || mintFlowData.pathId === null) {
     mintFlowState = "wallet_required";
+    recordCurrentMintConsoleState();
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
-  if (mintFlowState === "authorizing") {
-    return;
-  }
-
+  mintAuthorizationInFlight = true;
   const expectedAddress = walletState.address;
   const expectedPathId = mintFlowData.pathId;
   const requestId = mintAuthorizationRequestId + 1;
   mintAuthorizationRequestId = requestId;
   let authorizationStage: ThoughtAuthorizationStage = "preparing";
+  mintFlowState = "authorizing";
+  walletState.txError = "";
+  mintFlowData.error = "";
+  mintFlowData.errorKind = "none";
+  recordCurrentMintConsoleState();
+  syncInterface();
+  setWarning("");
+  setStatus("");
 
   try {
-    mintFlowState = "authorizing";
-    walletState.txError = "";
-    mintFlowData.error = "";
-    mintFlowData.errorKind = "none";
-    syncInterface();
-    setWarning("");
-    setStatus("");
+    const eligibility = await readPathEligibility(expectedPathId, expectedAddress);
+    if (!eligibility.ok) {
+      setMintFlowError(eligibility.message, eligibility.kind);
+      syncInterface();
+      focusMintDockStage();
+      return;
+    }
 
     await rebuildFinalMintProvenance();
     if (requestId !== mintAuthorizationRequestId) return;
@@ -9758,27 +10643,38 @@ const authorizeMint = async () => {
     mintFlowData.deadline = consumeAuth.deadline;
     mintFlowData.signature = consumeAuth.signature;
     mintFlowState = "authorized";
+    recordCurrentMintConsoleState();
   } catch (error) {
     if (requestId !== mintAuthorizationRequestId) return;
     const presentation = formatThoughtAuthorizationError(error, authorizationStage);
     setMintFlowError(presentation.message, presentation.kind);
     syncInterface();
+    focusMintDockStage();
     return;
+  } finally {
+    mintAuthorizationInFlight = false;
   }
 
   syncInterface();
+  focusMintDockStage();
 };
 
 type MintTransactionResponse = {
   hash: string;
   nonce?: number;
   from?: string;
-  wait: () => Promise<{ logs?: Array<{ topics: string[]; data: string }> } | null>;
+  wait: () => Promise<MintReceipt | null>;
 };
 
 type MintReceipt = {
+  status?: unknown;
   logs?: readonly { topics: readonly string[]; data: string }[];
 };
+
+type MintReceiptResult = Readonly<{
+  hash: string;
+  receipt: MintReceipt;
+}>;
 
 const mintErrorMessage = (error: unknown) => {
   const errorName =
@@ -9828,21 +10724,106 @@ const sleep = (ms: number) => new Promise((resolve) => {
   window.setTimeout(resolve, ms);
 });
 
-const waitForMintReceiptByHash = async (tx: MintTransactionResponse): Promise<MintReceipt | null> => {
-  const provider = getReadProvider();
-  const deadline = Date.now() + MINT_RECEIPT_TIMEOUT_MS;
+const mintReceiptFromUnknown = (value: unknown): MintReceipt | null => {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const item = value as { status?: unknown; logs?: unknown };
+  const logs = Array.isArray(item.logs)
+    ? item.logs.flatMap((log) => {
+        if (typeof log !== "object" || log === null) return [];
+        const candidate = log as { topics?: unknown; data?: unknown };
+        if (
+          !Array.isArray(candidate.topics) ||
+          !candidate.topics.every((topic) => typeof topic === "string") ||
+          typeof candidate.data !== "string"
+        ) {
+          return [];
+        }
+        return [{ topics: candidate.topics, data: candidate.data }];
+      })
+    : [];
+  return { status: item.status, logs };
+};
 
-  if (provider) {
-    while (Date.now() < deadline) {
-      const receipt = await provider.getTransactionReceipt(tx.hash);
-      if (receipt) {
-        return receipt;
+const migratePendingMintTransactionHash = (
+  expectedHash: string,
+  replacementHash: string,
+) => {
+  const durable = readPendingMintTransaction();
+  const current = pendingMintTransaction ?? durable;
+  if (!pendingMintTransactionMatches(current, expectedHash)) {
+    return false;
+  }
+  if (
+    durable &&
+    !pendingMintTransactionMatches(durable, expectedHash) &&
+    !pendingMintIdentityMatches(current!, durable)
+  ) {
+    return false;
+  }
+
+  pendingMintTransaction = replacePendingMintTransactionHash(current!, replacementHash);
+  writePendingMintTransaction(pendingMintTransaction);
+  walletState.txHash = pendingMintTransaction.hash;
+  mintFlowData.txHash = pendingMintTransaction.hash;
+  pendingMintReceiptMonitorHash = pendingMintTransaction.hash;
+  recordCurrentMintConsoleState();
+  syncInterface();
+  return true;
+};
+
+const waitForMintReceiptByHash = async (
+  tx: MintTransactionResponse,
+  onTrackedHash?: (hash: string) => void,
+): Promise<MintReceiptResult> => {
+  let trackedHash = tx.hash.toLowerCase();
+  try {
+    const receipt = await withTimeout(
+      tx.wait(),
+      MINT_RECEIPT_WAIT_TIMEOUT_MS,
+      MINT_RECEIPT_MONITOR_TIMEOUT_MESSAGE,
+    );
+    if (receipt && mintReceiptStatusOutcome(receipt.status) !== "unknown") {
+      return Object.freeze({ hash: trackedHash, receipt });
+    }
+  } catch (error) {
+    const replacement = parseMintTransactionReplacement(error);
+    if (replacement) {
+      if (replacement.cancelled) {
+        throw error;
       }
-      await sleep(MINT_RECEIPT_POLL_MS);
+      migratePendingMintTransactionHash(trackedHash, replacement.hash);
+      trackedHash = replacement.hash;
+      onTrackedHash?.(trackedHash);
+      const replacementReceipt = mintReceiptFromUnknown(replacement.receipt);
+      if (
+        replacementReceipt &&
+        mintReceiptStatusOutcome(replacementReceipt.status) !== "unknown"
+      ) {
+        return Object.freeze({ hash: trackedHash, receipt: replacementReceipt });
+      }
+    } else if (!classifyMintTrackingFailure(error, trackedHash).keepTracking) {
+      throw error;
     }
   }
 
-  return tx.wait();
+  const deadline = Date.now() + MINT_RECEIPT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    for (const provider of getMintReceiptMonitoringProviders()) {
+      try {
+        const receipt = await provider.getTransactionReceipt(trackedHash);
+        if (receipt && mintReceiptStatusOutcome(receipt.status) !== "unknown") {
+          return Object.freeze({ hash: trackedHash, receipt });
+        }
+      } catch {
+        // Keep polling; a persisted hash is the source of truth while RPC reads recover.
+      }
+    }
+    await sleep(MINT_RECEIPT_POLL_MS);
+  }
+
+  throw new Error(MINT_RECEIPT_MONITOR_TIMEOUT_MESSAGE);
 };
 
 const resolveMintedTokenId = async (receipt: MintReceipt | null) => {
@@ -9897,9 +10878,42 @@ const selectedPathAlreadyConsumed = async () => {
   }
 };
 
-const recoverMintStateAfterRevert = async (shouldAppendCliResult: boolean) => {
+const clearPendingMintTransactionIfMatches = (expectedHash: string) => {
+  if (!pendingMintTransactionMatches(pendingMintTransaction, expectedHash)) {
+    return false;
+  }
+  const durable = readPendingMintTransaction();
+  if (durable && !pendingMintTransactionMatches(durable, expectedHash)) {
+    return false;
+  }
+  pendingMintTransaction = null;
+  writePendingMintTransaction(null);
+  return true;
+};
+
+const recoverMintStateAfterRevert = async (
+  shouldAppendCliResult: boolean,
+  expectedTrackedHash?: string,
+) => {
+  const stillOwnsTrackedMint = () =>
+    !expectedTrackedHash || pendingMintTransactionMatches(
+      pendingMintTransaction,
+      expectedTrackedHash,
+    );
+  if (!stillOwnsTrackedMint()) {
+    return false;
+  }
   const existingTokenId = await resolveExistingThoughtTokenId();
   if (existingTokenId !== null) {
+    if (!stillOwnsTrackedMint()) {
+      return false;
+    }
+    if (
+      expectedTrackedHash &&
+      !clearPendingMintTransactionIfMatches(expectedTrackedHash)
+    ) {
+      return false;
+    }
     walletState.txState = "idle";
     walletState.txError = "";
     walletState.mintedTokenId = existingTokenId;
@@ -9908,6 +10922,7 @@ const recoverMintStateAfterRevert = async (shouldAppendCliResult: boolean) => {
     pendingMyBrainRunPayload = null;
     clearThoughtGalleryCache();
     await refreshMintPreflight();
+    recordCurrentMintConsoleState();
     syncInterface();
 
     if (shouldAppendCliResult) {
@@ -9925,6 +10940,15 @@ const recoverMintStateAfterRevert = async (shouldAppendCliResult: boolean) => {
   }
 
   if (await selectedPathAlreadyConsumed()) {
+    if (!stillOwnsTrackedMint()) {
+      return false;
+    }
+    if (
+      expectedTrackedHash &&
+      !clearPendingMintTransactionIfMatches(expectedTrackedHash)
+    ) {
+      return false;
+    }
     const pathId = selectedCliPathId();
     setMintFlowError(
       pathId ? `$PATH #${pathId} has no THOUGHT unit available.` : "$PATH has no THOUGHT unit available.",
@@ -9938,19 +10962,40 @@ const recoverMintStateAfterRevert = async (shouldAppendCliResult: boolean) => {
 };
 
 const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliResult: boolean) => {
+  let trackedHash = tx.hash.toLowerCase();
   try {
-    const receipt = await waitForMintReceiptByHash(tx);
-    const mintedTokenId = await resolveMintedTokenId(receipt);
+    const result = await waitForMintReceiptByHash(tx, (replacementHash) => {
+      trackedHash = replacementHash;
+    });
+    trackedHash = result.hash;
+    if (!pendingMintTransactionMatches(pendingMintTransaction, trackedHash)) {
+      return;
+    }
+    const receiptOutcome = mintReceiptStatusOutcome(result.receipt.status);
+    if (receiptOutcome === "reverted") {
+      throw new Error("transaction reverted.");
+    }
+    if (receiptOutcome !== "success") {
+      throw new Error("mint receipt status unavailable.");
+    }
+    const mintedTokenId = await resolveMintedTokenId(result.receipt);
+    if (!pendingMintTransactionMatches(pendingMintTransaction, trackedHash)) {
+      return;
+    }
+    if (!clearPendingMintTransactionIfMatches(trackedHash)) {
+      return;
+    }
 
     walletState.txState = "idle";
     walletState.txError = "";
     walletState.mintedTokenId = mintedTokenId;
-    walletState.txHash = tx.hash;
-    mintFlowData.txHash = tx.hash;
+    walletState.txHash = trackedHash;
+    mintFlowData.txHash = trackedHash;
     mintFlowState = "minted";
     pendingMyBrainRunPayload = null;
     clearThoughtGalleryCache();
     await refreshMintPreflight();
+    recordCurrentMintConsoleState();
     syncInterface();
     trackThoughtAnalytics("mint_succeeded", {
       mintStage: "confirmed",
@@ -9968,15 +11013,53 @@ const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliRe
       ].filter(Boolean));
     }
   } catch (error) {
-    if (await recoverMintStateAfterRevert(shouldAppendCliResult)) {
+    const ownedHash = pendingMintTransactionMatches(pendingMintTransaction, trackedHash)
+      ? trackedHash
+      : "";
+    if (!ownedHash) {
       return;
     }
-
+    const trackingFailure = classifyMintTrackingFailure(error, ownedHash);
+    if (
+      !trackingFailure.keepTracking &&
+      await recoverMintStateAfterRevert(shouldAppendCliResult, ownedHash)
+    ) {
+      return;
+    }
+    if (!pendingMintTransactionMatches(pendingMintTransaction, ownedHash)) {
+      return;
+    }
     const message = mintErrorMessage(error);
-    setMintFlowError(
-      message,
-      message.includes("provenance too large") ? "thought" : message.includes("expired") ? "signature" : "mint",
-    );
+    const errorKind = message.includes("provenance too large")
+      ? "thought"
+      : message.includes("expired")
+        ? "signature"
+        : "mint";
+    const shouldKeepTracking = trackingFailure.keepTracking;
+    if (shouldKeepTracking) {
+      walletState.txState = "submitted";
+      walletState.txError = message;
+      mintFlowState = "minting";
+      mintFlowData.error = message;
+      mintFlowData.errorKind = "mint";
+      recordCurrentMintConsoleState();
+    } else {
+      if (!clearPendingMintTransactionIfMatches(ownedHash)) {
+        const durable = readPendingMintTransaction();
+        if (durable) {
+          pendingMintTransaction = durable;
+          projectPendingMintTransaction(durable, {
+            deploymentWarning: !isPendingMintDeploymentCompatible(durable),
+          });
+        }
+        syncInterface();
+        return;
+      }
+      setMintFlowError(message, errorKind, {
+        preserveAuthorization: errorKind === "mint",
+        preserveSubmittedTransaction: false,
+      });
+    }
     syncInterface();
     setStatus("");
     trackThoughtAnalytics("mint_failed", {
@@ -9992,33 +11075,334 @@ const waitForMintReceipt = async (tx: MintTransactionResponse, shouldAppendCliRe
 
 const detectSubmittedTxNonceGap = async (
   tx: MintTransactionResponse,
-  fallbackAddress: string,
+  submission: MintSubmissionContext,
   provider: JsonRpcProvider | BrowserProvider | null,
 ) => {
-  if (typeof tx.nonce !== "number" || !provider) {
+  if (!provider) {
     return null;
   }
 
-  const from = tx.from || fallbackAddress || walletState.address;
-  if (!from) {
-    return null;
-  }
+  const submittedNonce = typeof tx.nonce === "number" ? tx.nonce : submission.nonce;
 
   try {
-    const expectedNonce = await provider.getTransactionCount(from, "pending");
-    return tx.nonce > expectedNonce ? { actual: tx.nonce, expected: expectedNonce } : null;
+    const expectedNonce = await provider.getTransactionCount(submission.account, "pending");
+    return submittedNonce > expectedNonce ? { actual: submittedNonce, expected: expectedNonce } : null;
   } catch {
     return null;
   }
 };
 
+const appendConflictingMintTransaction = (
+  transaction: PendingMintTransaction,
+) => {
+  const durable = readConflictingMintTransactions();
+  const next = [...durable, ...conflictingMintTransactions, transaction]
+    .filter((candidate, index, all) =>
+      all.findIndex((item) => item.hash === candidate.hash) === index
+    )
+    .slice(-8);
+  conflictingMintTransactions = next;
+  writeConflictingMintTransactions(next);
+};
+
+const removeConflictingMintTransaction = (hash: string) => {
+  const normalizedHash = hash.toLowerCase();
+  const next = conflictingMintTransactions.filter(
+    (transaction) => transaction.hash !== normalizedHash,
+  );
+  if (next.length === conflictingMintTransactions.length) {
+    return false;
+  }
+  conflictingMintTransactions = next;
+  writeConflictingMintTransactions(next);
+  return true;
+};
+
+const removeConflictingMintIdentity = (transaction: PendingMintTransaction) => {
+  const next = conflictingMintTransactions.filter(
+    (candidate) => !pendingMintIdentityMatches(candidate, transaction),
+  );
+  conflictingMintTransactions = next;
+  writeConflictingMintTransactions(next);
+};
+
+const clearPendingMintIdentityIfMatches = (transaction: PendingMintTransaction) => {
+  const durable = readPendingMintTransaction();
+  const current = pendingMintTransaction ?? durable;
+  if (current && !pendingMintIdentityMatches(current, transaction)) {
+    return false;
+  }
+  if (durable && !pendingMintIdentityMatches(durable, transaction)) {
+    return false;
+  }
+  pendingMintTransaction = null;
+  writePendingMintTransaction(null);
+  return true;
+};
+
+const finalizeSuccessfulKnownMint = async (
+  transaction: PendingMintTransaction,
+  receipt: MintReceipt,
+  shouldAppendCliResult: boolean,
+) => {
+  const current = pendingMintTransaction ?? readPendingMintTransaction();
+  if (current && !pendingMintIdentityMatches(current, transaction)) {
+    return false;
+  }
+  const mintedTokenId = await resolveMintedTokenId(receipt);
+  if (!clearPendingMintIdentityIfMatches(transaction)) {
+    return false;
+  }
+  removeConflictingMintIdentity(transaction);
+
+  mintAttemptId = transaction.attemptId?.trim() || mintAttemptId;
+  mintFlowData.textHash = transaction.workHash;
+  mintFlowData.pathIdInput = transaction.pathId;
+  mintFlowData.pathId = BigInt(transaction.pathId);
+  mintFlowData.txHash = transaction.hash;
+  mintFlowData.error = "";
+  mintFlowData.errorKind = "none";
+  walletState.txState = "idle";
+  walletState.txError = "";
+  walletState.txHash = transaction.hash;
+  walletState.mintedTokenId = mintedTokenId;
+  mintFlowState = "minted";
+  pendingMyBrainRunPayload = null;
+  clearThoughtGalleryCache();
+  await refreshMintPreflight();
+  emitThoughtConsoleEvent({
+    kind: "mint_receipt_confirmed",
+    title: "THOUGHT mint confirmed",
+    detail: `${shortHex(transaction.hash, 10, 8)} confirmed on-chain.`,
+    eventId: `mint-confirmed:${transaction.hash}`,
+  });
+  recordCurrentMintConsoleState();
+  syncInterface();
+  trackThoughtAnalytics("mint_succeeded", {
+    mintStage: "confirmed",
+  });
+
+  if (shouldAppendCliResult) {
+    appendCliOutput([
+      "minted.",
+      mintedTokenId !== null ? `THOUGHT: #${mintedTokenId}` : "THOUGHT: minted",
+      `$PATH #${transaction.pathId} THOUGHT unit consumed.`,
+      "use: view tx",
+      viewThoughtUseLine(mintedTokenId),
+      "use: gallery",
+    ].filter(Boolean));
+  }
+  return true;
+};
+
+const readKnownMintReceiptOnce = async (hash: string): Promise<MintReceipt | null> => {
+  for (const provider of getMintReceiptMonitoringProviders()) {
+    try {
+      const receipt = await withTimeout(
+        provider.getTransactionReceipt(hash),
+        MINT_RECEIPT_WAIT_TIMEOUT_MS,
+        MINT_RECEIPT_MONITOR_TIMEOUT_MESSAGE,
+      );
+      if (receipt && mintReceiptStatusOutcome(receipt.status) !== "unknown") {
+        return {
+          status: receipt.status,
+          logs: receipt.logs.map((log) => ({
+            topics: [...log.topics],
+            data: log.data,
+          })),
+        };
+      }
+    } catch {
+      // A transport failure is not a terminal receipt result. Try another provider.
+    }
+  }
+  return null;
+};
+
+const reconcileKnownMintReceipt = async (
+  transaction: PendingMintTransaction,
+  receipt: MintReceipt,
+  shouldAppendCliResult: boolean,
+) => {
+  const outcome = mintReceiptStatusOutcome(receipt.status);
+  if (outcome === "success") {
+    return finalizeSuccessfulKnownMint(transaction, receipt, shouldAppendCliResult);
+  }
+  if (outcome !== "reverted") {
+    return false;
+  }
+
+  if (pendingMintTransactionMatches(pendingMintTransaction, transaction.hash)) {
+    if (await recoverMintStateAfterRevert(shouldAppendCliResult, transaction.hash)) {
+      return true;
+    }
+    if (!clearPendingMintTransactionIfMatches(transaction.hash)) {
+      return false;
+    }
+    const promoted = adoptDurablePendingMintTransaction();
+    if (promoted) {
+      projectPendingMintTransaction(promoted, {
+        deploymentWarning: !isPendingMintDeploymentCompatible(promoted),
+      });
+      if (isPendingMintDeploymentCompatible(promoted)) {
+        resumePendingMintReceiptMonitoring();
+      }
+      recordCurrentMintConsoleState();
+      syncInterface();
+      return true;
+    }
+    setMintFlowError("transaction reverted.", "mint", {
+      preserveAuthorization: true,
+      preserveSubmittedTransaction: false,
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    resumeConflictingMintReceiptMonitoring();
+    return true;
+  }
+
+  if (!removeConflictingMintTransaction(transaction.hash)) {
+    return false;
+  }
+  emitThoughtConsoleEvent({
+    kind: "conflicting_mint_reverted",
+    title: "returned mint hash reverted",
+    detail: `${shortHex(transaction.hash, 10, 8)} reverted; the original hash remains tracked.`,
+    eventId: `conflicting-mint-reverted:${transaction.hash}`,
+    tone: "warning",
+  });
+  if (pendingMintTransaction) {
+    projectPendingMintTransaction(pendingMintTransaction, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(pendingMintTransaction),
+    });
+  }
+  recordCurrentMintConsoleState();
+  syncInterface();
+  return true;
+};
+
+const monitorConflictingMintReceipt = async (
+  transaction: PendingMintTransaction,
+  shouldAppendCliResult: boolean,
+) => {
+  const deadline = Date.now() + MINT_RECEIPT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!conflictingMintTransactions.some((candidate) => candidate.hash === transaction.hash)) {
+      return;
+    }
+    const receipt = await readKnownMintReceiptOnce(transaction.hash);
+    if (receipt && await reconcileKnownMintReceipt(
+      transaction,
+      receipt,
+      shouldAppendCliResult,
+    )) {
+      return;
+    }
+    await sleep(MINT_RECEIPT_POLL_MS);
+  }
+
+  if (!conflictingMintTransactions.some((candidate) => candidate.hash === transaction.hash)) {
+    return;
+  }
+  const message = `Automatic confirmation monitoring is delayed for returned hash ${shortHex(transaction.hash, 10, 8)}. Hash retained; do not submit a duplicate.`;
+  walletState.txState = "submitted";
+  walletState.txError = message;
+  mintFlowData.error = message;
+  mintFlowData.errorKind = "mint";
+  mintFlowState = "minting";
+  recordCurrentMintConsoleState();
+  syncInterface();
+};
+
+const startConflictingMintReceiptMonitor = (
+  transaction: PendingMintTransaction,
+  shouldAppendCliResult = false,
+) => {
+  if (
+    !isPendingMintDeploymentCompatible(transaction) ||
+    conflictingMintReceiptMonitorHashes.has(transaction.hash)
+  ) {
+    return false;
+  }
+  conflictingMintReceiptMonitorHashes.add(transaction.hash);
+  void monitorConflictingMintReceipt(transaction, shouldAppendCliResult).finally(() => {
+    conflictingMintReceiptMonitorHashes.delete(transaction.hash);
+  });
+  return true;
+};
+
+const resumeConflictingMintReceiptMonitoring = () => {
+  conflictingMintTransactions.forEach((transaction) => {
+    startConflictingMintReceiptMonitor(transaction);
+  });
+};
+
+const startMintReceiptMonitor = (
+  tx: MintTransactionResponse,
+  shouldAppendCliResult: boolean,
+) => {
+  const hash = tx.hash.toLowerCase();
+  if (pendingMintReceiptMonitorHash === hash) {
+    return;
+  }
+  const generation = pendingMintReceiptMonitorGeneration + 1;
+  pendingMintReceiptMonitorGeneration = generation;
+  pendingMintReceiptMonitorHash = hash;
+  void waitForMintReceipt(tx, shouldAppendCliResult).finally(() => {
+    if (pendingMintReceiptMonitorGeneration === generation) {
+      pendingMintReceiptMonitorHash = "";
+    }
+  });
+};
+
 const registerSubmittedMintTx = async (
   tx: MintTransactionResponse,
   shouldAppendCliResult: boolean,
-  fallbackAddress: string,
+  submission: MintSubmissionContext,
   provider: JsonRpcProvider | BrowserProvider | null,
 ) => {
-  const nonceGap = await detectSubmittedTxNonceGap(tx, fallbackAddress, provider);
+  const existing = pendingMintTransaction ?? readPendingMintTransaction();
+  if (existing) {
+    pendingMintTransaction = existing;
+    const sameHash = pendingMintTransactionMatches(existing, tx.hash);
+    if (!sameHash) {
+      const returnedTransaction = createPendingMintTransaction(
+        submission,
+        tx.hash,
+        Date.now(),
+      );
+      appendConflictingMintTransaction(returnedTransaction);
+      emitThoughtConsoleEvent({
+        kind: "multiple_mint_hashes_returned",
+        title: "multiple mint hashes returned",
+        detail: `${shortHex(existing.hash, 10, 8)} and ${shortHex(returnedTransaction.hash, 10, 8)} are both retained and monitored. Do not submit a duplicate.`,
+        eventId: `multiple-mint-hashes:${existing.hash}:${returnedTransaction.hash}`,
+        tone: "warning",
+      });
+      startConflictingMintReceiptMonitor(returnedTransaction, shouldAppendCliResult);
+    }
+    projectPendingMintTransaction(existing, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(existing),
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    if (
+      sameHash &&
+      isPendingMintDeploymentCompatible(existing)
+    ) {
+      startMintReceiptMonitor(tx, shouldAppendCliResult);
+    } else if (isPendingMintDeploymentCompatible(existing)) {
+      resumePendingMintReceiptMonitoring();
+    }
+    return true;
+  }
+
+  mintAttemptId = submission.attemptId;
+  mintFlowData.textHash = submission.workHash;
+  mintFlowData.pathIdInput = submission.pathId;
+  mintFlowData.pathId = BigInt(submission.pathId);
+  pendingMintTransaction = createPendingMintTransaction(submission, tx.hash, Date.now());
+  writePendingMintTransaction(pendingMintTransaction);
   walletState.txState = "submitted";
   walletState.txHash = tx.hash;
   mintFlowData.txHash = tx.hash;
@@ -10026,10 +11410,29 @@ const registerSubmittedMintTx = async (
   trackThoughtAnalytics("mint_started", {
     mintStage: "submitted",
   });
+  recordCurrentMintConsoleState();
+  syncInterface();
 
-  if (nonceGap) {
+  if (shouldAppendCliResult) {
+    appendCliOutput(["transaction submitted.", `tx: ${shortHex(tx.hash, 10, 8)}`, "waiting for chain confirmation...", "use: view tx"]);
+  }
+
+  startMintReceiptMonitor(tx, shouldAppendCliResult);
+  resumeConflictingMintReceiptMonitoring();
+  void detectSubmittedTxNonceGap(tx, submission, provider).then((nonceGap) => {
+    if (
+      !nonceGap ||
+      pendingMintTransaction?.hash.toLowerCase() !== tx.hash.toLowerCase()
+    ) {
+      return;
+    }
     const message = `transaction queued with nonce ${nonceGap.actual}; chain expects ${nonceGap.expected}.`;
-    setMintFlowError(message, "mint");
+    walletState.txState = "submitted";
+    walletState.txError = message;
+    mintFlowState = "minting";
+    mintFlowData.error = message;
+    mintFlowData.errorKind = "mint";
+    recordCurrentMintConsoleState();
     syncInterface();
     trackThoughtAnalytics("mint_failed", {
       mintStage: "submitted",
@@ -10043,20 +11446,311 @@ const registerSubmittedMintTx = async (
         `wallet nonce: ${nonceGap.actual}`,
         `chain expects: ${nonceGap.expected}`,
         "mint is not pending onchain yet.",
-        "reset Rabby nonce/activity, then retry confirm.",
-        "use: current",
+        "keep tracking this hash; do not submit a duplicate.",
+        "check Rabby activity and nonce before taking wallet action.",
+        "use: view tx",
       ]);
     }
-    return;
+  });
+  return true;
+};
+
+const resumePendingMintReceiptMonitoring = () => {
+  const pending = pendingMintTransaction;
+  if (!pending) {
+    return false;
   }
 
+  const resumedTx: MintTransactionResponse = {
+    hash: pending.hash,
+    nonce: pending.nonce,
+    from: pending.account,
+    wait: async () => {
+      const provider = getMintReceiptMonitoringProviders()[0];
+      if (!provider) {
+        throw new Error("mint receipt network unavailable.");
+      }
+      const receipt = await withTimeout(
+        provider.waitForTransaction(pending.hash),
+        MINT_RECEIPT_WAIT_TIMEOUT_MS,
+        MINT_RECEIPT_MONITOR_TIMEOUT_MESSAGE,
+      );
+      if (!receipt) return null;
+      return {
+        status: receipt.status,
+        logs: receipt.logs.map((log) => ({
+          topics: [...log.topics],
+          data: log.data,
+        })),
+      };
+    },
+  };
+  startMintReceiptMonitor(resumedTx, false);
+  return true;
+};
+
+const resumePendingMintTransaction = async () => {
+  const pending = pendingMintTransaction;
+  if (!pending) return false;
+
+  if (
+    pending.chainId !== THOUGHT_CHAIN_ID ||
+    pending.thoughtNft.toLowerCase() !== THOUGHT_NFT_ADDRESS.toLowerCase()
+  ) {
+    projectPendingMintTransaction(pending, { deploymentWarning: true });
+    emitThoughtConsoleEvent({
+      kind: "pending_mint_deployment_mismatch",
+      title: "mint deployment changed",
+      detail: `Keep tracking ${shortHex(pending.hash, 10, 8)} on chain ${pending.chainId}; this deployment cannot inspect it.`,
+      eventId: `pending-deployment:${pending.hash.toLowerCase()}`,
+      tone: "warning",
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    resumeConflictingMintReceiptMonitoring();
+    return true;
+  }
+
+  const retainedAttemptId = [...thoughtConsoleHistory.entries]
+    .reverse()
+    .find((entry) =>
+      entry.kind === "transaction_submitted" &&
+      entry.dedupeKey.includes(`transaction:${pending.hash.toLowerCase()}`)
+    )?.context.attemptId;
+  mintAttemptId = pending.attemptId?.trim() || retainedAttemptId || nextMintAttemptId("resume");
+  walletState.txError = "";
+  projectPendingMintTransaction(pending);
+  recordCurrentMintConsoleState();
   syncInterface();
+  resumePendingMintReceiptMonitoring();
+  resumeConflictingMintReceiptMonitoring();
+  return true;
+};
 
-  if (shouldAppendCliResult) {
-    appendCliOutput(["transaction submitted.", `tx: ${shortHex(tx.hash, 10, 8)}`, "waiting for chain confirmation...", "use: view tx"]);
+const restorePathMintHandoffWork = (handoff: PathMintHandoff) => {
+  if (handoff.work) {
+    const output = thoughtProtocolText(handoff.work.output, IS_LOCAL_THOUGHT_V2);
+    if (keccak256(toUtf8Bytes(output)).toLowerCase() !== handoff.workHash.toLowerCase()) {
+      return false;
+    }
+    const migratedSvg = migrateLegacyThoughtV2Svg(output, handoff.work.svg);
+    currentOutputText = output;
+    currentWorkSvg = migratedSvg.svg;
+    currentRunContext = isThoughtRunContext(handoff.work.runContext) ? handoff.work.runContext : null;
+    currentWorkId = handoff.work.workId;
+    runState = "output_ready";
+    writeCurrentOutputSession();
+    syncCurrentWorkVisual({ suppressWarning: true });
+    return true;
   }
 
-  void waitForMintReceipt(tx, shouldAppendCliResult);
+  return Boolean(
+    currentOutputText &&
+    keccak256(toUtf8Bytes(currentOutputText)).toLowerCase() === handoff.workHash.toLowerCase()
+  );
+};
+
+const pathTokenIdFromMintReceipt = (
+  receipt: { logs?: readonly { address?: string; topics?: readonly string[] }[] },
+  account: string,
+) => {
+  const zeroAddressTopic = `0x${"0".repeat(64)}`;
+  const accountTopic = account.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  for (const log of receipt.logs ?? []) {
+    const topics = log.topics ?? [];
+    if (
+      log.address?.toLowerCase() !== PATH_NFT_ADDRESS.toLowerCase() ||
+      topics[0]?.toLowerCase() !== ERC721_TRANSFER_TOPIC.toLowerCase() ||
+      topics[1]?.toLowerCase() !== zeroAddressTopic ||
+      topics[2]?.toLowerCase().replace(/^0x/, "") !== accountTopic ||
+      !topics[3]
+    ) {
+      continue;
+    }
+    try {
+      return BigInt(topics[3]).toString();
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+const checkSubmittedPathMintReturn = async (
+  record: NonNullable<ReturnType<typeof readPathMintReturnRecord>>,
+) => {
+  if (record.status !== "submitted" || record.chainId !== THOUGHT_CHAIN_ID) {
+    return { outcome: "pending" as const, record };
+  }
+
+  const deadline = Date.now() + Math.min(5_000, MINT_RECEIPT_WAIT_TIMEOUT_MS);
+  do {
+    for (const provider of getMintReceiptMonitoringProviders()) {
+      try {
+        const receipt = await provider.getTransactionReceipt(record.txHash);
+        if (!receipt) continue;
+        const outcome = mintReceiptStatusOutcome(receipt.status);
+        if (outcome === "reverted") {
+          removePathMintReturnRecord(getPathMintReturnStorageHost(), record.handoffId);
+          return { outcome: "reverted" as const, record };
+        }
+        if (outcome === "success") {
+          const tokenId = pathTokenIdFromMintReceipt(receipt, record.account);
+          const confirmed = {
+            ...record,
+            status: "confirmed" as const,
+            ...(tokenId ? { tokenId } : {}),
+            updatedAt: Date.now(),
+          };
+          writePathMintReturnRecord(getPathMintReturnStorageHost(), confirmed);
+          return { outcome: "confirmed" as const, record: confirmed };
+        }
+      } catch {
+        // Null and transport failures retain the submitted record for another check.
+      }
+    }
+    await sleep(MINT_RECEIPT_POLL_MS);
+  } while (Date.now() < deadline);
+
+  return { outcome: "pending" as const, record };
+};
+
+const resumePathMintHandoff = async () => {
+  if (blockPendingMintMutation()) {
+    return true;
+  }
+  const handoff = readPathMintHandoff();
+  if (!handoff || !restorePathMintHandoffWork(handoff)) return false;
+
+  let returnRecord = readPathMintReturnRecord(
+    getPathMintReturnStorageHost(),
+    handoff.attemptId,
+  );
+  let submittedReturnOutcome: "pending" | "confirmed" | "reverted" | null = null;
+  if (returnRecord?.status === "submitted") {
+    const checked = await checkSubmittedPathMintReturn(returnRecord);
+    submittedReturnOutcome = checked.outcome;
+    returnRecord = checked.outcome === "reverted" ? null : checked.record;
+  }
+  const confirmedReturn = returnRecord?.status === "confirmed" ? returnRecord : null;
+  const resumesSameWallet =
+    Boolean(handoff.account) &&
+    Boolean(walletState.address) &&
+    walletState.address.toLowerCase() === handoff.account.toLowerCase() &&
+    walletState.chainId === THOUGHT_CHAIN_ID &&
+    (handoff.chainId === undefined || handoff.chainId === null || walletState.chainId === handoff.chainId);
+  resetMintFlow({ preserveAttempt: true });
+  mintAttemptId = confirmedReturn || resumesSameWallet
+    ? handoff.attemptId
+    : nextMintAttemptId("wallet");
+  mintFlowUiMode = THOUGHT_PANEL_MINT_UI_MODE;
+  mintFlowData.rawText = currentOutputText;
+  mintFlowData.textHash = handoff.workHash;
+  if (!confirmedReturn && !resumesSameWallet) {
+    recordThoughtConsoleContextBoundary();
+  }
+
+  const showReturnError = (message: string, kind: MintFlowErrorKind) => {
+    const work = getThoughtDockWorkView();
+    if (work) {
+      setThoughtDockState({ kind: "minting", work });
+    }
+    setMintFlowError(message, kind);
+    syncInterface();
+    return true;
+  };
+
+  if (submittedReturnOutcome === "reverted") {
+    return showReturnError(
+      "PATH transaction reverted. Mint a PATH or choose one already in this wallet.",
+      "path_not_found",
+    );
+  }
+
+  if (returnRecord?.status === "submitted" && returnRecord.chainId !== THOUGHT_CHAIN_ID) {
+    return showReturnError(
+      `PATH transaction is on chain ${returnRecord.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
+      "path_mint_chain_mismatch",
+    );
+  }
+
+  if (returnRecord?.status === "submitted") {
+    return showReturnError(
+      `PATH transaction ${shortHex(returnRecord.txHash, 10, 8)} is still confirming.`,
+      "path_mint_pending",
+    );
+  }
+
+  if (confirmedReturn && confirmedReturn.chainId !== THOUGHT_CHAIN_ID) {
+    return showReturnError(
+      `PATH was minted on chain ${confirmedReturn.chainId}; THOUGHT needs ${THOUGHT_CHAIN_NAME} (${THOUGHT_CHAIN_ID}).`,
+      "path_mint_chain_mismatch",
+    );
+  }
+
+  if (
+    confirmedReturn &&
+    (!walletState.address || walletState.address.toLowerCase() !== confirmedReturn.account.toLowerCase())
+  ) {
+    return showReturnError(
+      `PATH was minted to ${shortHex(confirmedReturn.account)}; select that account in your wallet to continue.`,
+      "wallet_account_mismatch",
+    );
+  }
+
+  if (confirmedReturn && walletState.chainId !== THOUGHT_CHAIN_ID) {
+    return showReturnError("wrong network.", "wrong_network");
+  }
+
+  emitThoughtConsoleEvent({
+    kind: "path_mint_returned",
+    title: "returned from PATH mint",
+    detail: "Rechecking wallet PATHs and resuming this THOUGHT mint.",
+    eventId: `path-return:${handoff.attemptId}`,
+  });
+  const resumed = await mintThoughtDockWork({
+    attemptId: mintAttemptId,
+    pathId: confirmedReturn?.tokenId,
+  });
+  if (!resumed) return false;
+
+  let resumeSucceeded =
+    mintFlowState === "text_taken" ||
+    mintFlowState === "minted" ||
+    mintFlowState === "path_ready";
+  if (!resumeSucceeded && confirmedReturn) {
+    if (confirmedReturn.tokenId && mintFlowState !== "error") {
+      await checkPathEligibility();
+      resumeSucceeded = mintFlowState === "path_ready";
+    } else if (mintFlowState !== "error") {
+      await refreshPathInventoryForCurrentWallet({ force: true });
+      resumeSucceeded =
+        pathInventoryMatchesCurrentWallet() &&
+        pathInventoryState.status === "loaded" &&
+        availablePathInventoryItems().length > 0;
+    }
+  } else if (
+    !resumeSucceeded &&
+    !confirmedReturn &&
+    mintFlowState === "path_required" &&
+    walletState.address &&
+    walletState.chainId === THOUGHT_CHAIN_ID
+  ) {
+    await refreshPathInventoryForCurrentWallet({ force: true });
+    resumeSucceeded =
+      pathInventoryMatchesCurrentWallet() &&
+      pathInventoryState.status === "loaded" &&
+      availablePathInventoryItems().length > 0;
+  }
+
+  if (resumeSucceeded) {
+    removePathMintReturnRecord(getPathMintReturnStorageHost(), handoff.attemptId);
+    removePathMintHandoff(handoff.attemptId);
+    const returnUrl = new URL(window.location.href);
+    returnUrl.searchParams.delete("pathHandoff");
+    window.history.replaceState({}, "", `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`);
+  }
+  return true;
 };
 
 const rebuildFinalMintProvenance = async () => {
@@ -10086,9 +11780,16 @@ const rebuildFinalMintProvenance = async () => {
 
 const confirmMint = async (options?: { appendCliResult?: boolean }) => {
   const shouldAppendCliResult = options?.appendCliResult ?? false;
+  if (mintTransactionInFlight) {
+    return null;
+  }
+  if (blockPendingMintMutation({ cli: shouldAppendCliResult })) {
+    return pendingMintTransaction?.hash ?? null;
+  }
   const ethereum = getEthereumProvider();
   if (
     !ethereum ||
+    !walletState.address ||
     mintFlowData.pathId === null ||
     !mintFlowData.provenanceJson ||
     !mintFlowData.thoughtSpecId ||
@@ -10098,6 +11799,7 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
   ) {
     clearMintAuthorization();
     mintFlowState = "path_ready";
+    recordCurrentMintConsoleState();
     syncInterface();
     return;
   }
@@ -10112,103 +11814,460 @@ const confirmMint = async (options?: { appendCliResult?: boolean }) => {
     return;
   }
 
-  let txTimedOut = false;
+  const capturedAuthorization = Object.freeze({
+    attemptId: mintAttemptId,
+    account: walletState.address,
+    pathId: mintFlowData.pathId,
+    rawText: mintFlowData.rawText,
+    deadline: mintFlowData.deadline,
+    signature: mintFlowData.signature,
+  });
+  mintTransactionInFlight = true;
+  const requestId = mintTransactionRequestId + 1;
+  mintTransactionRequestId = requestId;
+  activeMintTransactionRequestId = requestId;
+  mintFlowState = "minting";
+  walletState.txState = "awaiting_signature";
+  walletState.txError = "";
+  mintFlowData.error = "";
+  mintFlowData.errorKind = "none";
+  recordCurrentMintConsoleState();
+  syncInterface();
   trackThoughtAnalytics("mint_started", {
     mintStage: "wallet_signature",
   });
 
   try {
-    await refreshWalletChainRpc();
     await rebuildFinalMintProvenance();
+    if (
+      walletState.address.toLowerCase() !== capturedAuthorization.account.toLowerCase() ||
+      mintFlowData.pathId !== capturedAuthorization.pathId ||
+      mintFlowData.rawText !== capturedAuthorization.rawText ||
+      mintFlowData.deadline !== capturedAuthorization.deadline ||
+      mintFlowData.signature !== capturedAuthorization.signature
+    ) {
+      throw new Error("mint context changed.");
+    }
+    const payload = Object.freeze({
+      attemptId: capturedAuthorization.attemptId,
+      account: capturedAuthorization.account,
+      promptLine: currentRunContext?.prompt ?? sessionState.prompt,
+      agentLine: capturedAuthorization.rawText,
+      pathId: capturedAuthorization.pathId,
+      thoughtSpecId: mintFlowData.thoughtSpecId,
+      thoughtSpecHash: mintFlowData.thoughtSpecHash,
+      promptHash: mintFlowData.promptHash,
+      provenanceJson: mintFlowData.provenanceJson,
+      deadline: capturedAuthorization.deadline,
+      pathSignature: capturedAuthorization.signature,
+      workHash: mintFlowData.textHash,
+    });
     const browserProvider = new BrowserProvider(ethereum);
-    const signer = await browserProvider.getSigner();
+    const signer = await browserProvider.getSigner(payload.account);
     const signerAddress = await signer.getAddress();
+    if (signerAddress.toLowerCase() !== payload.account.toLowerCase()) {
+      throw new Error("wallet account changed.");
+    }
+    const eligibility = await readPathEligibility(payload.pathId, signerAddress);
+    if (!eligibility.ok) {
+      setMintFlowError(eligibility.message, eligibility.kind);
+      syncInterface();
+      return null;
+    }
     const nonceProvider = getReadProvider() ?? browserProvider;
     const nonce = await nonceProvider.getTransactionCount(signerAddress, "pending");
     const writableToken = new Contract(THOUGHT_NFT_ADDRESS, THOUGHT_NFT_ABI, signer);
-
-    mintFlowState = "minting";
-    walletState.txState = "awaiting_signature";
-    walletState.txError = "";
-    mintFlowData.error = "";
-    mintFlowData.errorKind = "none";
-    syncInterface();
-
-    let txHandled = false;
-    const txPromise = (IS_LOCAL_THOUGHT_V2
-      ? writableToken.mint(
-          {
-            promptLine: currentRunContext?.prompt ?? sessionState.prompt,
-            agentLine: mintFlowData.rawText,
-            pathId: mintFlowData.pathId,
-            thoughtSpecId: mintFlowData.thoughtSpecId,
-            thoughtSpecHash: mintFlowData.thoughtSpecHash,
-            provenanceJson: mintFlowData.provenanceJson,
-            deadline: mintFlowData.deadline,
-            pathSignature: mintFlowData.signature,
-          },
-          { nonce },
-        )
-      : writableToken.mint(
-          mintFlowData.rawText,
-          mintFlowData.pathId,
-          mintFlowData.thoughtSpecId,
-          mintFlowData.thoughtSpecHash,
-          mintFlowData.promptHash,
-          mintFlowData.provenanceJson,
-          mintFlowData.deadline,
-          mintFlowData.signature,
-          { nonce },
-        )) as Promise<MintTransactionResponse>;
-
-    void txPromise.then((lateTx) => {
-      if (txHandled || !txTimedOut) {
-        return;
-      }
-      txHandled = true;
-      void registerSubmittedMintTx(lateTx, shouldAppendCliResult, signerAddress, nonceProvider);
-    }).catch(() => {
-      // The awaited path below owns the visible error state.
+    const submission = createMintSubmissionContext({
+      attemptId: payload.attemptId,
+      account: signerAddress,
+      chainId: THOUGHT_CHAIN_ID,
+      thoughtNft: THOUGHT_NFT_ADDRESS,
+      workHash: payload.workHash,
+      pathId: payload.pathId,
+      nonce,
+    });
+    let releaseLockAfterRecovery!: () => void;
+    const releaseLockSignal = new Promise<void>((resolve) => {
+      releaseLockAfterRecovery = resolve;
+    });
+    let resolveReleaseCompleted!: () => void;
+    const releaseCompleted = new Promise<void>((resolve) => {
+      resolveReleaseCompleted = resolve;
     });
 
-    const tx = await withTimeout(
-      txPromise,
-      WALLET_TX_SUBMIT_TIMEOUT_MS,
-      "wallet transaction not submitted.",
+    const lockedSubmission = await withMintSubmissionLock(
+      mintSubmissionLockEnvironment(),
+      async (lock) => {
+        const [liveAccounts, liveChainHex] = await withTimeout(
+          Promise.all([
+            ethereum.request({ method: "eth_accounts" }),
+            ethereum.request({ method: "eth_chainId" }),
+          ]),
+          PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
+          "wallet status request timed out.",
+        );
+        const liveAddress = extractPrimaryAccount(liveAccounts);
+        const liveChainId =
+          typeof liveChainHex === "string" && liveChainHex.length > 0
+            ? Number(BigInt(liveChainHex))
+            : null;
+        if (!liveAddress || liveAddress.toLowerCase() !== payload.account.toLowerCase()) {
+          throw new Error("wallet account changed.");
+        }
+        if (liveChainId !== THOUGHT_CHAIN_ID) {
+          throw new Error("wrong network.");
+        }
+        if (!lock.ownsExclusion()) {
+          throw new Error("mint submission lock lost before wallet request.");
+        }
+
+        // This synchronous durable re-read is the last operation before opening
+        // the wallet transaction request. The origin-wide lock makes it atomic
+        // with respect to every cooperating THOUGHT tab.
+        const competingPending = pendingMintTransaction ?? readPendingMintTransaction();
+        if (competingPending) {
+          pendingMintTransaction = competingPending;
+          projectPendingMintTransaction(competingPending, {
+            deploymentWarning: !isPendingMintDeploymentCompatible(competingPending),
+          });
+          recordCurrentMintConsoleState();
+          syncInterface();
+          if (isPendingMintDeploymentCompatible(competingPending)) {
+            resumePendingMintReceiptMonitoring();
+          }
+          return competingPending.hash;
+        }
+
+        const txPromise = (IS_LOCAL_THOUGHT_V2
+          ? writableToken.mint(
+              {
+                promptLine: payload.promptLine,
+                agentLine: payload.agentLine,
+                pathId: payload.pathId,
+                thoughtSpecId: payload.thoughtSpecId,
+                thoughtSpecHash: payload.thoughtSpecHash,
+                provenanceJson: payload.provenanceJson,
+                deadline: payload.deadline,
+                pathSignature: payload.pathSignature,
+              },
+              { nonce },
+            )
+          : writableToken.mint(
+              payload.agentLine,
+              payload.pathId,
+              payload.thoughtSpecId,
+              payload.thoughtSpecHash,
+              payload.promptHash,
+              payload.provenanceJson,
+              payload.deadline,
+              payload.pathSignature,
+              { nonce },
+            )) as Promise<MintTransactionResponse>;
+
+        walletMintSubmitPromiseUnresolved = true;
+        unresolvedMintSubmission = Object.freeze({
+          requestId,
+          submission,
+          provider: nonceProvider,
+          releaseLockAfterRecovery,
+          releaseCompleted,
+        });
+        try {
+          try {
+            const tx = await withTimeout(
+              txPromise,
+              WALLET_TX_SUBMIT_TIMEOUT_MS,
+              "wallet transaction not submitted.",
+            );
+            await registerSubmittedMintTx(tx, shouldAppendCliResult, submission, nonceProvider);
+            return tx.hash;
+          } catch (error) {
+            const message = mintErrorMessage(error);
+            if (!message.includes("not submitted")) {
+              throw error;
+            }
+
+            setMintFlowError(message, "mint", { preserveAuthorization: true });
+            syncInterface();
+            setStatus("");
+            trackThoughtAnalytics("mint_failed", {
+              mintStage: "wallet_signature",
+              errorCategory: thoughtAnalyticsErrorCategory(error),
+            });
+
+            // Keep exclusion until the original wallet promise settles, unless
+            // the explicit recovery flow proves twice that no hash or nonce
+            // activity exists and asks this waiter to detach.
+            const lateOutcome = await waitForMintSubmissionOrRelease(
+              txPromise,
+              releaseLockSignal,
+            );
+            if (lateOutcome.kind === "settled") {
+              const lateTx = lateOutcome.value;
+              await registerSubmittedMintTx(
+                lateTx,
+                shouldAppendCliResult,
+                submission,
+                nonceProvider,
+              );
+              return lateTx.hash;
+            }
+            if (lateOutcome.kind === "rejected") {
+              const lateError = lateOutcome.error;
+              const lateMessage = mintErrorMessage(lateError);
+              setMintFlowError(lateMessage, "mint", { preserveAuthorization: true });
+              recordCurrentMintConsoleState();
+              trackThoughtAnalytics("mint_failed", {
+                mintStage: "wallet_signature",
+                errorCategory: thoughtAnalyticsErrorCategory(lateError),
+              });
+              return null;
+            }
+
+            // The provider promise itself is not cancelled. Any late hash is
+            // still registered, persisted, and reconciled against a retried hash.
+            void txPromise.then(
+              async (lateTx) => {
+                await registerSubmittedMintTx(
+                  lateTx,
+                  false,
+                  submission,
+                  nonceProvider,
+                );
+              },
+              (lateError) => {
+                emitThoughtConsoleEvent({
+                  kind: "detached_mint_request_settled",
+                  title: "detached wallet request closed",
+                  detail: mintErrorMessage(lateError),
+                  eventId: `detached-mint-settled:${requestId}`,
+                });
+              },
+            );
+            return null;
+          }
+        } finally {
+          if (unresolvedMintSubmission?.requestId === requestId) {
+            unresolvedMintSubmission = null;
+            walletMintSubmitPromiseUnresolved = false;
+          }
+          syncInterface();
+        }
+      },
     );
-    if (!txHandled) {
-      txHandled = true;
-      await registerSubmittedMintTx(tx, shouldAppendCliResult, signerAddress, nonceProvider);
+    resolveReleaseCompleted();
+
+    if (!lockedSubmission.acquired) {
+      const competingPending = readPendingMintTransaction();
+      if (competingPending) {
+        pendingMintTransaction = competingPending;
+        projectPendingMintTransaction(competingPending, {
+          deploymentWarning: !isPendingMintDeploymentCompatible(competingPending),
+        });
+        recordCurrentMintConsoleState();
+        syncInterface();
+        if (isPendingMintDeploymentCompatible(competingPending)) {
+          resumePendingMintReceiptMonitoring();
+        }
+        return competingPending.hash;
+      }
+      const unavailable = lockedSubmission.reason === "unavailable";
+      setMintFlowError(
+        unavailable
+          ? "this browser cannot safely coordinate THOUGHT mint requests across tabs. Use a browser with Web Locks support; no wallet request was opened."
+          : "another tab has an unresolved mint submission. Check wallet activity; do not submit a duplicate.",
+        "mint",
+        { preserveAuthorization: true },
+      );
+      syncInterface();
+      return null;
     }
-    return tx.hash;
+    return lockedSubmission.value;
   } catch (error) {
+    const message = mintErrorMessage(error);
     if (await recoverMintStateAfterRevert(shouldAppendCliResult)) {
       setStatus("");
       return walletState.txHash || mintFlowData.txHash || null;
     }
 
-    const message = mintErrorMessage(error);
-    txTimedOut = message.includes("not submitted");
-    setMintFlowError(message, message.includes("expired") ? "signature" : "mint");
+    const errorKind: MintFlowErrorKind = message.includes("expired") ? "signature" : "mint";
+    setMintFlowError(message, errorKind, {
+      preserveAuthorization: errorKind === "mint",
+    });
     syncInterface();
     setStatus("");
     trackThoughtAnalytics("mint_failed", {
-      mintStage: txTimedOut ? "wallet_signature" : "transaction",
+      mintStage: "transaction",
       errorCategory: thoughtAnalyticsErrorCategory(error),
     });
     return null;
+  } finally {
+    if (activeMintTransactionRequestId === requestId) {
+      activeMintTransactionRequestId = 0;
+      mintTransactionInFlight = false;
+    }
   }
+};
+
+const recoverUnresolvedMintSubmission = async () => {
+  const durable = readPendingMintTransaction();
+  if (durable) {
+    pendingMintTransaction = durable;
+    projectPendingMintTransaction(durable, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(durable),
+    });
+    if (isPendingMintDeploymentCompatible(durable)) {
+      const receipt = await readKnownMintReceiptOnce(durable.hash);
+      if (receipt && await reconcileKnownMintReceipt(durable, receipt, false)) {
+        return;
+      } else {
+        resumePendingMintReceiptMonitoring();
+      }
+    }
+    resumeConflictingMintReceiptMonitoring();
+    emitThoughtConsoleEvent({
+      kind: "mint_activity_checked",
+      title: "mint activity checked",
+      detail: `Transaction hash ${shortHex(durable.hash, 10, 8)} is retained. Do not submit a duplicate.`,
+      eventId: `mint-activity-checked:${durable.hash}`,
+    });
+    recordCurrentMintConsoleState();
+    syncInterface();
+    return;
+  }
+
+  for (const transaction of conflictingMintTransactions) {
+    if (!isPendingMintDeploymentCompatible(transaction)) continue;
+    const receipt = await readKnownMintReceiptOnce(transaction.hash);
+    if (receipt && await reconcileKnownMintReceipt(transaction, receipt, false)) {
+      return;
+    }
+  }
+
+  const unresolved = unresolvedMintSubmission;
+  if (!unresolved?.provider) {
+    setMintFlowError(
+      "Another tab still controls the unresolved wallet submission. Check that tab and wallet activity; do not submit a duplicate.",
+      "mint",
+      { preserveAuthorization: true, preserveSubmittedTransaction: true },
+    );
+    syncInterface();
+    return;
+  }
+
+  const readNonceSnapshot = async () => {
+    try {
+      const [latest, pending] = await withTimeout(
+        Promise.all([
+          unresolved.provider!.getTransactionCount(unresolved.submission.account, "latest"),
+          unresolved.provider!.getTransactionCount(unresolved.submission.account, "pending"),
+        ]),
+        PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
+        "wallet activity check timed out.",
+      );
+      return { latest, pending, conclusive: true } as const;
+    } catch {
+      return { latest: null, pending: null, conclusive: false } as const;
+    }
+  };
+  const hasNonceActivity = (snapshot: Awaited<ReturnType<typeof readNonceSnapshot>>) =>
+    snapshot.conclusive && (
+      snapshot.latest > unresolved.submission.nonce ||
+      snapshot.pending > unresolved.submission.nonce
+    );
+
+  const firstNonceSnapshot = await readNonceSnapshot();
+  if (!hasNonceActivity(firstNonceSnapshot) && firstNonceSnapshot.conclusive) {
+    await sleep(MINT_RECOVERY_NONCE_RECHECK_MS);
+  }
+
+  const lateDurable = readPendingMintTransaction();
+  if (lateDurable) {
+    pendingMintTransaction = lateDurable;
+    projectPendingMintTransaction(lateDurable, {
+      deploymentWarning: !isPendingMintDeploymentCompatible(lateDurable),
+    });
+    if (isPendingMintDeploymentCompatible(lateDurable)) {
+      const receipt = await readKnownMintReceiptOnce(lateDurable.hash);
+      if (receipt && await reconcileKnownMintReceipt(lateDurable, receipt, false)) {
+        return;
+      }
+      resumePendingMintReceiptMonitoring();
+    }
+    syncInterface();
+    return;
+  }
+
+  if (unresolvedMintSubmission?.requestId !== unresolved.requestId) {
+    syncInterface();
+    return;
+  }
+
+  const secondNonceSnapshot = firstNonceSnapshot.conclusive && !hasNonceActivity(firstNonceSnapshot)
+    ? await readNonceSnapshot()
+    : firstNonceSnapshot;
+  const nonceAdvanced = hasNonceActivity(firstNonceSnapshot) || hasNonceActivity(secondNonceSnapshot);
+  const safelyClear =
+    firstNonceSnapshot.conclusive &&
+    secondNonceSnapshot.conclusive &&
+    !nonceAdvanced;
+
+  if (safelyClear) {
+    unresolved.releaseLockAfterRecovery();
+    try {
+      await withTimeout(
+        unresolved.releaseCompleted,
+        PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
+        "mint recovery release timed out.",
+      );
+      setMintFlowError(
+        "Recovery check complete: two nonce checks found no hash or account activity. The old wallet waiter is detached and any late hash will still be retained and monitored. Retry only after confirming the wallet shows no open request.",
+        "mint",
+        { preserveAuthorization: true },
+      );
+      emitThoughtConsoleEvent({
+        kind: "mint_submission_detached",
+        title: "wallet waiter safely detached",
+        detail: "No hash or nonce activity was found twice. Any late transaction remains monitored.",
+        eventId: `mint-submission-detached:${unresolved.requestId}`,
+        tone: "warning",
+      });
+      syncInterface();
+      return;
+    } catch {
+      // A failed release is inconclusive; keep the UI in no-duplicate mode.
+    }
+  }
+
+  setMintFlowError(
+    nonceAdvanced
+      ? `Wallet activity was detected at nonce ${unresolved.submission.nonce}, but no transaction hash has returned. The original submission is unresolved; do not submit a duplicate.`
+      : "Wallet activity could not be ruled out twice. The original wallet request is still unresolved. Cancel or reject it in the wallet and wait for it to settle; do not submit a duplicate.",
+    "mint",
+    { preserveAuthorization: true, preserveSubmittedTransaction: true },
+  );
+  emitThoughtConsoleEvent({
+    kind: "mint_activity_checked",
+    title: nonceAdvanced ? "wallet activity detected" : "wallet request still unresolved",
+    detail: mintFlowData.error,
+    eventId: `mint-activity-checked:${unresolved.requestId}:${nonceAdvanced ? "advanced" : "waiting"}`,
+    tone: "warning",
+  });
+  syncInterface();
 };
 
 const pathMintUrl = () => {
   try {
     const url = new URL(PATH_MINT_URL, sameOriginAppOrigin());
+    const returnUrl = new URL(window.location.href);
+    returnUrl.searchParams.set("pathHandoff", mintAttemptId);
     url.searchParams.set("intent", "mint-path");
     url.searchParams.set("from", "thought");
     url.searchParams.set(
       "returnTo",
-      `${window.location.pathname}${window.location.search}${window.location.hash}` || thoughtRoutePath("/"),
+      `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}` || thoughtRoutePath("/"),
     );
+    url.searchParams.set("handoff", mintAttemptId);
     if (walletState.address) {
       url.searchParams.set("account", walletState.address);
     }
@@ -10221,7 +12280,39 @@ const pathMintUrl = () => {
 };
 
 const handleMintPath = () => {
-  window.open(pathMintUrl(), "_blank", "noopener,noreferrer");
+  if (!currentOutputText) {
+    setMintFlowError("No accepted work to preserve for PATH mint.", "thought");
+    syncInterface();
+    return;
+  }
+  if (mintFlowData.errorKind === "path_mint_chain_mismatch") {
+    // Keep the mismatched return record as diagnostics, but never send PATH
+    // back into that completed handoff. The URL and new stored handoff must
+    // share one fresh ID.
+    mintAttemptId = nextMintAttemptId("path");
+  }
+  const workHash = keccak256(toUtf8Bytes(currentOutputText));
+  writePathMintHandoff({
+    version: 1,
+    attemptId: mintAttemptId,
+    workHash,
+    account: walletState.address,
+    chainId: THOUGHT_CHAIN_ID,
+    work: {
+      output: currentOutputText,
+      svg: currentWorkSvg,
+      runContext: currentRunContext,
+      workId: currentWorkId,
+    },
+    createdAt: Date.now(),
+  });
+  emitThoughtConsoleEvent({
+    kind: "path_mint_handoff",
+    title: "opening PATH mint",
+    detail: "Your THOUGHT work and mint history are preserved for the return.",
+    eventId: `path-handoff:${mintAttemptId}`,
+  });
+  window.location.assign(pathMintUrl());
 };
 
 const chooseAnotherPath = () => {
@@ -10248,13 +12339,16 @@ const refreshMintSheetPath = async () => {
     mintFlowState = "wallet_required";
     mintFlowData.error = "";
     mintFlowData.errorKind = "none";
+    recordCurrentMintConsoleState();
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
   if (walletState.chainId !== THOUGHT_CHAIN_ID) {
     setMintFlowError("wrong network.", "wrong_network");
     syncInterface();
+    focusMintDockStage();
     return;
   }
 
@@ -10265,6 +12359,7 @@ const refreshMintSheetPath = async () => {
 
   moveMintFlowToWalletOrPathSelection();
   syncInterface();
+  focusMintDockStage("path");
 };
 
 const handleMintSheetAction = async (action: MintSheetAction) => {
@@ -10279,16 +12374,28 @@ const handleMintSheetAction = async (action: MintSheetAction) => {
 
   if (action === "connect_wallet") {
     await requestWalletConnect();
+    if (blockPendingMintMutation()) {
+      return;
+    }
+    if (walletState.address && readPathMintHandoff()) {
+      const resumed = await resumePathMintHandoff();
+      if (resumed) {
+        return;
+      }
+    }
     if (!walletState.address) {
       mintFlowState = "wallet_required";
+      recordCurrentMintConsoleState();
     } else if (walletState.chainId !== THOUGHT_CHAIN_ID) {
       setMintFlowError("wrong network.", "wrong_network");
     } else {
       mintFlowState = "path_required";
       mintFlowData.error = "";
       mintFlowData.errorKind = "none";
+      recordCurrentMintConsoleState();
     }
     syncInterface();
+    focusMintDockStage("path");
     return;
   }
 
@@ -10304,11 +12411,17 @@ const handleMintSheetAction = async (action: MintSheetAction) => {
 
   if (action === "confirm_mint") {
     await confirmMint();
+    focusMintDockStage();
     return;
   }
 
   if (action === "view_tx") {
     await handleViewTx();
+    return;
+  }
+
+  if (action === "recover_submission") {
+    await recoverUnresolvedMintSubmission();
     return;
   }
 
@@ -10333,6 +12446,16 @@ const handleMintSheetAction = async (action: MintSheetAction) => {
   }
 
   if (action === "refresh") {
+    const pathHandoff = readPathMintHandoff();
+    const pathReturn = pathHandoff
+      ? readPathMintReturnRecord(getPathMintReturnStorageHost(), pathHandoff.attemptId)
+      : null;
+    if (pathHandoff && (pathReturn || mintFlowData.errorKind === "wallet_account_mismatch")) {
+      await refreshWalletState();
+      await resumePathMintHandoff();
+      syncInterface();
+      return;
+    }
     await refreshMintSheetPath();
     return;
   }
@@ -10345,16 +12468,27 @@ const handleMintSheetAction = async (action: MintSheetAction) => {
 
   if (action === "switch_network") {
     await switchWalletChain();
+    if (walletState.address && walletState.chainId === THOUGHT_CHAIN_ID && readPathMintHandoff()) {
+      const resumed = await resumePathMintHandoff();
+      if (resumed) {
+        syncInterface();
+        focusMintDockStage("path");
+        return;
+      }
+    }
     if (!walletState.address) {
       mintFlowState = "wallet_required";
+      recordCurrentMintConsoleState();
     } else if (walletState.chainId !== THOUGHT_CHAIN_ID) {
       setMintFlowError("wrong network.", "wrong_network");
     } else {
       mintFlowState = "path_required";
       mintFlowData.error = "";
       mintFlowData.errorKind = "none";
+      recordCurrentMintConsoleState();
     }
     syncInterface();
+    focusMintDockStage("path");
   }
 };
 
@@ -11749,12 +13883,16 @@ const syncOutputToCanvas = (raw: string, options?: { suppressWarning?: boolean }
 };
 
 const setAgentOutput = (text: string, rawOutput: string, svg: string) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   resetMintRuntimeState();
   currentOutputText = text;
   currentWorkSvg = svg;
   showContractSvgPreview(svg);
   currentWorkId = recordCurrentWork(rawOutput);
   writeCurrentOutputSession();
+  return true;
 };
 
 const hasCurrentContractWorkSvg = () => currentWorkSvg.trim().startsWith("<svg");
@@ -11809,6 +13947,9 @@ const recordCurrentWork = (rawOutput: string) => {
 };
 
 const loadWorkRecord = (work: ThoughtWorkRecord) => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return false;
+  }
   resetMintRuntimeState();
   currentOutputText = thoughtProtocolText(work.text || work.title, IS_LOCAL_THOUGHT_V2);
   currentWorkSvg = work.svg ?? "";
@@ -11818,6 +13959,7 @@ const loadWorkRecord = (work: ThoughtWorkRecord) => {
   syncCurrentWorkVisual({ suppressWarning: true });
   writeCurrentOutputSession();
   syncInterface();
+  return true;
 };
 
 const isThoughtRunContext = (value: unknown): value is ThoughtRunContext => {
@@ -11981,6 +14123,9 @@ const recordThoughtRun = (
 };
 
 const resetThought = (options?: { preserveStoredOutput?: boolean }) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   runState = "idle";
   walletConnectInFlight = false;
   pendingMyBrainRunPayload = null;
@@ -12000,6 +14145,7 @@ const resetThought = (options?: { preserveStoredOutput?: boolean }) => {
   setStatus("");
   syncCtaState();
   syncPrimaryCtaAvailability();
+  return true;
 };
 
 const base64UrlEncode = (bytes: Uint8Array) => {
@@ -13311,6 +15457,9 @@ const refreshCurrentModels = (options?: { silent?: boolean }) =>
     : Promise.resolve();
 
 const setMode = (mode: Mode) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   sessionState.routeConfigured = true;
   sessionState.mode = mode;
   pendingMyBrainRunPayload = null;
@@ -13331,6 +15480,7 @@ const setMode = (mode: Mode) => {
   }
 
   setStatus("");
+  return true;
 };
 
 const setThoughtInstructionsOverride = (override: ThoughtInstructionsOverride | null) => {
@@ -13372,6 +15522,9 @@ const promotePreviewedCandidateToWork = (
   preview: ContractWorkPreview,
   trace: ThoughtPreviewProviderTrace,
 ) => {
+  if (blockPendingMintMutation()) {
+    return false;
+  }
   lastRejectedRun = null;
   lastPreviewRetryContext = null;
   recordThoughtRun(
@@ -13381,7 +15534,9 @@ const promotePreviewedCandidateToWork = (
     trace,
     candidate.agentEvidence,
   );
-  setAgentOutput(preview.text, candidate.rawModelReturn, preview.svg);
+  if (!setAgentOutput(preview.text, candidate.rawModelReturn, preview.svg)) {
+    return false;
+  }
   clearCurrentCandidate();
   runState = "output_ready";
   walletState.txState = "idle";
@@ -13394,6 +15549,7 @@ const promotePreviewedCandidateToWork = (
   });
   setStatus("");
   setWarning("");
+  return true;
 };
 
 const completeThoughtRunFromModelReturn = async (
@@ -13401,6 +15557,9 @@ const completeThoughtRunFromModelReturn = async (
   modelReturn: string,
   agentEvidence?: ThoughtV2LocalAgentEvidence,
 ) => {
+  if (blockPendingMintMutation()) {
+    return { kind: "pending_mint" as const };
+  }
   const candidate = createThoughtCandidate(thoughtRunPayload, modelReturn, agentEvidence);
   currentCandidate = candidate;
   writeCurrentCandidateSession();
@@ -13426,7 +15585,9 @@ const completeThoughtRunFromModelReturn = async (
     throw attempt.error;
   }
 
-  promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace);
+  if (!promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace)) {
+    return { kind: "pending_mint" as const };
+  }
   return attempt;
 };
 
@@ -13455,6 +15616,10 @@ const runAgent = async (options?: { forceGenerate?: boolean; cli?: boolean }) =>
     if (primaryActionState === "none") {
       return;
     }
+  }
+
+  if (blockPendingMintMutation({ cli: options?.cli })) {
+    return;
   }
 
   if (!isRouteConfigured()) {
@@ -15072,6 +17237,9 @@ const setCliModel = (modelId: string) => {
     return;
   }
 
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   setCurrentModelValue(modelId);
@@ -15109,6 +17277,9 @@ const setCliProvider = (providerId: string) => {
     return;
   }
 
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.mode = "direct";
@@ -15144,6 +17315,9 @@ const setCliApiKey = (keyInput: string) => {
   }
 
   if (key.toLowerCase() === "clear") {
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     resetMintRuntimeState();
     pendingMyBrainRunPayload = null;
     clearDirectApiKey();
@@ -15153,6 +17327,9 @@ const setCliApiKey = (keyInput: string) => {
     return;
   }
 
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.mode = "direct";
@@ -15175,6 +17352,9 @@ const setCliPrompt = (promptInput: string) => {
   }
 
   if (commandValue.toLowerCase() === "clear") {
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     resetMintRuntimeState();
     pendingMyBrainRunPayload = null;
     sessionState.prompt = "";
@@ -15184,6 +17364,9 @@ const setCliPrompt = (promptInput: string) => {
     return;
   }
 
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.prompt = protocolLineInput(promptInput);
@@ -15198,7 +17381,9 @@ const outputCliMode = async (mode: Mode | "") => {
     return;
   }
 
-  setMode(mode);
+  if (blockPendingMintMutation({ cli: true }) || !setMode(mode)) {
+    return;
+  }
   await refreshCurrentModels({ silent: true });
   const lines = mode === MY_BRAIN_MODE
     ? [
@@ -15269,6 +17454,9 @@ const outputCliPreviewConfig = (previewInput: string) => {
     return;
   }
 
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   writePreviewMode(mode);
   appendCliOutput([
     `preview mode: ${mode}`,
@@ -15279,8 +17467,11 @@ const outputCliPreviewConfig = (previewInput: string) => {
 };
 
 const startOpenRouterConnectFromCli = async () => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   if (!isRouteConfigured() || sessionState.mode !== "connect") {
-    setMode("connect");
+    if (!setMode("connect")) return;
   }
   if (sessionState.connect.apiKey.trim()) {
     appendCliOutput(["openrouter linked.", "route: connect", "use: run"]);
@@ -15314,7 +17505,9 @@ const outputCliLocalDetectionResult = () => {
 
 const outputCliRouteModel = async (mode: Mode, modelInput: string) => {
   if (!isRouteConfigured() || sessionState.mode !== mode) {
-    setMode(mode);
+    if (blockPendingMintMutation({ cli: true }) || !setMode(mode)) {
+      return;
+    }
   }
 
   const normalizedInput = modelInput.trim().toLowerCase();
@@ -15348,6 +17541,9 @@ const outputCliLocalConfig = async (localInput: string) => {
   }
 
   if (lowerHead === "detect" || lowerHead === "retry") {
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     pendingMyBrainRunPayload = null;
     sessionState.routeConfigured = true;
     sessionState.mode = "local";
@@ -15372,6 +17568,9 @@ const outputCliLocalConfig = async (localInput: string) => {
       return;
     }
 
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     try {
       sessionState.mode = "local";
       sessionState.routeConfigured = true;
@@ -15438,11 +17637,17 @@ const outputCliConnectConfig = async (connectInput: string) => {
   }
 
   if (lowerHead === "authorize" || lowerHead === "openrouter") {
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     await startOpenRouterConnectFromCli();
     return;
   }
 
   if (lowerHead === "disconnect") {
+    if (blockPendingMintMutation({ cli: true })) {
+      return;
+    }
     pendingMyBrainRunPayload = null;
     disconnectOpenRouter();
     appendCliOutput(["openrouter unlinked.", "use: config connect authorize"]);
@@ -15459,7 +17664,9 @@ const outputCliConnectConfig = async (connectInput: string) => {
 
 const outputCliMyBrainConfig = async (myBrainInput: string) => {
   if (!isRouteConfigured() || sessionState.mode !== MY_BRAIN_MODE) {
-    setMode(MY_BRAIN_MODE);
+    if (blockPendingMintMutation({ cli: true }) || !setMode(MY_BRAIN_MODE)) {
+      return;
+    }
   }
 
   const [head = ""] = myBrainInput.trim().split(/\s+/, 1);
@@ -15474,7 +17681,9 @@ const outputCliMyBrainConfig = async (myBrainInput: string) => {
 
 const outputCliCodexConfig = async (codexInput: string) => {
   if (!isRouteConfigured() || sessionState.mode !== CODEX_MODE) {
-    setMode(CODEX_MODE);
+    if (blockPendingMintMutation({ cli: true }) || !setMode(CODEX_MODE)) {
+      return;
+    }
   }
 
   const [head = ""] = codexInput.trim().split(/\s+/, 1);
@@ -15973,8 +18182,9 @@ const loadWorkFromCli = (input: string) => {
     return;
   }
 
-  loadWorkRecord(work);
-  appendCliOutput(workDetailLines(work));
+  if (loadWorkRecord(work)) {
+    appendCliOutput(workDetailLines(work));
+  }
 };
 
 const loadPreviousWorkFromCli = () => {
@@ -15984,8 +18194,9 @@ const loadPreviousWorkFromCli = () => {
     return;
   }
 
-  loadWorkRecord(work);
-  appendCliOutput(workDetailLines(work));
+  if (loadWorkRecord(work)) {
+    appendCliOutput(workDetailLines(work));
+  }
 };
 
 const loadNextWorkFromCli = () => {
@@ -15995,8 +18206,9 @@ const loadNextWorkFromCli = () => {
     return;
   }
 
-  loadWorkRecord(work);
-  appendCliOutput(workDetailLines(work));
+  if (loadWorkRecord(work)) {
+    appendCliOutput(workDetailLines(work));
+  }
 };
 
 const loadLatestWorkFromCli = () => {
@@ -16006,8 +18218,9 @@ const loadLatestWorkFromCli = () => {
     return;
   }
 
-  loadWorkRecord(work);
-  appendCliOutput(workDetailLines(work));
+  if (loadWorkRecord(work)) {
+    appendCliOutput(workDetailLines(work));
+  }
 };
 
 const myBrainRunPendingLines = () => [
@@ -16048,6 +18261,9 @@ const buildMyBrainRunPayload = async (): Promise<PendingMyBrainRound> => {
 };
 
 const startMyBrainRunFromCli = async () => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   try {
     pendingMyBrainRunPayload = await buildMyBrainRunPayload();
     runState = "running";
@@ -16084,6 +18300,9 @@ const cliWorkReadyLines = () => {
 };
 
 const returnMyBrainModelTextFromCli = async (returnInput: string) => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   if (sessionState.mode !== MY_BRAIN_MODE) {
     appendCliError(["return unavailable.", `route: ${sessionState.mode}`, "use: config my-brain", "use: run"]);
     return;
@@ -16119,6 +18338,11 @@ const returnMyBrainModelTextFromCli = async (returnInput: string) => {
       appendCliOutput(result.lines);
       return;
     }
+    if (result.kind === "pending_mint") {
+      pendingMyBrainRunPayload = null;
+      blockPendingMintMutation({ cli: true });
+      return;
+    }
     pendingMyBrainRunPayload = null;
     appendCliOutput(["preview accepted.", "current work set.", "", ...cliWorkReadyLines()]);
   } catch (error) {
@@ -16150,6 +18374,9 @@ const cancelMyBrainRunFromCli = () => {
 };
 
 const retryContractPreviewFromCli = async () => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   let candidate = currentCandidate;
   if (!candidate && lastPreviewRetryContext) {
     candidate = createThoughtCandidate(
@@ -16178,7 +18405,9 @@ const retryContractPreviewFromCli = async () => {
     if (attempt.kind === "rejected") {
       throw attempt.error;
     }
-    promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace);
+    if (!promotePreviewedCandidateToWork(candidate, attempt.preview, attempt.trace)) {
+      return;
+    }
     const lines = cliWorkReadyLines();
     if (lines[0] === "work blocked.") {
       appendCliError(lines);
@@ -16309,6 +18538,9 @@ const resumePendingThoughtAgentRun = () => {
 };
 
 const runFromCli = async () => {
+  if (blockPendingMintMutation({ cli: true })) {
+    return;
+  }
   if (!isRouteConfigured()) {
     appendCliError(["run failed.", ...routeRequiredLines()]);
     return;
@@ -17719,8 +19951,11 @@ const executeCliCommand = async (rawCommand: string) => {
       writeCliTranscript();
       initializeCliTranscript();
     } else if (lowerHead === "reset") {
-      resetThought();
-      appendCliOutput(["reset current work, canvas, and mint state.", "next: prompt <text>"]);
+      if (resetThought()) {
+        appendCliOutput(["reset current work, canvas, and mint state.", "next: prompt <text>"]);
+      } else {
+        blockPendingMintMutation({ cli: true });
+      }
     } else if (lowerHead === "gallery") {
       if (hasPendingMintTransaction()) {
         appendCliOutput([
@@ -17967,6 +20202,11 @@ providerBox.addEventListener("change", () => {
     return;
   }
 
+  if (blockPendingMintMutation()) {
+    providerBox.value = sessionState.direct.provider;
+    return;
+  }
+
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.direct.provider = providerBox.value;
@@ -17979,6 +20219,10 @@ providerBox.addEventListener("change", () => {
 });
 
 apiKeyBox.addEventListener("input", () => {
+  if (blockPendingMintMutation()) {
+    apiKeyBox.value = getDirectApiKey();
+    return;
+  }
   pendingMyBrainRunPayload = null;
   setDirectApiKey(apiKeyBox.value);
   writeSessionState();
@@ -17986,6 +20230,10 @@ apiKeyBox.addEventListener("input", () => {
 });
 
 modelBox.addEventListener("change", () => {
+  if (blockPendingMintMutation()) {
+    syncModelControls();
+    return;
+  }
   syncManualModelField();
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
@@ -18001,6 +20249,10 @@ modelBox.addEventListener("change", () => {
 });
 
 modelManualBox.addEventListener("input", () => {
+  if (blockPendingMintMutation()) {
+    modelManualBox.value = getCurrentModelValue();
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   setCurrentModelValue(modelManualBox.value.trim());
@@ -18010,6 +20262,10 @@ modelManualBox.addEventListener("input", () => {
 });
 
 promptBox.addEventListener("input", () => {
+  if (blockPendingMintMutation()) {
+    promptBox.value = sessionState.prompt;
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.prompt = promptBox.value;
@@ -18018,6 +20274,10 @@ promptBox.addEventListener("input", () => {
 });
 
 thoughtDockPrompt.addEventListener("input", () => {
+  if (blockPendingMintMutation()) {
+    thoughtDockPrompt.value = sessionState.prompt;
+    return;
+  }
   resetMintRuntimeState();
   pendingMyBrainRunPayload = null;
   sessionState.prompt = thoughtDockPrompt.value;
@@ -18268,6 +20528,8 @@ window.addEventListener("beforeunload", () => {
 });
 window.addEventListener("focus", () => {
   refreshThoughtDockPolling();
+  resumePendingMintReceiptMonitoring();
+  resumeConflictingMintReceiptMonitoring();
   const canSoftRefresh =
     mintFlowState === "path_required" ||
     mintFlowState === "path_ready" ||
@@ -18276,33 +20538,50 @@ window.addEventListener("focus", () => {
   if (
     !canSoftRefresh ||
     !walletState.address ||
-    !canContinueWithPathInput() ||
     Date.now() - lastMintSheetFocusRefreshAt < 8000
   ) {
     return;
   }
 
   lastMintSheetFocusRefreshAt = Date.now();
-  void refreshMintSheetPath();
+  void refreshWalletState().then(async () => {
+    if (!walletState.address || walletState.chainId !== THOUGHT_CHAIN_ID) return;
+    await refreshPathInventoryForCurrentWallet({ force: true });
+    if (canContinueWithPathInput() && mintFlowState !== "authorizing" && mintFlowState !== "minting") {
+      await checkPathEligibility();
+    }
+  });
 });
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") {
     refreshThoughtDockPolling();
+    resumePendingMintReceiptMonitoring();
+    resumeConflictingMintReceiptMonitoring();
   }
 });
 window.addEventListener("pageshow", () => {
   refreshThoughtDockPolling();
+  resumePendingMintReceiptMonitoring();
+  resumeConflictingMintReceiptMonitoring();
 });
 document.addEventListener("resume", () => {
   refreshThoughtDockPolling();
+  resumePendingMintReceiptMonitoring();
+  resumeConflictingMintReceiptMonitoring();
 });
 window.addEventListener("online", () => {
   refreshThoughtDockPolling();
+  resumePendingMintReceiptMonitoring();
+  resumeConflictingMintReceiptMonitoring();
 });
 document.addEventListener("keydown", (event) => {
-  if (event.key === "Escape" && mintFlowState !== "closed") {
-    closeMintSheet();
-  }
+    if (
+      event.key === "Escape" &&
+      mintFlowUiMode === "sheet" &&
+      mintFlowState !== "closed"
+    ) {
+      closeMintSheet();
+    }
 });
 
 const initFrontpage = async () => {
@@ -18440,7 +20719,17 @@ const initFrontpage = async () => {
 
   bindThoughtShellWallet();
   bindWalletProviderEvents();
+  bindPendingMintStorageEvents();
   await refreshWalletState();
+  const resumedPendingMint = await resumePendingMintTransaction();
+  resumeConflictingMintReceiptMonitoring();
+  let resumedPathMint = false;
+  if (!resumedPendingMint) {
+    resumedPathMint = await resumePathMintHandoff();
+  }
+  if (!resumedPendingMint && !resumedPathMint) {
+    recordCurrentMintConsoleState();
+  }
   syncInterface();
 
   void ensureActiveThoughtSpec()

--- a/apps/thought/src/main.ts
+++ b/apps/thought/src/main.ts
@@ -113,10 +113,12 @@ import {
 } from "./thought-preview-policy";
 import { createSingleRequestJsonRpcProvider } from "./rpc-provider";
 import {
+  formatThoughtAuthorizationError,
   getThoughtWorkReadyPresentation,
   THOUGHT_PANEL_MINT_UI_MODE,
   THOUGHT_V2_MINT_UNAVAILABLE_COPY,
   type MintFlowUiMode,
+  type ThoughtAuthorizationStage,
 } from "./thought-mint-ui";
 import { buildThoughtConsoleLines } from "./thought-console";
 import { canonicalThoughtTitle, thoughtProtocolText } from "./thought-display-text";
@@ -125,6 +127,7 @@ import {
   THOUGHT_V2_LOCAL_NFT_ABI,
   buildThoughtV2LocalProvenance,
   thoughtV2AgentLineHash,
+  type ThoughtV2LocalProcess,
 } from "./thought-v2-local-mint";
 import {
   buildThoughtV2LocalAgentProcess,
@@ -969,6 +972,7 @@ const THOUGHT_AGENT_STATUS_POLL_MS = 1000;
 const THOUGHT_AGENT_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 const THOUGHT_DOCK_RETURN_RECEIVED_MS = 420;
 const PREFLIGHT_REQUEST_TIMEOUT_MS = 15000;
+const PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS = 15000;
 const WALLET_TX_SUBMIT_TIMEOUT_MS = 60000;
 const MINT_RECEIPT_TIMEOUT_MS = 120000;
 const MINT_RECEIPT_POLL_MS = 1000;
@@ -3607,7 +3611,7 @@ const visibleMintErrorCopy = () => {
     return "PATH has no THOUGHT unit available.";
   }
   if (mintFlowData.errorKind === "signature") {
-    return /expired/i.test(mintFlowData.error) ? "authorization expired." : "transaction rejected.";
+    return mintFlowData.error || "authorization failed.";
   }
   if (mintFlowData.errorKind === "thought") {
     return mintFlowData.error || "mint failed.";
@@ -5133,6 +5137,7 @@ let readPathNft: Contract | null = null;
 let walletListenersBound = false;
 let thoughtShellWalletSubscribed = false;
 let thoughtShellWalletRefreshQueued = false;
+let mintAuthorizationRequestId = 0;
 let mintSheetPrimaryAction: MintSheetAction = "none";
 let mintSheetSecondaryAction: MintSheetAction = "none";
 let mintSheetTertiaryAction: MintSheetAction = "none";
@@ -7381,7 +7386,7 @@ const buildProvenanceJson = (
   };
   if (IS_LOCAL_THOUGHT_V2 && mint) {
     const agentLine = currentOutputText || context.returnedText || "";
-    let process;
+    let process: ThoughtV2LocalProcess;
     if (context.mode === MY_BRAIN_MODE) {
       process = { kind: "manual" };
     } else {
@@ -7518,6 +7523,7 @@ const verifyThoughtSpecAnchor = async () => {
 };
 
 const clearMintAuthorization = () => {
+  mintAuthorizationRequestId += 1;
   mintFlowData.deadline = null;
   mintFlowData.signature = "";
 };
@@ -7579,10 +7585,20 @@ const signPathConsumeAuthorization = async (
   signer: JsonRpcSigner,
   claimer: string,
   pathId: bigint,
+  onStage: (stage: ThoughtAuthorizationStage) => void,
 ) => {
-  const pathNft = new Contract(PATH_NFT_ADDRESS, PATH_NFT_ABI, signer);
-  const nonce = (await pathNft.getConsumeNonce(claimer)) as bigint;
+  const pathNft = getReadPathNft();
+  if (!pathNft) {
+    throw new Error("PATH authorization unavailable.");
+  }
+  onStage("nonce");
+  const nonce = await withTimeout(
+    pathNft.getConsumeNonce(claimer) as Promise<bigint>,
+    PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
+    "PATH authorization request timed out.",
+  );
   const deadline = BigInt(Math.floor(Date.now() / 1000)) + PATH_CONSUME_AUTH_TTL_SECONDS;
+  onStage("digest");
   const structHash = keccak256(
     EVM_ABI_CODER.encode(
       [
@@ -7609,6 +7625,7 @@ const signPathConsumeAuthorization = async (
       ],
     ),
   );
+  onStage("signature");
   const signature = await signer.signMessage(getBytes(structHash));
   return { deadline, signature };
 };
@@ -9616,16 +9633,23 @@ const checkPathEligibility = async () => {
 };
 
 const authorizeMint = async () => {
-  const ethereum = getEthereumProvider();
-  if (!ethereum || !walletState.address || mintFlowData.pathId === null) {
+  if (!getEthereumProvider() || !walletState.address || mintFlowData.pathId === null) {
     mintFlowState = "wallet_required";
     syncInterface();
     return;
   }
 
-  try {
-    await rebuildFinalMintProvenance();
+  if (mintFlowState === "authorizing") {
+    return;
+  }
 
+  const expectedAddress = walletState.address;
+  const expectedPathId = mintFlowData.pathId;
+  const requestId = mintAuthorizationRequestId + 1;
+  mintAuthorizationRequestId = requestId;
+  let authorizationStage: ThoughtAuthorizationStage = "preparing";
+
+  try {
     mintFlowState = "authorizing";
     walletState.txError = "";
     mintFlowData.error = "";
@@ -9634,26 +9658,67 @@ const authorizeMint = async () => {
     setWarning("");
     setStatus("");
 
+    await rebuildFinalMintProvenance();
+    if (requestId !== mintAuthorizationRequestId) return;
+    if (mintFlowData.pathId !== expectedPathId) return;
+
+    authorizationStage = "wallet";
+    const ethereum = getEthereumProvider();
+    if (!ethereum) {
+      throw new Error("wallet not connected");
+    }
+    const [liveAccounts, liveChainHex] = await withTimeout(
+      Promise.all([
+        ethereum.request({ method: "eth_accounts" }),
+        ethereum.request({ method: "eth_chainId" }),
+      ]),
+      PATH_AUTHORIZATION_REQUEST_TIMEOUT_MS,
+      "wallet status request timed out.",
+    );
+    if (requestId !== mintAuthorizationRequestId) return;
+    const liveAddress = extractPrimaryAccount(liveAccounts);
+    const liveChainId =
+      typeof liveChainHex === "string" && liveChainHex.length > 0
+        ? Number(BigInt(liveChainHex))
+        : null;
+    if (!liveAddress) {
+      throw new Error("wallet not connected");
+    }
+    if (liveChainId !== THOUGHT_CHAIN_ID) {
+      throw new Error("wrong network");
+    }
+    if (liveAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+      throw new Error("wallet account changed");
+    }
+    if (mintFlowData.pathId !== expectedPathId) return;
+
     const browserProvider = new BrowserProvider(ethereum);
-    const signer = await browserProvider.getSigner();
-    const consumeAuth = await signPathConsumeAuthorization(signer, await signer.getAddress(), mintFlowData.pathId);
+    const signer = await browserProvider.getSigner(expectedAddress);
+    const signerAddress = await signer.getAddress();
+    if (signerAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+      throw new Error("wallet account changed");
+    }
+    const consumeAuth = await signPathConsumeAuthorization(
+      signer,
+      signerAddress,
+      expectedPathId,
+      (stage) => {
+        authorizationStage = stage;
+      },
+    );
+    if (requestId !== mintAuthorizationRequestId) return;
     mintFlowData.deadline = consumeAuth.deadline;
     mintFlowData.signature = consumeAuth.signature;
     mintFlowState = "authorized";
-    syncInterface();
   } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    if (message.includes("provenance too large")) {
-      setMintFlowError(message, "thought");
-      syncInterface();
-      return;
-    }
-    setMintFlowError(
-      message.startsWith("spec ") ? message : "authorization rejected.",
-      message.startsWith("spec ") ? "spec" : "signature",
-    );
+    if (requestId !== mintAuthorizationRequestId) return;
+    const presentation = formatThoughtAuthorizationError(error, authorizationStage);
+    setMintFlowError(presentation.message, presentation.kind);
     syncInterface();
+    return;
   }
+
+  syncInterface();
 };
 
 type MintTransactionResponse = {

--- a/apps/thought/src/style.css
+++ b/apps/thought/src/style.css
@@ -367,7 +367,7 @@ html.agent-demo-route .frontpage-stage {
   margin: 0;
   color: var(--accent);
   font-size: var(--shell-route-title-font-size);
-  font-weight: var(--shell-route-title-font-weight);
+  font-weight: var(--weight-thin);
   line-height: var(--shell-route-title-line-height);
   letter-spacing: var(--shell-route-title-letter-spacing);
 }
@@ -1532,6 +1532,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 .thought-panel .thought-dock-status-screen,
 .thought-panel .thought-dock-status-screen :where(*) {
   font-size: var(--font-size-14);
+  font-weight: var(--weight-mid);
 }
 
 .frontpage-input-panel {

--- a/apps/thought/src/style.css
+++ b/apps/thought/src/style.css
@@ -186,11 +186,12 @@ body {
   --thought-dock-control-height: calc(var(--thought-dock-row-height) - 16px);
   --thought-dock-chip-height: 26px;
   --thought-panel-section-padding: 12px 14px;
+  --thought-panel-control-gap: 10px;
+  --thought-panel-console-gap: 22px;
+  --thought-panel-row-alignment: center;
   --thought-mint-hairline-width: 1px;
   --thought-mint-stage-gap: 12px;
-  --thought-mint-copy-gap: 4px;
   --thought-mint-inventory-gap: 7px;
-  --thought-mint-review-row-gap: 5px;
   --thought-mint-action-gap: 14px;
   --thought-mint-progress-gap: 6px;
   --thought-mint-progress-cell-padding: 7px 8px;
@@ -200,14 +201,14 @@ body {
   --thought-path-picker-max-height: calc(
     (var(--thought-dock-chip-height) * 3) + (var(--thought-path-picker-gap) * 2)
   );
-  --thought-mint-review-max-height: 180px;
-  --thought-wallet-context-space: 8px;
-  --thought-focus-ring-width: 2px;
-  --thought-focus-ring-offset: 2px;
-  --thought-mint-link-underline-offset: 3px;
+  --thought-focus-ring-width: 1px;
+  --thought-focus-ring-offset: 1px;
   --thought-console-entry-gap: 14px;
   --thought-console-boundary-padding: 10px;
-  --thought-console-history-opacity: 0.5;
+  --thought-console-text-opacity: 0.5;
+  --thought-console-warning-opacity: 1;
+  --thought-progress-ellipsis-cycle: 900ms;
+  --thought-progress-ellipsis-dim-opacity: 0.2;
   --thought-frontpage-shell-padding-block-start: var(--shell-route-padding-block-start);
   --thought-frontpage-shell-padding-block-end: 18px;
   --thought-frontpage-shell-padding-inline: 20px;
@@ -222,13 +223,20 @@ body.frontpage {
   --thought-art-canvas-bg: #000000;
   --detail-scrollbar-track: #050505;
   --detail-scrollbar-thumb: rgba(178, 184, 198, 0.5);
-  --thought-panel-accent-text: #00a000;
+  --thought-panel-interactive: #ffffff;
+  --thought-panel-interactive-soft: rgba(255, 255, 255, 0.08);
+  --thought-panel-on-interactive: #000000;
+  --thought-panel-accent-text: var(--thought-panel-interactive);
   --thought-panel-subtle-text: #9ca3af;
   --thought-panel-error-text: #ff6b6b;
-  --thought-focus-ring-color: var(--text);
+  --thought-panel-secondary-text: #ffffff;
+  --thought-console-text: #ffffff;
+  --thought-console-warning-text: #8b731c;
+  --thought-button-on-accent: var(--thought-panel-on-interactive);
+  --thought-button-disabled-text: var(--thought-panel-subtle-text);
+  --thought-focus-ring-color: var(--thought-panel-interactive);
   --thought-dock-button-color: var(--muted);
-  --thought-dock-button-hover: var(--accent);
-  --thought-dock-status-color: var(--muted);
+  --thought-dock-button-hover: var(--thought-panel-interactive);
   --chip-bg: rgba(255, 255, 255, 0.02);
   --chip-border: rgba(255, 255, 255, 0.06);
   margin: 0;
@@ -245,12 +253,16 @@ body.frontpage {
   body.frontpage {
     --detail-scrollbar-track: rgba(255, 255, 255, 0.96);
     --detail-scrollbar-thumb: rgba(75, 85, 99, 0.45);
-    --thought-panel-accent-text: var(--accent);
+    --thought-panel-interactive: #000000;
+    --thought-panel-interactive-soft: rgba(0, 0, 0, 0.06);
+    --thought-panel-on-interactive: #ffffff;
+    --thought-panel-accent-text: var(--thought-panel-interactive);
     --thought-panel-subtle-text: var(--muted-dim);
     --thought-panel-error-text: #b91c1c;
+    --thought-panel-secondary-text: var(--text);
+    --thought-console-text: var(--text);
     --thought-dock-button-color: var(--muted);
-    --thought-dock-button-hover: var(--accent);
-    --thought-dock-status-color: var(--muted);
+    --thought-dock-button-hover: var(--thought-panel-interactive);
     --chip-bg: rgba(0, 0, 0, 0.02);
     --chip-border: rgba(0, 0, 0, 0.06);
   }
@@ -587,13 +599,16 @@ html.debug-cli body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-m
 
 .thought-panel {
   --thought-create-available-height: 100cqh;
+  --accent: var(--thought-panel-interactive);
+  --accent-border: var(--thought-panel-interactive);
+  --accent-bg: var(--thought-panel-interactive-soft);
   grid-area: panel;
   width: 100%;
   max-width: 100%;
   min-width: 0;
   height: min(var(--thought-cli-height), var(--thought-create-available-height));
   max-height: min(var(--thought-cli-height), var(--thought-create-available-height));
-  align-self: start;
+  align-self: var(--thought-panel-row-alignment);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -616,9 +631,7 @@ html.debug-cli body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-m
 }
 
 .thought-panel__title,
-.thought-panel__subtitle,
-.thought-panel__status-title,
-.thought-panel__status-detail {
+.thought-panel__subtitle {
   letter-spacing: 0;
 }
 
@@ -667,34 +680,8 @@ html.debug-cli body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-m
   overflow: visible;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: var(--thought-panel-console-gap);
   padding-top: 0;
-}
-
-.thought-panel__status {
-  display: grid;
-  gap: 8px;
-}
-
-.thought-panel__status-title,
-.thought-panel__status-detail {
-  margin: 0;
-  overflow-wrap: anywhere;
-}
-
-.thought-panel__status-title {
-  color: var(--accent);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-mid);
-  line-height: 1.55;
-  letter-spacing: 0.08em;
-}
-
-.thought-panel__status-detail {
-  color: var(--muted);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.55;
 }
 
 .frontpage-side {
@@ -761,16 +748,14 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   max-width: 100%;
   box-sizing: border-box;
   display: grid;
-  gap: 16px;
-  padding: var(--thought-panel-section-padding);
-  background: var(--panel);
+  gap: var(--thought-panel-control-gap);
+  padding: 0;
+  background: transparent;
 }
 
 .thought-dock {
   grid-area: auto;
   --thought-dock-input-text: var(--muted);
-  --thought-dock-status-text: var(--thought-dock-status-color);
-  --thought-dock-status-border: var(--thought-dock-status-color);
   width: 100%;
   max-width: 100%;
   height: auto;
@@ -779,116 +764,14 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
-    "input";
+    "input"
+    "actions";
   column-gap: 0;
-  row-gap: 0;
+  row-gap: var(--thought-path-picker-gap);
   box-sizing: border-box;
-  padding: 0;
-  background: transparent;
+  padding: var(--thought-panel-section-padding);
+  background: var(--panel);
   color: var(--muted);
-}
-
-.thought-dock[hidden] {
-  display: none;
-}
-
-.thought-wallet-strip {
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: var(--thought-wallet-context-space);
-  min-height: var(--thought-dock-control-height);
-  padding-block: var(--thought-wallet-context-space);
-  border-block: var(--thought-mint-hairline-width) solid var(--panel-border);
-  background: transparent;
-  color: var(--muted);
-  overflow: hidden;
-}
-
-.thought-wallet-strip.is-hidden {
-  display: none;
-}
-
-.thought-wallet-strip__copy {
-  min-width: 0;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  grid-template-areas:
-    "title detail"
-    "title meta";
-  align-items: start;
-  column-gap: var(--thought-wallet-context-space);
-  row-gap: calc(var(--thought-wallet-context-space) / 4);
-  overflow: hidden;
-}
-
-.thought-wallet-strip__title,
-.thought-wallet-strip__detail,
-.thought-wallet-strip__meta {
-  margin: 0;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.thought-wallet-strip__title {
-  grid-area: title;
-  flex: 0 0 auto;
-  color: var(--thought-panel-accent-text);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-mid);
-  line-height: 1.55;
-  letter-spacing: 0.08em;
-}
-
-.thought-wallet-strip__detail,
-.thought-wallet-strip__meta {
-  flex: 0 1 auto;
-  color: var(--muted);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.45;
-}
-
-.thought-wallet-strip__detail {
-  grid-area: detail;
-}
-
-.thought-wallet-strip__meta {
-  grid-area: meta;
-  flex: 1 1 auto;
-  color: var(--thought-panel-subtle-text);
-}
-
-.thought-wallet-strip__meta.is-hidden {
-  display: none;
-}
-
-.thought-wallet-strip__actions {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--thought-wallet-context-space);
-  min-width: 0;
-  overflow: hidden;
-}
-
-.thought-wallet-strip[data-tone="ready"] .thought-wallet-strip__title {
-  color: var(--thought-panel-accent-text);
-}
-
-.thought-wallet-strip[data-tone="warning"] .thought-wallet-strip__title,
-.thought-wallet-strip[data-tone="running"] .thought-wallet-strip__title {
-  color: var(--thought-panel-accent-text);
-}
-
-.thought-wallet-strip[data-tone="error"] .thought-wallet-strip__title {
-  color: var(--thought-panel-error-text);
 }
 
 .thought-dock-prompt-row {
@@ -922,6 +805,10 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   letter-spacing: 0.08em;
 }
 
+.thought-dock-label--secondary {
+  color: var(--thought-panel-secondary-text);
+}
+
 .thought-dock-input {
   width: 100%;
   min-height: 0;
@@ -950,7 +837,8 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   text-align: left;
 }
 
-.thought-dock-input:focus {
+.thought-dock-input:focus,
+.thought-panel .thought-panel__body .thought-dock-input:focus-visible {
   outline: none;
 }
 
@@ -971,8 +859,8 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   display: grid;
   gap: var(--thought-mint-stage-gap);
   padding: var(--thought-panel-section-padding);
-  border: var(--thought-mint-hairline-width) solid var(--panel-border);
-  background: var(--panel-soft);
+  border: 0;
+  background: var(--panel);
   color: var(--muted);
 }
 
@@ -982,6 +870,89 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 
 .thought-dock-path.is-hidden {
   display: none;
+}
+
+.thought-dock-works {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  display: grid;
+  gap: var(--thought-mint-stage-gap);
+  padding: var(--thought-panel-section-padding);
+  border: 0;
+  background: var(--panel);
+  color: var(--muted);
+}
+
+.thought-dock-works.is-hidden {
+  display: none;
+}
+
+.thought-dock-select-wrap {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.thought-dock-select {
+  width: 100%;
+  min-width: 0;
+  height: var(--thought-dock-chip-height);
+  box-sizing: border-box;
+  padding: 0 var(--font-size-22) 0 calc(var(--font-size-12) / 2);
+  border: var(--thought-mint-hairline-width) solid var(--accent);
+  border-radius: 0;
+  background: transparent;
+  color: var(--thought-panel-accent-text);
+  font: inherit;
+  font-size: var(--font-size-12);
+  font-weight: var(--weight-light);
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.thought-dock-select-arrow {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: var(--thought-mint-hairline-width);
+  width: var(--font-size-18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--thought-panel-accent-text);
+  pointer-events: none;
+}
+
+.thought-dock-select-arrow::before {
+  content: "";
+  width: calc(var(--font-size-12) / 2);
+  height: calc(var(--font-size-12) / 2);
+  box-sizing: border-box;
+  border-inline-end: var(--thought-mint-hairline-width) solid currentColor;
+  border-block-end: var(--thought-mint-hairline-width) solid currentColor;
+  transform: translateY(calc(var(--thought-mint-hairline-width) * -1)) rotate(45deg);
+}
+
+.thought-dock-select:disabled {
+  border-color: var(--thought-button-disabled-text);
+  color: var(--thought-button-disabled-text);
+  cursor: default;
+}
+
+.thought-dock-select:disabled + .thought-dock-select-arrow {
+  color: var(--thought-button-disabled-text);
+}
+
+.thought-dock-select option {
+  background: var(--panel);
+  color: var(--text);
 }
 
 .thought-dock-path-inventory {
@@ -994,151 +965,29 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   display: none;
 }
 
-.thought-dock-path-inventory-list {
-  max-height: var(--thought-path-picker-max-height);
-  align-content: flex-start;
-  gap: var(--thought-path-picker-gap);
-  padding-inline-end: var(--thought-path-picker-gap);
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-
 .thought-mint-step {
-  display: grid;
-  gap: var(--thought-mint-copy-gap);
+  display: block;
 }
 
-.thought-mint-step__title,
-.thought-mint-step__detail {
-  margin: 0;
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.45;
+.thought-mint-step.is-hidden {
+  display: none;
 }
 
 .thought-mint-step__title {
-  color: var(--thought-panel-accent-text);
-}
-
-.thought-mint-step__detail {
-  color: var(--muted);
-}
-
-.thought-dock-path-field {
-  display: grid;
-  gap: var(--thought-mint-inventory-gap);
-}
-
-.thought-dock-path-field.is-hidden {
-  display: none;
-}
-
-.thought-dock-path-input {
-  padding: 8px 10px;
-  border: 1px solid var(--ghost-border);
-  color: var(--muted);
-  text-overflow: clip;
-}
-
-.thought-dock-path-input.is-hidden {
-  display: none;
-}
-
-.thought-dock-path-select {
-  appearance: auto;
-}
-
-.thought-dock-path-input:focus {
-  border-color: var(--accent);
-}
-
-.thought-dock-path-input:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-}
-
-.thought-dock-path-provenance,
-.thought-dock-path-status,
-.thought-dock-path-context {
   margin: 0;
-  color: var(--muted);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.45;
-  white-space: pre-line;
-}
-
-.thought-dock-path-provenance {
-  color: var(--thought-panel-subtle-text);
-  font-size: var(--font-size-11);
-  line-height: 1.25;
-}
-
-.thought-dock-path-provenance.is-hidden,
-.thought-dock-path-context.is-hidden {
-  display: none;
-}
-
-.thought-dock-path-context {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-height: var(--thought-mint-review-max-height);
-  padding-block-start: var(--thought-wallet-context-space);
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-
-.thought-dock-path-review {
-  margin: 0;
-  padding-block-start: var(--thought-wallet-context-space);
-  border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
-  color: var(--muted);
-}
-
-.thought-dock-path-review.is-hidden {
-  display: none;
-}
-
-.thought-dock-path-review > summary {
   color: var(--thought-panel-accent-text);
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
   line-height: 1.45;
-  cursor: pointer;
 }
 
-.thought-dock-path-review__rows {
-  display: grid;
-  gap: var(--thought-mint-review-row-gap);
+.thought-mint-step__title[data-tone="idle"],
+.thought-mint-step__title[data-tone="warning"] {
+  color: var(--thought-panel-secondary-text);
 }
 
-.thought-dock-path-review__row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: var(--thought-wallet-context-space);
-  color: var(--muted);
-}
-
-.thought-dock-path-review__row strong {
-  min-width: 0;
-  color: var(--muted);
-  font-weight: var(--weight-light);
-  text-align: end;
-  overflow-wrap: anywhere;
-}
-
-.thought-dock-path-review__note {
-  color: var(--thought-panel-subtle-text);
-  white-space: pre-line;
-}
-
-.thought-dock-path-review__link {
-  color: inherit;
-  text-decoration: underline;
-  text-underline-offset: var(--thought-mint-link-underline-offset);
+.thought-mint-step__title[data-tone="error"] {
+  color: var(--thought-panel-error-text);
 }
 
 .mint-sheet-path-inventory {
@@ -1198,10 +1047,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   gap: var(--thought-mint-action-gap);
 }
 
-.thought-dock-path-actions.thought-dock-path-inventory-list {
-  gap: var(--thought-path-picker-gap);
-}
-
 .thought-dock-path .thought-dock-button.is-hidden {
   display: none;
 }
@@ -1247,8 +1092,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-action-rail {
-  --thought-dock-status-text: var(--thought-dock-status-color);
-  --thought-dock-status-border: var(--thought-dock-status-color);
+  grid-area: actions;
   position: static;
   z-index: 2;
   width: 100%;
@@ -1260,11 +1104,11 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   max-height: none;
   display: grid;
   grid-template-columns: auto;
-  grid-auto-rows: var(--thought-dock-control-height);
+  grid-auto-rows: var(--thought-dock-chip-height);
   align-items: center;
   align-content: center;
   justify-content: flex-start;
-  gap: 8px;
+  gap: var(--thought-path-picker-gap);
   padding: 0;
   box-sizing: border-box;
   border: 0;
@@ -1281,57 +1125,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   justify-content: flex-start;
 }
 
-.thought-dock-action-rail[data-content="status"] {
-  grid-template-columns: auto;
-  align-items: center;
-  justify-content: flex-start;
-}
-
-.thought-dock-action-rail[data-content="status"] .thought-dock-status {
-  justify-self: center;
-}
-
-.thought-dock-action-rail[data-content="mixed"] {
-  grid-template-columns: auto auto;
-  align-items: center;
-  justify-content: flex-start;
-}
-
-.thought-dock-action-rail[data-content="mixed"] .thought-dock-status {
-  justify-self: center;
-}
-
-@keyframes thought-dock-chip-enter {
-  from {
-    opacity: 0;
-    transform: translateX(8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-@keyframes thought-dock-dot-flash {
-  0%,
-  70%,
-  100% {
-    opacity: 0.45;
-  }
-
-  30% {
-    opacity: 1;
-  }
-}
-
-.thought-dock-chip-enter {
-  animation: thought-dock-chip-enter 150ms cubic-bezier(0.16, 1, 0.3, 1) both;
-  animation-delay: var(--thought-dock-chip-enter-delay, 0ms);
-  will-change: opacity, transform;
-}
-
-.thought-dock-status,
 .thought-dock-button {
   box-sizing: border-box;
   min-width: 0;
@@ -1349,70 +1142,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   justify-content: center;
   white-space: nowrap;
   overflow: hidden;
-}
-
-.thought-dock-status {
-  margin: 0;
-  align-self: center;
-  width: max-content;
-  max-width: 100%;
-  flex: 0 0 auto;
-  background: transparent;
-  color: var(--thought-panel-accent-text);
-  overflow-wrap: normal;
-}
-
-.thought-dock-status-label {
-  display: block;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: clip;
-  white-space: nowrap;
-}
-
-.thought-dock-ellipsis {
-  display: inline-flex;
-  flex: 0 0 auto;
-  width: 3.2ch;
-  min-width: 3.2ch;
-  justify-content: flex-start;
-}
-
-.thought-dock-ellipsis-dot {
-  opacity: 0.45;
-  animation: thought-dock-dot-flash 900ms steps(1, end) infinite;
-}
-
-.thought-dock-ellipsis-dot:nth-child(2) {
-  animation-delay: 150ms;
-}
-
-.thought-dock-ellipsis-dot:nth-child(3) {
-  animation-delay: 300ms;
-}
-
-.thought-dock-status.thought-dock-error {
-  background: transparent;
-  border-color: var(--thought-dock-status-border);
-  color: var(--thought-dock-status-text);
-}
-
-.thought-dock-status--warning {
-  background: transparent;
-  border-color: var(--thought-dock-status-border);
-  color: var(--thought-dock-status-text);
-}
-
-.thought-dock-status--empty {
-  display: none;
-}
-
-.thought-dock-status--muted {
-  color: var(--thought-dock-status-text);
-}
-
-.thought-dock-error {
-  color: var(--thought-dock-status-text);
 }
 
 .thought-dock-actions {
@@ -1435,7 +1164,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   flex: 0 0 auto;
   appearance: none;
   background: var(--accent);
-  color: #ffffff;
+  color: var(--thought-button-on-accent);
   font: inherit;
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
@@ -1449,25 +1178,16 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   outline: none;
   border-color: var(--accent);
   background: var(--accent);
-  color: #ffffff;
+  color: var(--thought-button-on-accent);
   text-decoration: none;
 }
 
 .thought-dock-button:disabled {
-  color: var(--muted);
-  background: var(--ghost-bg);
-  border-color: transparent;
+  color: var(--thought-button-disabled-text);
+  background: transparent;
+  border-color: var(--thought-button-disabled-text);
   cursor: default;
   opacity: 1;
-}
-
-.thought-dock-path-token[aria-pressed="true"],
-.thought-dock-path-token[aria-pressed="true"]:disabled,
-.thought-dock-path-token[aria-pressed="true"]:hover,
-.thought-dock-path-token[aria-pressed="true"]:focus-visible {
-  border-color: var(--text);
-  background: var(--text);
-  color: var(--bg-body);
 }
 
 .thought-dock-button--secondary {
@@ -1484,16 +1204,16 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-button--tertiary {
-  border-color: transparent;
+  border-color: var(--accent-border);
   background: transparent;
-  color: var(--muted);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-dock-button--tertiary:hover,
 .thought-dock-button--tertiary:focus-visible {
-  border-color: var(--panel-border);
-  background: transparent;
-  color: var(--text);
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-dock-button--quiet {
@@ -1501,98 +1221,20 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   color: var(--accent);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .thought-dock-chip-enter {
-    animation: none;
-    will-change: auto;
-  }
-
-  .thought-dock-ellipsis-dot {
-    animation: none;
-    opacity: 1;
-  }
+.thought-dock-action-rail .thought-work-cta,
+.thought-dock-action-rail .thought-work-cta:hover,
+.thought-dock-action-rail .thought-work-cta:focus-visible {
+  border-color: var(--accent);
+  background: transparent;
+  color: var(--thought-panel-accent-text);
 }
 
-.thought-dock-detail-tray {
-  grid-area: auto;
-  position: static;
-  z-index: 5;
-  width: 100%;
-  max-width: 100%;
-  align-self: center;
-  margin-top: 0;
-  min-width: 0;
-  min-height: 0;
-  box-sizing: border-box;
-  overflow: visible;
-}
-
-.thought-dock-detail-tray[hidden] {
-  display: none;
-}
-
-.thought-dock-return {
-  width: 100%;
-  min-height: 118px;
-  box-sizing: border-box;
-  padding: 12px 14px;
-  border: 0;
-  border-radius: 0;
-  background: var(--panel);
-  color: var(--text);
-  caret-color: var(--accent);
-  font: inherit;
-  font-size: var(--font-size-14);
-  font-weight: var(--weight-light);
-  line-height: 1.45;
-  resize: vertical;
-}
-
-.thought-dock-return:focus {
-  outline: none;
-}
-
-.thought-dock-return::placeholder {
-  color: var(--muted);
-  opacity: 0.85;
-}
-
-.thought-dock-detail-actions {
-  margin-top: 8px;
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-}
-
-.thought-dock-detail-title,
-.thought-dock-detail-body {
-  margin: 0;
-  color: var(--muted);
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.55;
-  overflow-wrap: anywhere;
-}
-
-.thought-dock-detail-title {
-  color: var(--accent);
-  margin-bottom: 6px;
-}
-
-.thought-dock-detail-code {
-  max-height: 180px;
-  margin: 0;
-  overflow: auto;
-  border: 0;
-  background: var(--panel);
-  color: var(--muted);
-  font: inherit;
-  font-size: var(--font-size-12);
-  font-weight: var(--weight-light);
-  line-height: 1.55;
-  padding: 12px 14px;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+.thought-dock-action-rail .thought-work-cta:disabled {
+  border-color: var(--thought-button-disabled-text);
+  background: transparent;
+  color: var(--thought-button-disabled-text);
+  cursor: default;
+  opacity: 1;
 }
 
 .thought-dock-status-screen {
@@ -1608,7 +1250,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   padding: var(--thought-panel-section-padding);
   display: block;
   background: var(--panel);
-  color: var(--muted);
+  color: var(--thought-console-text);
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
   line-height: 1.55;
@@ -1616,8 +1258,8 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   overflow-y: auto;
   overscroll-behavior: contain;
   max-height: none;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  scrollbar-color: var(--detail-scrollbar-thumb) var(--detail-scrollbar-track);
+  scrollbar-width: thin;
 }
 
 .thought-dock-status-screen[hidden] {
@@ -1625,14 +1267,16 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-status-screen::-webkit-scrollbar {
-  display: none;
-  width: 0;
-  height: 0;
+  width: 8px;
+  height: 8px;
 }
 
-.thought-dock-status-screen > .thought-panel__status-title,
-.thought-dock-status-screen > .thought-panel__status-detail {
-  display: none;
+.thought-dock-status-screen::-webkit-scrollbar-track {
+  background: var(--detail-scrollbar-track);
+}
+
+.thought-dock-status-screen::-webkit-scrollbar-thumb {
+  background: var(--detail-scrollbar-thumb);
 }
 
 .thought-dock-status-screen__body {
@@ -1651,10 +1295,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   margin-top: var(--thought-console-entry-gap);
 }
 
-.thought-dock-status-screen__entry:not(.is-current-attempt) {
-  opacity: var(--thought-console-history-opacity);
-}
-
 .thought-dock-status-screen__entry.is-boundary {
   padding-top: var(--thought-console-boundary-padding);
   border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
@@ -1662,7 +1302,8 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 
 .thought-dock-status-screen__line {
   margin: 0;
-  color: var(--muted);
+  color: var(--thought-console-text);
+  opacity: var(--thought-console-text-opacity);
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
   line-height: 1.45;
@@ -1671,21 +1312,64 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-status-screen__line--heading {
-  color: var(--accent);
+  color: var(--thought-console-text);
   font-weight: var(--weight-light);
   letter-spacing: 0;
 }
 
 .thought-dock-status-screen__line--error {
-  color: var(--accent);
+  color: var(--thought-console-text);
 }
 
 .thought-dock-status-screen__line--success {
-  color: var(--muted);
+  color: var(--thought-console-text);
 }
 
 .thought-dock-status-screen__line--warning {
-  color: var(--muted);
+  color: var(--thought-console-warning-text);
+  opacity: var(--thought-console-warning-opacity);
+}
+
+.thought-progress-ellipsis {
+  display: inline-block;
+  width: 3ch;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.thought-progress-ellipsis__dot {
+  color: inherit;
+}
+
+.thought-progress-ellipsis.is-active .thought-progress-ellipsis__dot {
+  animation: thought-progress-ellipsis-dot var(--thought-progress-ellipsis-cycle) steps(1, end) infinite;
+}
+
+.thought-progress-ellipsis.is-active .thought-progress-ellipsis__dot:nth-child(2) {
+  animation-delay: calc(var(--thought-progress-ellipsis-cycle) / 3);
+}
+
+.thought-progress-ellipsis.is-active .thought-progress-ellipsis__dot:nth-child(3) {
+  animation-delay: calc(var(--thought-progress-ellipsis-cycle) * 2 / 3);
+}
+
+@keyframes thought-progress-ellipsis-dot {
+  0%,
+  100% {
+    opacity: var(--thought-progress-ellipsis-dim-opacity);
+  }
+
+  33%,
+  66% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thought-progress-ellipsis.is-active .thought-progress-ellipsis__dot {
+    animation: none;
+    opacity: 1;
+  }
 }
 
 .thought-panel .thought-dock-control-area,
@@ -2564,6 +2248,9 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .mint-sheet {
+  --accent: var(--thought-panel-interactive);
+  --accent-border: var(--thought-panel-interactive);
+  --accent-bg: var(--thought-panel-interactive-soft);
   position: fixed;
   z-index: 21;
   left: 50%;
@@ -2811,7 +2498,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   min-width: 0;
   padding: 0 6px;
   background: var(--accent);
-  color: #ffffff;
+  color: var(--thought-button-on-accent);
   letter-spacing: 0;
 }
 
@@ -2820,13 +2507,13 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   outline: none;
   border-color: var(--accent);
   background: var(--accent);
-  color: #ffffff;
+  color: var(--thought-button-on-accent);
 }
 
 .mint-sheet-primary:disabled {
-  color: var(--muted);
-  background: var(--ghost-bg);
-  border-color: transparent;
+  color: var(--thought-button-disabled-text);
+  background: transparent;
+  border-color: var(--thought-button-disabled-text);
   cursor: not-allowed;
   opacity: 1;
 }
@@ -2845,16 +2532,16 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .mint-sheet-primary--tertiary {
-  border-color: transparent;
+  border-color: var(--accent-border);
   background: transparent;
-  color: var(--muted);
+  color: var(--thought-panel-accent-text);
 }
 
 .mint-sheet-primary--tertiary:hover,
 .mint-sheet-primary--tertiary:focus-visible {
-  border-color: var(--panel-border);
+  border-color: var(--accent);
   background: transparent;
-  color: var(--text);
+  color: var(--thought-panel-accent-text);
 }
 
 .mint-sheet-primary.is-hidden {
@@ -2866,8 +2553,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
     input,
     select,
     a,
-    summary,
-    [tabindex="-1"]
+    summary
   ):focus-visible,
 .mint-sheet :where(button, input, select, a, summary):focus-visible {
   outline: var(--thought-focus-ring-width) solid var(--thought-focus-ring-color);
@@ -2879,8 +2565,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
     input,
     select,
     a,
-    summary,
-    [tabindex="-1"]
+    summary
   ):focus,
 #mint-sheet :where(button, input, select, a, summary):focus {
   outline: var(--thought-focus-ring-width) solid var(--thought-focus-ring-color);
@@ -4151,7 +3836,9 @@ html.agent-demo-route .thought-agent-demo.is-hidden {
 
 @media (prefers-color-scheme: dark) {
   .thought-dock-status-screen,
-  .thought-dock-control-area,
+  .thought-dock,
+  .thought-dock-path,
+  .thought-dock-works,
   .mint-sheet {
     background: #000000;
   }
@@ -4170,6 +3857,10 @@ html.agent-demo-route .thought-agent-demo.is-hidden {
 }
 
 @media (max-width: 900px) {
+  :root {
+    --thought-panel-row-alignment: stretch;
+  }
+
   .frontpage-shell {
     padding: 12px 14px 14px;
   }

--- a/apps/thought/src/style.css
+++ b/apps/thought/src/style.css
@@ -185,6 +185,29 @@ body {
   --thought-dock-row-height: 48px;
   --thought-dock-control-height: calc(var(--thought-dock-row-height) - 16px);
   --thought-dock-chip-height: 26px;
+  --thought-panel-section-padding: 12px 14px;
+  --thought-mint-hairline-width: 1px;
+  --thought-mint-stage-gap: 12px;
+  --thought-mint-copy-gap: 4px;
+  --thought-mint-inventory-gap: 7px;
+  --thought-mint-review-row-gap: 5px;
+  --thought-mint-action-gap: 14px;
+  --thought-mint-progress-gap: 6px;
+  --thought-mint-progress-cell-padding: 7px 8px;
+  --thought-mint-progress-letter-spacing: 0.08em;
+  --thought-mint-progress-transition: 140ms ease;
+  --thought-path-picker-gap: 8px;
+  --thought-path-picker-max-height: calc(
+    (var(--thought-dock-chip-height) * 3) + (var(--thought-path-picker-gap) * 2)
+  );
+  --thought-mint-review-max-height: 180px;
+  --thought-wallet-context-space: 8px;
+  --thought-focus-ring-width: 2px;
+  --thought-focus-ring-offset: 2px;
+  --thought-mint-link-underline-offset: 3px;
+  --thought-console-entry-gap: 14px;
+  --thought-console-boundary-padding: 10px;
+  --thought-console-history-opacity: 0.5;
   --thought-frontpage-shell-padding-block-start: var(--shell-route-padding-block-start);
   --thought-frontpage-shell-padding-block-end: 18px;
   --thought-frontpage-shell-padding-inline: 20px;
@@ -199,6 +222,10 @@ body.frontpage {
   --thought-art-canvas-bg: #000000;
   --detail-scrollbar-track: #050505;
   --detail-scrollbar-thumb: rgba(178, 184, 198, 0.5);
+  --thought-panel-accent-text: #00a000;
+  --thought-panel-subtle-text: #9ca3af;
+  --thought-panel-error-text: #ff6b6b;
+  --thought-focus-ring-color: var(--text);
   --thought-dock-button-color: var(--muted);
   --thought-dock-button-hover: var(--accent);
   --thought-dock-status-color: var(--muted);
@@ -218,6 +245,9 @@ body.frontpage {
   body.frontpage {
     --detail-scrollbar-track: rgba(255, 255, 255, 0.96);
     --detail-scrollbar-thumb: rgba(75, 85, 99, 0.45);
+    --thought-panel-accent-text: var(--accent);
+    --thought-panel-subtle-text: var(--muted-dim);
+    --thought-panel-error-text: #b91c1c;
     --thought-dock-button-color: var(--muted);
     --thought-dock-button-hover: var(--accent);
     --thought-dock-status-color: var(--muted);
@@ -732,7 +762,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   box-sizing: border-box;
   display: grid;
   gap: 16px;
-  padding: 12px 14px;
+  padding: var(--thought-panel-section-padding);
   background: var(--panel);
 }
 
@@ -768,10 +798,11 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 12px;
+  align-items: start;
+  gap: var(--thought-wallet-context-space);
   min-height: var(--thought-dock-control-height);
-  padding: 0;
+  padding-block: var(--thought-wallet-context-space);
+  border-block: var(--thought-mint-hairline-width) solid var(--panel-border);
   background: transparent;
   color: var(--muted);
   overflow: hidden;
@@ -783,9 +814,14 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 
 .thought-wallet-strip__copy {
   min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "title detail"
+    "title meta";
+  align-items: start;
+  column-gap: var(--thought-wallet-context-space);
+  row-gap: calc(var(--thought-wallet-context-space) / 4);
   overflow: hidden;
 }
 
@@ -800,8 +836,9 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-wallet-strip__title {
+  grid-area: title;
   flex: 0 0 auto;
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
   font-size: var(--font-size-12);
   font-weight: var(--weight-mid);
   line-height: 1.55;
@@ -817,9 +854,14 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   line-height: 1.45;
 }
 
+.thought-wallet-strip__detail {
+  grid-area: detail;
+}
+
 .thought-wallet-strip__meta {
+  grid-area: meta;
   flex: 1 1 auto;
-  color: var(--muted-dim);
+  color: var(--thought-panel-subtle-text);
 }
 
 .thought-wallet-strip__meta.is-hidden {
@@ -831,22 +873,22 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   flex-wrap: nowrap;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--thought-wallet-context-space);
   min-width: 0;
   overflow: hidden;
 }
 
 .thought-wallet-strip[data-tone="ready"] .thought-wallet-strip__title {
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-wallet-strip[data-tone="warning"] .thought-wallet-strip__title,
 .thought-wallet-strip[data-tone="running"] .thought-wallet-strip__title {
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-wallet-strip[data-tone="error"] .thought-wallet-strip__title {
-  color: #b91c1c;
+  color: var(--thought-panel-error-text);
 }
 
 .thought-dock-prompt-row {
@@ -873,7 +915,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   clip: auto;
   white-space: normal;
   border: 0;
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
   font-size: var(--font-size-12);
   font-weight: var(--weight-mid);
   line-height: 1.55;
@@ -913,7 +955,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-input::placeholder {
-  color: var(--muted-dim);
+  color: var(--thought-panel-subtle-text);
   font-weight: inherit;
   opacity: 1;
 }
@@ -927,7 +969,10 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   max-width: 100%;
   box-sizing: border-box;
   display: grid;
-  gap: 8px;
+  gap: var(--thought-mint-stage-gap);
+  padding: var(--thought-panel-section-padding);
+  border: var(--thought-mint-hairline-width) solid var(--panel-border);
+  background: var(--panel-soft);
   color: var(--muted);
 }
 
@@ -939,13 +984,29 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   display: none;
 }
 
+.thought-dock-path-inventory {
+  min-width: 0;
+  display: grid;
+  gap: var(--thought-mint-inventory-gap);
+}
+
 .thought-dock-path-inventory.is-hidden {
   display: none;
 }
 
+.thought-dock-path-inventory-list {
+  max-height: var(--thought-path-picker-max-height);
+  align-content: flex-start;
+  gap: var(--thought-path-picker-gap);
+  padding-inline-end: var(--thought-path-picker-gap);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .thought-mint-step {
   display: grid;
-  gap: 4px;
+  gap: var(--thought-mint-copy-gap);
 }
 
 .thought-mint-step__title,
@@ -957,7 +1018,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-mint-step__title {
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-mint-step__detail {
@@ -966,7 +1027,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 
 .thought-dock-path-field {
   display: grid;
-  gap: 7px;
+  gap: var(--thought-mint-inventory-gap);
 }
 
 .thought-dock-path-field.is-hidden {
@@ -1009,7 +1070,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-path-provenance {
-  color: var(--muted-dim);
+  color: var(--thought-panel-subtle-text);
   font-size: var(--font-size-11);
   line-height: 1.25;
 }
@@ -1023,13 +1084,68 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  max-height: var(--thought-mint-review-max-height);
+  padding-block-start: var(--thought-wallet-context-space);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.thought-dock-path-review {
+  margin: 0;
+  padding-block-start: var(--thought-wallet-context-space);
+  border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
+  color: var(--muted);
+}
+
+.thought-dock-path-review.is-hidden {
+  display: none;
+}
+
+.thought-dock-path-review > summary {
+  color: var(--thought-panel-accent-text);
+  font-size: var(--font-size-12);
+  font-weight: var(--weight-light);
+  line-height: 1.45;
+  cursor: pointer;
+}
+
+.thought-dock-path-review__rows {
+  display: grid;
+  gap: var(--thought-mint-review-row-gap);
+}
+
+.thought-dock-path-review__row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--thought-wallet-context-space);
+  color: var(--muted);
+}
+
+.thought-dock-path-review__row strong {
+  min-width: 0;
+  color: var(--muted);
+  font-weight: var(--weight-light);
+  text-align: end;
+  overflow-wrap: anywhere;
+}
+
+.thought-dock-path-review__note {
+  color: var(--thought-panel-subtle-text);
+  white-space: pre-line;
+}
+
+.thought-dock-path-review__link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: var(--thought-mint-link-underline-offset);
 }
 
 .mint-sheet-path-inventory {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 7px;
+  gap: var(--thought-mint-inventory-gap);
   color: var(--muted);
 }
 
@@ -1042,7 +1158,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .mint-sheet-path-inventory-title {
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
 }
 
 .mint-sheet-path-inventory-detail {
@@ -1066,7 +1182,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   padding: 0 8px;
   background: var(--accent);
   color: #ffffff;
-  text-transform: lowercase;
 }
 
 .mint-sheet-path-inventory-action:hover,
@@ -1080,7 +1195,11 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 14px;
+  gap: var(--thought-mint-action-gap);
+}
+
+.thought-dock-path-actions.thought-dock-path-inventory-list {
+  gap: var(--thought-path-picker-gap);
 }
 
 .thought-dock-path .thought-dock-button.is-hidden {
@@ -1088,26 +1207,43 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-path-flow {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  gap: 7px;
-  color: var(--muted-dim);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--thought-mint-progress-gap);
+  margin: 0;
+  padding: 0;
+  color: var(--thought-panel-subtle-text);
   font-size: var(--font-size-11);
   font-weight: var(--weight-light);
   line-height: 1.2;
+  list-style: none;
+}
+
+.thought-dock-path-flow > :not([data-step]) {
+  display: none;
 }
 
 .thought-dock-path-flow [data-step] {
-  transition: color 140ms ease, opacity 140ms ease;
+  min-width: 0;
+  padding: var(--thought-mint-progress-cell-padding);
+  border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
+  text-align: center;
+  letter-spacing: var(--thought-mint-progress-letter-spacing);
+  transition:
+    color var(--thought-mint-progress-transition),
+    border-color var(--thought-mint-progress-transition),
+    background-color var(--thought-mint-progress-transition);
 }
 
 .thought-dock-path-flow [data-step].is-complete {
-  color: var(--muted-dim);
+  border-color: var(--accent-border);
+  color: var(--muted);
 }
 
 .thought-dock-path-flow [data-step].is-active {
-  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-dock-action-rail {
@@ -1222,7 +1358,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   max-width: 100%;
   flex: 0 0 auto;
   background: transparent;
-  color: var(--accent);
+  color: var(--thought-panel-accent-text);
   overflow-wrap: normal;
 }
 
@@ -1304,7 +1440,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
   line-height: 1;
-  text-transform: lowercase;
   text-overflow: ellipsis;
   cursor: pointer;
 }
@@ -1336,16 +1471,29 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .thought-dock-button--secondary {
-  border-color: transparent;
-  background: var(--accent);
-  color: #ffffff;
+  border-color: var(--accent-border);
+  background: transparent;
+  color: var(--thought-panel-accent-text);
 }
 
 .thought-dock-button--secondary:hover,
 .thought-dock-button--secondary:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--thought-panel-accent-text);
+}
+
+.thought-dock-button--tertiary {
   border-color: transparent;
-  background: var(--accent);
-  color: #ffffff;
+  background: transparent;
+  color: var(--muted);
+}
+
+.thought-dock-button--tertiary:hover,
+.thought-dock-button--tertiary:focus-visible {
+  border-color: var(--panel-border);
+  background: transparent;
+  color: var(--text);
 }
 
 .thought-dock-button--quiet {
@@ -1457,7 +1605,7 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   align-self: stretch;
   box-sizing: border-box;
   margin-top: 0;
-  padding: 12px 14px;
+  padding: var(--thought-panel-section-padding);
   display: block;
   background: var(--panel);
   color: var(--muted);
@@ -1497,6 +1645,19 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   min-width: 0;
   padding-top: 0;
   border-top: 0;
+}
+
+.thought-dock-status-screen__entry + .thought-dock-status-screen__entry {
+  margin-top: var(--thought-console-entry-gap);
+}
+
+.thought-dock-status-screen__entry:not(.is-current-attempt) {
+  opacity: var(--thought-console-history-opacity);
+}
+
+.thought-dock-status-screen__entry.is-boundary {
+  padding-top: var(--thought-console-boundary-padding);
+  border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
 }
 
 .thought-dock-status-screen__line {
@@ -2452,7 +2613,6 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   font-size: var(--font-size-12);
   font-weight: var(--weight-light);
   line-height: 1;
-  text-transform: lowercase;
   cursor: pointer;
 }
 
@@ -2541,16 +2701,21 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .mint-sheet-flow {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 7px;
-  margin-top: -2px;
-  color: var(--muted-dim);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--thought-mint-progress-gap);
+  margin: 0;
+  padding: 0;
+  color: var(--thought-panel-subtle-text);
   font-size: var(--font-size-11);
   font-weight: var(--weight-light);
   letter-spacing: 0;
   line-height: 1.2;
+  list-style: none;
+}
+
+.mint-sheet-flow > :not([data-step]) {
+  display: none;
 }
 
 .mint-sheet-flow.is-hidden {
@@ -2558,15 +2723,26 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
 }
 
 .mint-sheet-flow [data-step] {
-  transition: color 140ms ease, opacity 140ms ease;
+  min-width: 0;
+  padding: var(--thought-mint-progress-cell-padding);
+  border-top: var(--thought-mint-hairline-width) solid var(--panel-border);
+  text-align: center;
+  letter-spacing: var(--thought-mint-progress-letter-spacing);
+  transition:
+    color var(--thought-mint-progress-transition),
+    border-color var(--thought-mint-progress-transition),
+    background-color var(--thought-mint-progress-transition);
 }
 
 .mint-sheet-flow [data-step].is-complete {
-  color: var(--muted-dim);
+  border-color: var(--accent-border);
+  color: var(--muted);
 }
 
 .mint-sheet-flow [data-step].is-active {
-  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--thought-panel-accent-text);
 }
 
 .mint-sheet-status {
@@ -2655,8 +2831,65 @@ body.frontpage:has(.frontpage-stage:not(.is-hidden)) .frontpage-side {
   opacity: 1;
 }
 
+.mint-sheet-primary--secondary {
+  border-color: var(--accent-border);
+  background: transparent;
+  color: var(--thought-panel-accent-text);
+}
+
+.mint-sheet-primary--secondary:hover,
+.mint-sheet-primary--secondary:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--thought-panel-accent-text);
+}
+
+.mint-sheet-primary--tertiary {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.mint-sheet-primary--tertiary:hover,
+.mint-sheet-primary--tertiary:focus-visible {
+  border-color: var(--panel-border);
+  background: transparent;
+  color: var(--text);
+}
+
 .mint-sheet-primary.is-hidden {
   display: none;
+}
+
+.thought-panel .thought-panel__body :where(
+    button,
+    input,
+    select,
+    a,
+    summary,
+    [tabindex="-1"]
+  ):focus-visible,
+.mint-sheet :where(button, input, select, a, summary):focus-visible {
+  outline: var(--thought-focus-ring-width) solid var(--thought-focus-ring-color);
+  outline-offset: var(--thought-focus-ring-offset);
+}
+
+.thought-panel .thought-dock-path :where(
+    button,
+    input,
+    select,
+    a,
+    summary,
+    [tabindex="-1"]
+  ):focus,
+#mint-sheet :where(button, input, select, a, summary):focus {
+  outline: var(--thought-focus-ring-width) solid var(--thought-focus-ring-color);
+  outline-offset: var(--thought-focus-ring-offset);
+}
+
+.thought-panel .thought-dock-path .is-focus-restored {
+  outline: var(--thought-focus-ring-width) solid var(--thought-focus-ring-color);
+  outline-offset: var(--thought-focus-ring-offset);
 }
 
 .frontpage-button:disabled {

--- a/apps/thought/src/surfaceShell/thoughtCommandTree.ts
+++ b/apps/thought/src/surfaceShell/thoughtCommandTree.ts
@@ -382,16 +382,16 @@ export const thoughtCommandTree: ThoughtCommandNode[] = [
     ["path"],
     "$PATH",
     [
-      leaf(["path", "list"], "list wallet $PATHs", {
-        sideEffect: sideEffectContractRead("read wallet $PATHs"),
+      leaf(["path", "list"], "list wallet $PATH tokens", {
+        sideEffect: sideEffectContractRead("read wallet $PATH tokens"),
       }),
     ],
     {
       sideEffect: sideEffectContractRead("read $PATH"),
     },
   ),
-  leaf(["authorize"], "authorize $PATH", {
-    sideEffect: sideEffectWallet("sign $PATH authorization"),
+  leaf(["authorize"], "sign $PATH", {
+    sideEffect: sideEffectWallet("sign $PATH permission"),
   }),
   leaf(["confirm"], "confirm THOUGHT mint", {
     sideEffect: sideEffectContractWrite("mint THOUGHT"),

--- a/apps/thought/src/thought-agent-fixture.ts
+++ b/apps/thought/src/thought-agent-fixture.ts
@@ -1,0 +1,23 @@
+const LOCAL_AGENT_FIXTURE_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
+
+export const shouldUseThoughtAgentFixture = (input: {
+  dev: boolean;
+  hostname: string;
+  search: string;
+}) => {
+  if (!input.dev || !LOCAL_AGENT_FIXTURE_HOSTS.has(input.hostname.toLowerCase())) {
+    return false;
+  }
+
+  return new URLSearchParams(input.search).get("agent") !== "live";
+};
+
+export const buildThoughtAgentFixtureLine = (
+  adapterId: "codex" | "claude",
+  nonce: string,
+) => `fixture ${adapterId} ${nonce}`;

--- a/apps/thought/src/thought-console.test.ts
+++ b/apps/thought/src/thought-console.test.ts
@@ -74,8 +74,9 @@ export const runThoughtConsoleTests = () => {
     eventId: "inventory:8",
     kind: "no_usable_path",
     time: "20:01:10",
-    title: "no usable PATH",
+    title: "no usable $PATH",
     detail: "this wallet has no available THOUGHT mints",
+    nextStep: "mint a $PATH, then refresh wallet from the shell bar",
     context: walletChangedContext,
     tone: "warning",
   });
@@ -96,6 +97,10 @@ export const runThoughtConsoleTests = () => {
   assert.match(walletBoundary?.detail ?? "", /0x5818…e100 → 0x170a…e100/i);
   assert.match(walletBoundary?.detail ?? "", /permission cleared/i);
   assert.equal(walletBoundary?.context.attemptId, "attempt-2");
+  assert.equal(
+    noPath.entries.at(-1)?.nextStep,
+    "mint a $PATH, then refresh wallet from the shell bar",
+  );
 
   const explicitResetContext: ThoughtConsoleContext = {
     ...walletChangedContext,
@@ -146,14 +151,14 @@ export const runThoughtConsoleTests = () => {
   const unsignedRepeat = appendThoughtConsoleEvent(switchedAgain, {
     kind: "wallet_prompt_closed",
     time: "20:02:10",
-    title: "permission not signed",
+    title: "$PATH not signed",
     detail: "nothing changed",
     context: differentNetworkContext,
   });
   const adjacentRepeat = appendThoughtConsoleEvent(unsignedRepeat, {
     kind: "wallet_prompt_closed",
     time: "20:02:11",
-    title: "permission not signed",
+    title: "$PATH not signed",
     detail: "nothing changed",
     context: differentNetworkContext,
   });
@@ -171,7 +176,7 @@ export const runThoughtConsoleTests = () => {
   const legitimateRetry = appendThoughtConsoleEvent(interveningEvent, {
     kind: "wallet_prompt_closed",
     time: "20:02:13",
-    title: "permission not signed",
+    title: "$PATH not signed",
     detail: "nothing changed",
     context: differentNetworkContext,
   });

--- a/apps/thought/src/thought-console.test.ts
+++ b/apps/thought/src/thought-console.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+
+import {
+  appendThoughtConsoleContextBoundary,
+  appendThoughtConsoleEvent,
+  createThoughtConsoleHistory,
+  parseThoughtConsoleHistory,
+  serializeThoughtConsoleHistory,
+  type ThoughtConsoleContext,
+} from "./thought-console";
+
+const baseContext: ThoughtConsoleContext = {
+  attemptId: "attempt-1",
+  workHash: "0xwork",
+  account: "0x581800000000000000000000000000000000E100",
+  chainId: 31337,
+  deploymentFingerprint: "anvil-v2",
+};
+
+export const runThoughtConsoleTests = () => {
+  const empty = createThoughtConsoleHistory();
+  const pathFound = appendThoughtConsoleEvent(empty, {
+    eventId: "inventory:7",
+    kind: "paths_found",
+    time: "19:47:13",
+    title: "PATHs found",
+    detail: "4 held · 2 available",
+    context: baseContext,
+  });
+  assert.equal(pathFound.entries.length, 1);
+  assert.equal(pathFound.entries[0]?.context.account, baseContext.account?.toLowerCase());
+
+  const samePathFound = appendThoughtConsoleEvent(pathFound, {
+    eventId: "inventory:7",
+    kind: "paths_found",
+    time: "19:47:14",
+    title: "PATHs found",
+    detail: "4 held · 2 available",
+    context: baseContext,
+  });
+  assert.equal(
+    samePathFound,
+    pathFound,
+    "a stable event id must make repeated async/render delivery idempotent",
+  );
+
+  const transient = appendThoughtConsoleEvent(pathFound, {
+    kind: "checking_paths",
+    time: "19:47:15",
+    title: "checking PATHs",
+    context: baseContext,
+    transient: true,
+  });
+  assert.equal(
+    transient,
+    pathFound,
+    "short-lived progress belongs in the control panel rather than retained history",
+  );
+
+  const permissionRequested = appendThoughtConsoleEvent(pathFound, {
+    eventId: "permission:request:1",
+    kind: "permission_requested",
+    time: "19:47:25",
+    title: "permission requested",
+    detail: "wallet request 1 of 2 · no gas",
+    context: baseContext,
+  });
+  const walletChangedContext: ThoughtConsoleContext = {
+    ...baseContext,
+    attemptId: "attempt-2",
+    account: "0x170A00000000000000000000000000000000E100",
+  };
+  const noPath = appendThoughtConsoleEvent(permissionRequested, {
+    eventId: "inventory:8",
+    kind: "no_usable_path",
+    time: "20:01:10",
+    title: "no usable PATH",
+    detail: "this wallet has no available THOUGHT mints",
+    context: walletChangedContext,
+    tone: "warning",
+  });
+
+  assert.equal(noPath.entries.length, 4);
+  assert.deepEqual(
+    noPath.entries.map(({ kind }) => kind),
+    [
+      "paths_found",
+      "permission_requested",
+      "wallet_changed",
+      "no_usable_path",
+    ],
+    "a context change must retain prior events and insert an explicit boundary",
+  );
+  const walletBoundary = noPath.entries[2];
+  assert.equal(walletBoundary?.boundary, true);
+  assert.match(walletBoundary?.detail ?? "", /0x5818…e100 → 0x170a…e100/i);
+  assert.match(walletBoundary?.detail ?? "", /permission cleared/i);
+  assert.equal(walletBoundary?.context.attemptId, "attempt-2");
+
+  const explicitResetContext: ThoughtConsoleContext = {
+    ...walletChangedContext,
+    attemptId: "idle-3",
+    workHash: undefined,
+  };
+  const resetBoundary = appendThoughtConsoleContextBoundary(noPath, {
+    time: "20:01:30",
+    context: explicitResetContext,
+    kind: "mint_reset",
+    title: "mint reset",
+    detail: "previous attempt kept in history",
+  });
+  assert.equal(resetBoundary.entries.at(-1)?.kind, "mint_reset");
+  assert.equal(resetBoundary.entries.at(-1)?.boundary, true);
+  assert.equal(resetBoundary.entries.at(-1)?.context.attemptId, "idle-3");
+
+  const differentNetworkContext: ThoughtConsoleContext = {
+    ...walletChangedContext,
+    attemptId: "attempt-3",
+    chainId: 1,
+  };
+  const networkReady = appendThoughtConsoleEvent(noPath, {
+    eventId: "network:1",
+    kind: "network_ready",
+    time: "20:02:00",
+    title: "network ready",
+    detail: "Ethereum",
+    context: differentNetworkContext,
+  });
+  assert.equal(networkReady.entries.at(-2)?.kind, "network_changed");
+  assert.equal(networkReady.entries.at(-2)?.boundary, true);
+
+  const switchedBack = appendThoughtConsoleContextBoundary(networkReady, {
+    time: "20:02:05",
+    context: walletChangedContext,
+  });
+  const switchedAgain = appendThoughtConsoleContextBoundary(switchedBack, {
+    time: "20:02:06",
+    context: differentNetworkContext,
+  });
+  assert.equal(
+    switchedAgain.entries.length,
+    networkReady.entries.length + 2,
+    "returning to a prior context must create a fresh semantic boundary",
+  );
+
+  const unsignedRepeat = appendThoughtConsoleEvent(switchedAgain, {
+    kind: "wallet_prompt_closed",
+    time: "20:02:10",
+    title: "permission not signed",
+    detail: "nothing changed",
+    context: differentNetworkContext,
+  });
+  const adjacentRepeat = appendThoughtConsoleEvent(unsignedRepeat, {
+    kind: "wallet_prompt_closed",
+    time: "20:02:11",
+    title: "permission not signed",
+    detail: "nothing changed",
+    context: differentNetworkContext,
+  });
+  assert.equal(
+    adjacentRepeat,
+    unsignedRepeat,
+    "identical adjacent events without an explicit id must collapse",
+  );
+  const interveningEvent = appendThoughtConsoleEvent(unsignedRepeat, {
+    kind: "permission_requested",
+    time: "20:02:12",
+    title: "permission requested",
+    context: differentNetworkContext,
+  });
+  const legitimateRetry = appendThoughtConsoleEvent(interveningEvent, {
+    kind: "wallet_prompt_closed",
+    time: "20:02:13",
+    title: "permission not signed",
+    detail: "nothing changed",
+    context: differentNetworkContext,
+  });
+  assert.equal(
+    legitimateRetry.entries.length,
+    interveningEvent.entries.length + 1,
+    "the same outcome after another semantic event is a legitimate retry",
+  );
+
+  const restored = parseThoughtConsoleHistory(
+    serializeThoughtConsoleHistory(legitimateRetry),
+  );
+  assert.deepEqual(restored, legitimateRetry, "session history must round-trip");
+  assert.deepEqual(
+    parseThoughtConsoleHistory("not json"),
+    createThoughtConsoleHistory(),
+    "corrupt retained history must fail closed",
+  );
+  assert.equal(
+    parseThoughtConsoleHistory(serializeThoughtConsoleHistory(legitimateRetry), {
+      limit: 2,
+    }).entries.length,
+    2,
+    "restored history must honor its retention limit",
+  );
+};

--- a/apps/thought/src/thought-console.ts
+++ b/apps/thought/src/thought-console.ts
@@ -1,35 +1,430 @@
+export type ThoughtConsoleTone = "neutral" | "success" | "warning" | "error";
+
+export type ThoughtConsoleContext = {
+  attemptId: string;
+  workHash?: string;
+  account?: string;
+  chainId?: string | number;
+  deploymentFingerprint?: string;
+};
+
 export type ThoughtConsoleInput = {
   time: string;
   title: string;
   detail?: string;
+  /**
+   * @deprecated Controls belong to the live panel, not to its retained history.
+   * Kept temporarily so older callers can migrate without rendering `next:` lines.
+   */
   actions?: string[];
 };
 
+export type ThoughtConsoleEventInput = ThoughtConsoleInput & {
+  /** A call-site supplied idempotency key, such as a request or transaction id. */
+  eventId?: string;
+  kind: string;
+  context: ThoughtConsoleContext;
+  tone?: ThoughtConsoleTone;
+  /** Short-lived projections such as `checking` never belong in retained history. */
+  transient?: boolean;
+};
+
+export type ThoughtConsoleBoundaryInput = {
+  time: string;
+  context: ThoughtConsoleContext;
+  kind?: string;
+  title?: string;
+  detail?: string;
+  tone?: ThoughtConsoleTone;
+};
+
+export type ThoughtConsoleEntry = {
+  id: string;
+  dedupeKey: string;
+  kind: string;
+  time: string;
+  title: string;
+  detail?: string;
+  context: ThoughtConsoleContext;
+  tone: ThoughtConsoleTone;
+  boundary: boolean;
+};
+
+export type ThoughtConsoleHistory = {
+  version: typeof THOUGHT_CONSOLE_HISTORY_VERSION;
+  entries: ThoughtConsoleEntry[];
+};
+
+export const THOUGHT_CONSOLE_HISTORY_VERSION = 1 as const;
+export const THOUGHT_CONSOLE_HISTORY_LIMIT = 80;
+export const THOUGHT_CONSOLE_HISTORY_STORAGE_KEY =
+  "inshell:thought:console-history:v1";
+
 const normalizeConsoleText = (value: string) => value.trim();
+
+const normalizeOptionalConsoleText = (value: unknown) => {
+  if (typeof value !== "string") return undefined;
+  const normalized = normalizeConsoleText(value);
+  return normalized || undefined;
+};
+
+const normalizeAccount = (account: unknown) =>
+  normalizeOptionalConsoleText(account)?.toLowerCase();
+
+const normalizeChainId = (chainId: unknown) => {
+  if (typeof chainId === "number" && Number.isSafeInteger(chainId) && chainId >= 0) {
+    return String(chainId);
+  }
+  return normalizeOptionalConsoleText(chainId);
+};
+
+const normalizeThoughtConsoleContext = (
+  context: ThoughtConsoleContext,
+): ThoughtConsoleContext => ({
+  attemptId: normalizeConsoleText(context.attemptId) || "legacy",
+  ...(normalizeOptionalConsoleText(context.workHash)
+    ? { workHash: normalizeOptionalConsoleText(context.workHash) }
+    : {}),
+  ...(normalizeAccount(context.account)
+    ? { account: normalizeAccount(context.account) }
+    : {}),
+  ...(normalizeChainId(context.chainId)
+    ? { chainId: normalizeChainId(context.chainId) }
+    : {}),
+  ...(normalizeOptionalConsoleText(context.deploymentFingerprint)
+    ? {
+        deploymentFingerprint: normalizeOptionalConsoleText(
+          context.deploymentFingerprint,
+        ),
+      }
+    : {}),
+});
+
+const thoughtConsoleContextKey = (context: ThoughtConsoleContext) =>
+  [
+    context.attemptId,
+    context.workHash ?? "",
+    context.account ?? "",
+    context.chainId ?? "",
+    context.deploymentFingerprint ?? "",
+  ].join("|");
+
+const sameThoughtConsoleContext = (
+  left: ThoughtConsoleContext,
+  right: ThoughtConsoleContext,
+) => thoughtConsoleContextKey(left) === thoughtConsoleContextKey(right);
+
+const sameThoughtConsoleDetail = (title: string, detail?: string) =>
+  detail?.toLowerCase() === title.toLowerCase();
+
+const compactAccount = (account?: string) => {
+  if (!account || account.length <= 13) return account ?? "none";
+  return `${account.slice(0, 6)}…${account.slice(-4)}`;
+};
+
+const hashConsoleKey = (value: string) => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const trimThoughtConsoleEntries = (
+  entries: ThoughtConsoleEntry[],
+  limit: number,
+) => entries.slice(-Math.max(1, limit));
+
+export const createThoughtConsoleHistory = (): ThoughtConsoleHistory => ({
+  version: THOUGHT_CONSOLE_HISTORY_VERSION,
+  entries: [],
+});
 
 export const buildThoughtConsoleLines = ({
   time,
   title,
   detail = "",
-  actions = [],
 }: ThoughtConsoleInput) => {
   const normalizedTitle = normalizeConsoleText(title);
   const normalizedDetail = normalizeConsoleText(detail);
-  const normalizedActions = actions
-    .map(normalizeConsoleText)
-    .filter(Boolean);
   const lines = [`[${normalizeConsoleText(time)}] ${normalizedTitle}`];
 
   if (
     normalizedDetail &&
-    normalizedDetail.toLowerCase() !== normalizedTitle.toLowerCase()
+    !sameThoughtConsoleDetail(normalizedTitle, normalizedDetail)
   ) {
     lines.push(normalizedDetail);
   }
 
-  if (normalizedActions.length > 0) {
-    lines.push(`next: ${normalizedActions.join(" / ")}`);
+  return lines;
+};
+
+type NormalizedThoughtConsoleEvent = Omit<ThoughtConsoleEventInput, "actions"> & {
+  context: ThoughtConsoleContext;
+  detail?: string;
+  eventId?: string;
+  tone: ThoughtConsoleTone;
+};
+
+const normalizeThoughtConsoleEvent = (
+  event: ThoughtConsoleEventInput,
+): NormalizedThoughtConsoleEvent => {
+  const title = normalizeConsoleText(event.title);
+  const detail = normalizeOptionalConsoleText(event.detail);
+  return {
+    time: normalizeConsoleText(event.time),
+    title,
+    ...(detail && !sameThoughtConsoleDetail(title, detail) ? { detail } : {}),
+    ...(normalizeOptionalConsoleText(event.eventId)
+      ? { eventId: normalizeOptionalConsoleText(event.eventId) }
+      : {}),
+    kind: normalizeConsoleText(event.kind) || "activity",
+    context: normalizeThoughtConsoleContext(event.context),
+    tone: event.tone ?? "neutral",
+    transient: event.transient ?? false,
+  };
+};
+
+const appendNormalizedThoughtConsoleEvent = (
+  history: ThoughtConsoleHistory,
+  event: NormalizedThoughtConsoleEvent,
+  options: { boundary?: boolean; limit?: number } = {},
+) => {
+  if (event.transient) return history;
+
+  const contextKey = thoughtConsoleContextKey(event.context);
+  const contentKey = [
+    contextKey,
+    event.kind,
+    event.title.toLowerCase(),
+    event.detail?.toLowerCase() ?? "",
+    event.tone,
+  ].join("|");
+  const dedupeKey = event.eventId
+    ? `event|${contextKey}|${event.eventId}`
+    : `content|${contentKey}`;
+  const isDuplicate = event.eventId
+    ? history.entries.some((entry) => entry.dedupeKey === dedupeKey)
+    : history.entries.at(-1)?.dedupeKey === dedupeKey;
+
+  if (isDuplicate) return history;
+
+  const idSeed = [
+    dedupeKey,
+    event.time,
+    history.entries.at(-1)?.id ?? "start",
+  ].join("|");
+  const entry: ThoughtConsoleEntry = {
+    id: `thought-console-${hashConsoleKey(idSeed)}`,
+    dedupeKey,
+    kind: event.kind,
+    time: event.time,
+    title: event.title,
+    ...(event.detail ? { detail: event.detail } : {}),
+    context: event.context,
+    tone: event.tone,
+    boundary: options.boundary ?? false,
+  };
+
+  return {
+    version: THOUGHT_CONSOLE_HISTORY_VERSION,
+    entries: trimThoughtConsoleEntries(
+      [...history.entries, entry],
+      options.limit ?? THOUGHT_CONSOLE_HISTORY_LIMIT,
+    ),
+  } satisfies ThoughtConsoleHistory;
+};
+
+const boundaryPresentation = (
+  previous: ThoughtConsoleContext,
+  next: ThoughtConsoleContext,
+) => {
+  if (previous.account !== next.account) {
+    if (!previous.account) {
+      return {
+        kind: "wallet_connected",
+        title: "wallet connected",
+        detail: compactAccount(next.account),
+      };
+    }
+    if (!next.account) {
+      return {
+        kind: "wallet_disconnected",
+        title: "wallet disconnected",
+        detail: `${compactAccount(previous.account)}; PATH selection and permission cleared`,
+      };
+    }
+    return {
+      kind: "wallet_changed",
+      title: "wallet changed",
+      detail: `${compactAccount(previous.account)} → ${compactAccount(next.account)}; PATH selection and permission cleared`,
+    };
+  }
+  if (previous.chainId !== next.chainId) {
+    return {
+      kind: "network_changed",
+      title: "network changed",
+      detail: `${previous.chainId ?? "none"} → ${next.chainId ?? "none"}; PATH selection and permission cleared`,
+    };
+  }
+  if (previous.workHash !== next.workHash) {
+    return {
+      kind: "work_changed",
+      title: "work changed",
+      detail: "previous PATH selection and permission cleared",
+    };
+  }
+  if (previous.deploymentFingerprint !== next.deploymentFingerprint) {
+    return {
+      kind: "deployment_changed",
+      title: "deployment changed",
+      detail: "PATH inventory and permission cleared",
+    };
+  }
+  return {
+    kind: "attempt_started",
+    title: "mint attempt started",
+    detail: compactAccount(next.account),
+  };
+};
+
+export const appendThoughtConsoleContextBoundary = (
+  history: ThoughtConsoleHistory,
+  input: ThoughtConsoleBoundaryInput,
+  options: { limit?: number } = {},
+): ThoughtConsoleHistory => {
+  const context = normalizeThoughtConsoleContext(input.context);
+  const previousContext = history.entries.at(-1)?.context;
+  if (!previousContext || sameThoughtConsoleContext(previousContext, context)) {
+    return history;
   }
 
-  return lines;
+  const presentation = boundaryPresentation(previousContext, context);
+  return appendNormalizedThoughtConsoleEvent(
+    history,
+    {
+      time: normalizeConsoleText(input.time),
+      kind: normalizeOptionalConsoleText(input.kind) ?? presentation.kind,
+      title: normalizeOptionalConsoleText(input.title) ?? presentation.title,
+      detail: normalizeOptionalConsoleText(input.detail) ?? presentation.detail,
+      context,
+      tone: input.tone ?? "neutral",
+      transient: false,
+    },
+    { boundary: true, limit: options.limit },
+  );
+};
+
+export const appendThoughtConsoleEvent = (
+  history: ThoughtConsoleHistory,
+  input: ThoughtConsoleEventInput,
+  options: { limit?: number } = {},
+): ThoughtConsoleHistory => {
+  const event = normalizeThoughtConsoleEvent(input);
+  if (event.transient) return history;
+
+  const previousContext = history.entries.at(-1)?.context;
+  let nextHistory = history;
+  if (previousContext && !sameThoughtConsoleContext(previousContext, event.context)) {
+    nextHistory = appendThoughtConsoleContextBoundary(
+      history,
+      {
+        time: event.time,
+        context: event.context,
+      },
+      options,
+    );
+  }
+
+  return appendNormalizedThoughtConsoleEvent(nextHistory, event, options);
+};
+
+export const serializeThoughtConsoleHistory = (
+  history: ThoughtConsoleHistory,
+) => JSON.stringify(history);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const parseThoughtConsoleEntry = (value: unknown): ThoughtConsoleEntry | null => {
+  if (!isRecord(value) || !isRecord(value.context)) return null;
+  const { context } = value;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.dedupeKey !== "string" ||
+    typeof value.kind !== "string" ||
+    typeof value.time !== "string" ||
+    typeof value.title !== "string" ||
+    typeof value.tone !== "string" ||
+    typeof value.boundary !== "boolean" ||
+    typeof context.attemptId !== "string"
+  ) {
+    return null;
+  }
+  if (
+    value.tone !== "neutral" &&
+    value.tone !== "success" &&
+    value.tone !== "warning" &&
+    value.tone !== "error"
+  ) {
+    return null;
+  }
+
+  const normalizedContext = normalizeThoughtConsoleContext({
+    attemptId: context.attemptId,
+    ...(typeof context.workHash === "string" ? { workHash: context.workHash } : {}),
+    ...(typeof context.account === "string" ? { account: context.account } : {}),
+    ...(typeof context.chainId === "string" || typeof context.chainId === "number"
+      ? { chainId: context.chainId }
+      : {}),
+    ...(typeof context.deploymentFingerprint === "string"
+      ? { deploymentFingerprint: context.deploymentFingerprint }
+      : {}),
+  });
+  const title = normalizeConsoleText(value.title);
+  const detail = normalizeOptionalConsoleText(value.detail);
+
+  return {
+    id: normalizeConsoleText(value.id),
+    dedupeKey: normalizeConsoleText(value.dedupeKey),
+    kind: normalizeConsoleText(value.kind),
+    time: normalizeConsoleText(value.time),
+    title,
+    ...(detail && !sameThoughtConsoleDetail(title, detail) ? { detail } : {}),
+    context: normalizedContext,
+    tone: value.tone,
+    boundary: value.boundary,
+  };
+};
+
+export const parseThoughtConsoleHistory = (
+  serialized: unknown,
+  options: { limit?: number } = {},
+): ThoughtConsoleHistory => {
+  if (typeof serialized !== "string" || serialized.length > 200_000) {
+    return createThoughtConsoleHistory();
+  }
+
+  try {
+    const value: unknown = JSON.parse(serialized);
+    if (
+      !isRecord(value) ||
+      value.version !== THOUGHT_CONSOLE_HISTORY_VERSION ||
+      !Array.isArray(value.entries)
+    ) {
+      return createThoughtConsoleHistory();
+    }
+    return {
+      version: THOUGHT_CONSOLE_HISTORY_VERSION,
+      entries: trimThoughtConsoleEntries(
+        value.entries
+          .map(parseThoughtConsoleEntry)
+          .filter((entry): entry is ThoughtConsoleEntry => entry !== null),
+        options.limit ?? THOUGHT_CONSOLE_HISTORY_LIMIT,
+      ),
+    };
+  } catch {
+    return createThoughtConsoleHistory();
+  }
 };

--- a/apps/thought/src/thought-console.ts
+++ b/apps/thought/src/thought-console.ts
@@ -12,6 +12,7 @@ export type ThoughtConsoleInput = {
   time: string;
   title: string;
   detail?: string;
+  nextStep?: string;
   /**
    * @deprecated Controls belong to the live panel, not to its retained history.
    * Kept temporarily so older callers can migrate without rendering `next:` lines.
@@ -35,6 +36,7 @@ export type ThoughtConsoleBoundaryInput = {
   kind?: string;
   title?: string;
   detail?: string;
+  nextStep?: string;
   tone?: ThoughtConsoleTone;
 };
 
@@ -45,6 +47,7 @@ export type ThoughtConsoleEntry = {
   time: string;
   title: string;
   detail?: string;
+  nextStep?: string;
   context: ThoughtConsoleContext;
   tone: ThoughtConsoleTone;
   boundary: boolean;
@@ -145,9 +148,11 @@ export const buildThoughtConsoleLines = ({
   time,
   title,
   detail = "",
+  nextStep = "",
 }: ThoughtConsoleInput) => {
   const normalizedTitle = normalizeConsoleText(title);
   const normalizedDetail = normalizeConsoleText(detail);
+  const normalizedNextStep = normalizeConsoleText(nextStep);
   const lines = [`[${normalizeConsoleText(time)}] ${normalizedTitle}`];
 
   if (
@@ -157,12 +162,17 @@ export const buildThoughtConsoleLines = ({
     lines.push(normalizedDetail);
   }
 
+  if (normalizedNextStep) {
+    lines.push(`next: ${normalizedNextStep}`);
+  }
+
   return lines;
 };
 
 type NormalizedThoughtConsoleEvent = Omit<ThoughtConsoleEventInput, "actions"> & {
   context: ThoughtConsoleContext;
   detail?: string;
+  nextStep?: string;
   eventId?: string;
   tone: ThoughtConsoleTone;
 };
@@ -172,10 +182,12 @@ const normalizeThoughtConsoleEvent = (
 ): NormalizedThoughtConsoleEvent => {
   const title = normalizeConsoleText(event.title);
   const detail = normalizeOptionalConsoleText(event.detail);
+  const nextStep = normalizeOptionalConsoleText(event.nextStep);
   return {
     time: normalizeConsoleText(event.time),
     title,
     ...(detail && !sameThoughtConsoleDetail(title, detail) ? { detail } : {}),
+    ...(nextStep ? { nextStep } : {}),
     ...(normalizeOptionalConsoleText(event.eventId)
       ? { eventId: normalizeOptionalConsoleText(event.eventId) }
       : {}),
@@ -199,6 +211,7 @@ const appendNormalizedThoughtConsoleEvent = (
     event.kind,
     event.title.toLowerCase(),
     event.detail?.toLowerCase() ?? "",
+    event.nextStep?.toLowerCase() ?? "",
     event.tone,
   ].join("|");
   const dedupeKey = event.eventId
@@ -222,6 +235,7 @@ const appendNormalizedThoughtConsoleEvent = (
     time: event.time,
     title: event.title,
     ...(event.detail ? { detail: event.detail } : {}),
+    ...(event.nextStep ? { nextStep: event.nextStep } : {}),
     context: event.context,
     tone: event.tone,
     boundary: options.boundary ?? false,
@@ -252,34 +266,34 @@ const boundaryPresentation = (
       return {
         kind: "wallet_disconnected",
         title: "wallet disconnected",
-        detail: `${compactAccount(previous.account)}; PATH selection and permission cleared`,
+        detail: `${compactAccount(previous.account)}; $PATH pick and permission cleared`,
       };
     }
     return {
       kind: "wallet_changed",
       title: "wallet changed",
-      detail: `${compactAccount(previous.account)} → ${compactAccount(next.account)}; PATH selection and permission cleared`,
+        detail: `${compactAccount(previous.account)} → ${compactAccount(next.account)}; $PATH pick and permission cleared`,
     };
   }
   if (previous.chainId !== next.chainId) {
     return {
       kind: "network_changed",
       title: "network changed",
-      detail: `${previous.chainId ?? "none"} → ${next.chainId ?? "none"}; PATH selection and permission cleared`,
+      detail: `${previous.chainId ?? "none"} → ${next.chainId ?? "none"}; $PATH pick and permission cleared`,
     };
   }
   if (previous.workHash !== next.workHash) {
     return {
       kind: "work_changed",
       title: "work changed",
-      detail: "previous PATH selection and permission cleared",
+      detail: "previous $PATH pick and permission cleared",
     };
   }
   if (previous.deploymentFingerprint !== next.deploymentFingerprint) {
     return {
       kind: "deployment_changed",
       title: "deployment changed",
-      detail: "PATH inventory and permission cleared",
+      detail: "$PATH inventory and permission cleared",
     };
   }
   return {
@@ -308,6 +322,9 @@ export const appendThoughtConsoleContextBoundary = (
       kind: normalizeOptionalConsoleText(input.kind) ?? presentation.kind,
       title: normalizeOptionalConsoleText(input.title) ?? presentation.title,
       detail: normalizeOptionalConsoleText(input.detail) ?? presentation.detail,
+      ...(normalizeOptionalConsoleText(input.nextStep)
+        ? { nextStep: normalizeOptionalConsoleText(input.nextStep) }
+        : {}),
       context,
       tone: input.tone ?? "neutral",
       transient: false,
@@ -384,6 +401,7 @@ const parseThoughtConsoleEntry = (value: unknown): ThoughtConsoleEntry | null =>
   });
   const title = normalizeConsoleText(value.title);
   const detail = normalizeOptionalConsoleText(value.detail);
+  const nextStep = normalizeOptionalConsoleText(value.nextStep);
 
   return {
     id: normalizeConsoleText(value.id),
@@ -392,6 +410,7 @@ const parseThoughtConsoleEntry = (value: unknown): ThoughtConsoleEntry | null =>
     time: normalizeConsoleText(value.time),
     title,
     ...(detail && !sameThoughtConsoleDetail(title, detail) ? { detail } : {}),
+    ...(nextStep ? { nextStep } : {}),
     context: normalizedContext,
     tone: value.tone,
     boundary: value.boundary,

--- a/apps/thought/src/thought-mint-presentation.test.ts
+++ b/apps/thought/src/thought-mint-presentation.test.ts
@@ -20,6 +20,13 @@ const baseFacts = (): ThoughtMintFacts => ({
     held: 2,
     available: 2,
   },
+  pathAcquisition: {
+    state: "idle",
+    completed: false,
+    priceLabel: "0.1 local ETH",
+    txHash: "",
+    error: "",
+  },
   pathId: "",
   existingTokenId: null,
   authorization: {
@@ -46,9 +53,10 @@ export const runThoughtMintPresentationTests = () => {
       available: 0,
     },
   });
-  assert.equal(unavailable.title, "PATH inventory unavailable");
+  assert.equal(unavailable.title, "$PATH inventory unavailable");
   assert.match(unavailable.detail, /does not mean the wallet is empty/i);
-  assert.deepEqual(unavailable.actions.map((item) => item.label), ["Recheck PATHs", "Enter token ID"]);
+  assert.equal(unavailable.consoleNextStep, "refresh wallet from the shell bar");
+  assert.deepEqual(unavailable.actions.map((item) => item.label), ["Enter token ID"]);
 
   const empty = presentThoughtMint({
     ...baseFacts(),
@@ -59,8 +67,71 @@ export const runThoughtMintPresentationTests = () => {
       available: 0,
     },
   });
-  assert.equal(empty.title, "you need a PATH");
-  assert.deepEqual(empty.actions.map((item) => item.label), ["Mint a PATH", "Recheck"]);
+  assert.equal(empty.title, "you need a $PATH");
+  assert.equal(empty.consoleNextStep, "mint here, or explore $PATH at /path");
+  assert.equal(empty.tone, "running");
+  assert.deepEqual(empty.actions.map((item) => item.id), ["none"]);
+
+  const pathQuote = presentThoughtMint({
+    ...baseFacts(),
+    inventory: {
+      status: "loaded",
+      matchesWallet: true,
+      held: 0,
+      available: 0,
+    },
+    pathAcquisition: {
+      state: "review",
+      completed: false,
+      priceLabel: "0.1 local ETH",
+      txHash: "",
+      error: "",
+    },
+  });
+  assert.equal(pathQuote.title, "you need a $PATH");
+  assert.match(pathQuote.detail, /0\.1 local ETH/);
+  assert.match(pathQuote.stageCopy, /1 of 3.*transaction.*gas applies/i);
+  assert.equal(pathQuote.consoleNextStep, "mint here, or explore $PATH at /path");
+  assert.deepEqual(pathQuote.actions.map((item) => item.id), ["confirm_path_mint"]);
+  assert.equal(pathQuote.actions[0]?.label, "Mint $PATH for 0.1 local ETH");
+
+  const pathSubmitted = presentThoughtMint({
+    ...baseFacts(),
+    inventory: {
+      status: "loaded",
+      matchesWallet: true,
+      held: 0,
+      available: 0,
+    },
+    pathAcquisition: {
+      state: "submitted",
+      completed: false,
+      priceLabel: "0.1 local ETH",
+      txHash: `0x${"aa".repeat(32)}`,
+      error: "",
+    },
+  });
+  assert.equal(pathSubmitted.title, "$PATH mint submitted");
+  assert.equal(pathSubmitted.actions[0]?.id, "view_path_tx");
+
+  const pickPath = presentThoughtMint(baseFacts());
+  assert.equal(pickPath.title, "pick a $PATH");
+  assert.equal(pickPath.stageCopy, "The picked $PATH becomes part of this THOUGHT’s provenance.");
+  assert.equal(pickPath.consoleNextStep, undefined);
+  assert.equal(pickPath.actions[0]?.label, "Pick $PATH");
+
+  const pickAnotherPath = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    pathId: "2",
+    error: {
+      kind: "path_consumed",
+      message: "$PATH has no THOUGHT mint available.",
+    },
+  });
+  assert.equal(pickAnotherPath.stageCopy, "Pick another $PATH, or refresh wallet from the shell bar.");
+  assert.equal(pickAnotherPath.consoleNextStep, "pick another $PATH, or refresh wallet from the shell bar");
+  assert.equal(pickAnotherPath.actions[0]?.label, "Pick another $PATH");
 
   const pathReady = presentThoughtMint({
     ...baseFacts(),
@@ -69,7 +140,9 @@ export const runThoughtMintPresentationTests = () => {
   });
   assert.equal(pathReady.activeStep, "sign");
   assert.deepEqual(pathReady.completedSteps, ["path"]);
-  assert.equal(pathReady.actions[0]?.label, "Sign PATH permission");
+  assert.equal(pathReady.title, "sign $PATH #2");
+  assert.equal(pathReady.actions[0]?.label, "Sign $PATH #2");
+  assert.equal(pathReady.actions[1]?.label, "Pick another $PATH");
   assert.match(pathReady.stageCopy, /1 of 2.*no transaction.*no gas/i);
 
   const authorized = presentThoughtMint({
@@ -82,9 +155,23 @@ export const runThoughtMintPresentationTests = () => {
     },
   });
   assert.equal(authorized.activeStep, "mint");
+  assert.equal(authorized.title, "$PATH #2 signed");
   assert.deepEqual(authorized.completedSteps, ["path", "sign"]);
   assert.equal(authorized.actions[0]?.label, "Mint THOUGHT");
+  assert.equal(authorized.actions[1]?.label, "Pick another $PATH");
   assert.doesNotMatch(`${authorized.title} ${authorized.detail} ${authorized.stageCopy}`, /consume/i);
+
+  const textTaken = presentThoughtMint({
+    ...baseFacts(),
+    state: "text_taken",
+    existingTokenId: 7,
+  });
+  assert.equal(textTaken.title, "THOUGHT already exists");
+  assert.match(textTaken.detail, /exact text is already on-chain/i);
+  assert.match(textTaken.detail, /each THOUGHT can be minted only once/i);
+  assert.match(textTaken.detail, /your \$PATH was not used/i);
+  assert.equal(textTaken.stageCopy, "THOUGHT #7 is already on-chain.");
+  assert.equal(textTaken.consoleNextStep, "reset and create a new THOUGHT");
 
   const rejected = presentThoughtMint({
     ...baseFacts(),
@@ -102,6 +189,38 @@ export const runThoughtMintPresentationTests = () => {
   assert.equal(rejected.title, "mint not submitted");
   assert.match(rejected.detail, /permission is still valid/i);
   assert.equal(rejected.actions[0]?.label, "Try transaction again");
+
+  const failedOnchain = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+    transaction: {
+      state: "failed",
+      hash: `0x${"ef".repeat(32)}`,
+    },
+    error: {
+      kind: "mint",
+      message: "transaction reverted.",
+    },
+  });
+  assert.equal(
+    failedOnchain.consoleNextStep,
+    "view the transaction, then refresh wallet from the shell bar",
+  );
+
+  const genericMintError = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    error: {
+      kind: "thought",
+      message: "mint contract unavailable.",
+    },
+  });
+  assert.equal(genericMintError.consoleNextStep, "refresh wallet from the shell bar");
 
   const submitted = presentThoughtMint({
     ...baseFacts(),
@@ -178,12 +297,16 @@ export const runThoughtMintPresentationTests = () => {
     state: "error",
     error: {
       kind: "wallet_account_mismatch",
-      message: "PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
+      message: "$PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
     },
   });
   assert.equal(accountMismatch.title, "switch wallet account");
-  assert.match(accountMismatch.detail, /PATH was minted to/i);
-  assert.deepEqual(accountMismatch.actions.map((item) => item.label), ["Recheck account", "Disconnect wallet"]);
+  assert.match(accountMismatch.detail, /\$PATH was minted to/i);
+  assert.equal(
+    accountMismatch.consoleNextStep,
+    "switch to the $PATH owner account, then refresh wallet from the shell bar",
+  );
+  assert.deepEqual(accountMismatch.actions.map((item) => item.label), ["Disconnect wallet"]);
 
   const disconnectedAccountMismatch = presentThoughtMint({
     ...baseFacts(),
@@ -192,7 +315,7 @@ export const runThoughtMintPresentationTests = () => {
     chainId: null,
     error: {
       kind: "wallet_account_mismatch",
-      message: "PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
+      message: "$PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
     },
   });
   assert.deepEqual(disconnectedAccountMismatch.actions.map((item) => item.label), ["Connect wallet"]);
@@ -202,29 +325,41 @@ export const runThoughtMintPresentationTests = () => {
     state: "error",
     error: {
       kind: "path_mint_pending",
-      message: "PATH transaction 0x1234…abcd is still confirming.",
+      message: "$PATH transaction 0x1234…abcd is still confirming.",
     },
   });
-  assert.equal(pathMintPending.title, "PATH mint confirming");
-  assert.equal(pathMintPending.actions[0]?.label, "Check confirmation");
+  assert.equal(pathMintPending.title, "$PATH mint confirming");
+  assert.equal(pathMintPending.consoleNextStep, "refresh wallet from the shell bar");
+  assert.equal(pathMintPending.actions[0]?.id, "none");
 
   const pathMintChainMismatch = presentThoughtMint({
     ...baseFacts(),
     state: "error",
     error: {
       kind: "path_mint_chain_mismatch",
-      message: "PATH was minted on chain 1; THOUGHT needs Anvil Local (31337).",
+      message: "$PATH was minted on chain 1; THOUGHT needs Anvil Local (31337).",
     },
   });
-  assert.equal(pathMintChainMismatch.title, "PATH minted on another network");
-  assert.equal(pathMintChainMismatch.actions[0]?.label, "Mint another PATH");
+  assert.equal(pathMintChainMismatch.title, "$PATH minted on another network");
+  assert.equal(
+    pathMintChainMismatch.consoleNextStep,
+    "mint another $PATH, then refresh wallet from the shell bar",
+  );
+  assert.equal(pathMintChainMismatch.actions[0]?.label, "Mint another $PATH");
 
   for (const presentation of [
     unavailable,
     empty,
+    pathQuote,
+    pathSubmitted,
+    pickPath,
+    pickAnotherPath,
     pathReady,
     authorized,
+    textTaken,
     rejected,
+    failedOnchain,
+    genericMintError,
     submitted,
     trackingDelayed,
     unresolvedSubmission,
@@ -238,6 +373,11 @@ export const runThoughtMintPresentationTests = () => {
       presentation.actions.some((item) => item.label.toLowerCase() === "reset"),
       false,
       "the canonical mint panel must not expose a generic reset action",
+    );
+    assert.equal(
+      presentation.actions.map((item) => String(item.id)).includes("refresh"),
+      false,
+      "wallet refresh must remain in the shell bar",
     );
   }
 };

--- a/apps/thought/src/thought-mint-presentation.test.ts
+++ b/apps/thought/src/thought-mint-presentation.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+
+import {
+  presentThoughtMint,
+  type ThoughtMintFacts,
+} from "./thought-mint-presentation";
+
+const baseFacts = (): ThoughtMintFacts => ({
+  state: "path_required",
+  mintEnabled: true,
+  providerDetected: true,
+  walletRequestPending: false,
+  address: "0x1111111111111111111111111111111111111111",
+  chainId: 31337,
+  requiredChainId: 31337,
+  chainName: "Anvil Local",
+  inventory: {
+    status: "loaded",
+    matchesWallet: true,
+    held: 2,
+    available: 2,
+  },
+  pathId: "",
+  existingTokenId: null,
+  authorization: {
+    signed: false,
+    deadline: null,
+  },
+  transaction: {
+    state: "idle",
+    hash: "",
+  },
+  error: {
+    kind: "none",
+    message: "",
+  },
+});
+
+export const runThoughtMintPresentationTests = () => {
+  const unavailable = presentThoughtMint({
+    ...baseFacts(),
+    inventory: {
+      status: "unavailable",
+      matchesWallet: true,
+      held: 0,
+      available: 0,
+    },
+  });
+  assert.equal(unavailable.title, "PATH inventory unavailable");
+  assert.match(unavailable.detail, /does not mean the wallet is empty/i);
+  assert.deepEqual(unavailable.actions.map((item) => item.label), ["Recheck PATHs", "Enter token ID"]);
+
+  const empty = presentThoughtMint({
+    ...baseFacts(),
+    inventory: {
+      status: "loaded",
+      matchesWallet: true,
+      held: 0,
+      available: 0,
+    },
+  });
+  assert.equal(empty.title, "you need a PATH");
+  assert.deepEqual(empty.actions.map((item) => item.label), ["Mint a PATH", "Recheck"]);
+
+  const pathReady = presentThoughtMint({
+    ...baseFacts(),
+    state: "path_ready",
+    pathId: "2",
+  });
+  assert.equal(pathReady.activeStep, "sign");
+  assert.deepEqual(pathReady.completedSteps, ["path"]);
+  assert.equal(pathReady.actions[0]?.label, "Sign PATH permission");
+  assert.match(pathReady.stageCopy, /1 of 2.*no transaction.*no gas/i);
+
+  const authorized = presentThoughtMint({
+    ...baseFacts(),
+    state: "authorized",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+  });
+  assert.equal(authorized.activeStep, "mint");
+  assert.deepEqual(authorized.completedSteps, ["path", "sign"]);
+  assert.equal(authorized.actions[0]?.label, "Mint THOUGHT");
+  assert.doesNotMatch(`${authorized.title} ${authorized.detail} ${authorized.stageCopy}`, /consume/i);
+
+  const rejected = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+    error: {
+      kind: "mint",
+      message: "transaction rejected.",
+    },
+  });
+  assert.equal(rejected.title, "mint not submitted");
+  assert.match(rejected.detail, /permission is still valid/i);
+  assert.equal(rejected.actions[0]?.label, "Try transaction again");
+
+  const submitted = presentThoughtMint({
+    ...baseFacts(),
+    state: "minting",
+    pathId: "2",
+    address: "",
+    chainId: null,
+    transaction: {
+      state: "submitted",
+      hash: `0x${"ab".repeat(32)}`,
+    },
+  });
+  assert.equal(submitted.title, "mint submitted");
+  assert.equal(submitted.actions[0]?.label, "View transaction");
+
+  const trackingDelayed = presentThoughtMint({
+    ...baseFacts(),
+    state: "minting",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+    transaction: {
+      state: "submitted",
+      hash: `0x${"cd".repeat(32)}`,
+    },
+    error: {
+      kind: "mint",
+      message: "Automatic confirmation monitoring is unavailable. Hash retained; do not submit a duplicate.",
+    },
+  });
+  assert.equal(trackingDelayed.title, "mint tracking delayed");
+  assert.match(trackingDelayed.stageCopy, /hash retained.*do not submit a duplicate/i);
+  assert.equal(trackingDelayed.actions[0]?.label, "View transaction");
+
+  const unresolvedSubmission = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+    error: {
+      kind: "mint",
+      message: "The original wallet submission is unresolved; do not submit a duplicate.",
+    },
+  });
+  assert.equal(unresolvedSubmission.title, "wallet response delayed");
+  assert.equal(unresolvedSubmission.actions[0]?.id, "recover_submission");
+
+  const recoveredSubmission = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    pathId: "2",
+    authorization: {
+      signed: true,
+      deadline: 4_102_444_800n,
+    },
+    error: {
+      kind: "mint",
+      message: "Recovery check complete: the old wallet waiter is detached.",
+    },
+  });
+  assert.equal(recoveredSubmission.title, "wallet retry unlocked");
+  assert.deepEqual(
+    recoveredSubmission.actions.map((item) => item.id),
+    ["confirm_mint", "recover_submission"],
+  );
+
+  const accountMismatch = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    error: {
+      kind: "wallet_account_mismatch",
+      message: "PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
+    },
+  });
+  assert.equal(accountMismatch.title, "switch wallet account");
+  assert.match(accountMismatch.detail, /PATH was minted to/i);
+  assert.deepEqual(accountMismatch.actions.map((item) => item.label), ["Recheck account", "Disconnect wallet"]);
+
+  const disconnectedAccountMismatch = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    address: "",
+    chainId: null,
+    error: {
+      kind: "wallet_account_mismatch",
+      message: "PATH was minted to 0x1234…abcd; select that account in your wallet to continue.",
+    },
+  });
+  assert.deepEqual(disconnectedAccountMismatch.actions.map((item) => item.label), ["Connect wallet"]);
+
+  const pathMintPending = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    error: {
+      kind: "path_mint_pending",
+      message: "PATH transaction 0x1234…abcd is still confirming.",
+    },
+  });
+  assert.equal(pathMintPending.title, "PATH mint confirming");
+  assert.equal(pathMintPending.actions[0]?.label, "Check confirmation");
+
+  const pathMintChainMismatch = presentThoughtMint({
+    ...baseFacts(),
+    state: "error",
+    error: {
+      kind: "path_mint_chain_mismatch",
+      message: "PATH was minted on chain 1; THOUGHT needs Anvil Local (31337).",
+    },
+  });
+  assert.equal(pathMintChainMismatch.title, "PATH minted on another network");
+  assert.equal(pathMintChainMismatch.actions[0]?.label, "Mint another PATH");
+
+  for (const presentation of [
+    unavailable,
+    empty,
+    pathReady,
+    authorized,
+    rejected,
+    submitted,
+    trackingDelayed,
+    unresolvedSubmission,
+    recoveredSubmission,
+    accountMismatch,
+    disconnectedAccountMismatch,
+    pathMintPending,
+    pathMintChainMismatch,
+  ]) {
+    assert.equal(
+      presentation.actions.some((item) => item.label.toLowerCase() === "reset"),
+      false,
+      "the canonical mint panel must not expose a generic reset action",
+    );
+  }
+};

--- a/apps/thought/src/thought-mint-presentation.ts
+++ b/apps/thought/src/thought-mint-presentation.ts
@@ -1,0 +1,548 @@
+export type ThoughtMintFlowState =
+  | "closed"
+  | "thought_checking"
+  | "text_taken"
+  | "wallet_required"
+  | "path_required"
+  | "path_checking"
+  | "path_ready"
+  | "authorizing"
+  | "authorized"
+  | "minting"
+  | "minted"
+  | "error";
+
+export type ThoughtMintErrorKind =
+  | "none"
+  | "thought"
+  | "spec"
+  | "path_invalid"
+  | "path_not_found"
+  | "path_consumed"
+  | "path_not_ready"
+  | "path_unknown"
+  | "path_mint_pending"
+  | "path_mint_chain_mismatch"
+  | "wallet_account_mismatch"
+  | "wrong_network"
+  | "funds"
+  | "signature"
+  | "mint";
+
+export type ThoughtMintInventoryStatus =
+  | "idle"
+  | "loading"
+  | "loaded"
+  | "unavailable"
+  | "error";
+
+export type ThoughtMintActionId =
+  | "none"
+  | "continue"
+  | "connect_wallet"
+  | "disconnect_wallet"
+  | "authorize"
+  | "confirm_mint"
+  | "view_tx"
+  | "view_thought"
+  | "choose_another"
+  | "enter_path_manually"
+  | "mint_path"
+  | "refresh"
+  | "recover_submission"
+  | "switch_network";
+
+export type ThoughtMintAction = {
+  id: ThoughtMintActionId;
+  label: string;
+  disabled?: boolean;
+};
+
+export type ThoughtMintStep = "path" | "sign" | "mint";
+
+export type ThoughtMintPresentation = {
+  title: string;
+  detail: string;
+  stageCopy: string;
+  tone: "idle" | "running" | "success" | "warning" | "error";
+  panelMode:
+    | "ready_to_mint"
+    | "wallet_needed"
+    | "path_needed"
+    | "minting"
+    | "minted"
+    | "failed";
+  activeStep: ThoughtMintStep;
+  completedSteps: ThoughtMintStep[];
+  actions: ThoughtMintAction[];
+};
+
+export type ThoughtMintFacts = {
+  state: ThoughtMintFlowState;
+  mintEnabled: boolean;
+  providerDetected: boolean;
+  walletRequestPending: boolean;
+  address: string;
+  chainId: number | null;
+  requiredChainId: number;
+  chainName: string;
+  inventory: {
+    status: ThoughtMintInventoryStatus;
+    matchesWallet: boolean;
+    held: number;
+    available: number;
+    error?: string;
+  };
+  pathId: string;
+  existingTokenId: number | null;
+  authorization: {
+    signed: boolean;
+    deadline: bigint | null;
+  };
+  transaction: {
+    state: "idle" | "awaiting_signature" | "submitted" | "failed";
+    hash: string;
+  };
+  error: {
+    kind: ThoughtMintErrorKind;
+    message: string;
+  };
+  nowSeconds?: bigint;
+};
+
+const noAction = (): ThoughtMintAction => ({ id: "none", label: "" });
+const action = (
+  id: ThoughtMintActionId,
+  label: string,
+  disabled = false,
+): ThoughtMintAction => ({ id, label, ...(disabled ? { disabled } : {}) });
+
+const shortAddress = (address: string) =>
+  address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+
+const shortHash = (hash: string) =>
+  hash.length > 18 ? `${hash.slice(0, 10)}…${hash.slice(-6)}` : hash;
+
+const withDefaults = (
+  value: Omit<ThoughtMintPresentation, "activeStep" | "completedSteps"> &
+    Partial<Pick<ThoughtMintPresentation, "activeStep" | "completedSteps">>,
+): ThoughtMintPresentation => ({
+  activeStep: "path",
+  completedSteps: [],
+  ...value,
+});
+
+const pathRecoveryKinds = new Set<ThoughtMintErrorKind>([
+  "path_invalid",
+  "path_not_found",
+  "path_consumed",
+  "path_not_ready",
+  "path_unknown",
+]);
+
+const presentPathInventory = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
+  const { inventory } = facts;
+  const walletContext = facts.address
+    ? `${shortAddress(facts.address)} on ${facts.chainName}`
+    : facts.chainName;
+
+  if (!inventory.matchesWallet || inventory.status === "idle" || inventory.status === "loading") {
+    return withDefaults({
+      title: "finding your PATHs",
+      detail: `Reading ${walletContext}.`,
+      stageCopy: "Checking PATH inventory",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [noAction()],
+    });
+  }
+
+  if (inventory.status === "unavailable" || inventory.status === "error") {
+    return withDefaults({
+      title: "PATH inventory unavailable",
+      detail: "We could not read this wallet’s PATHs. This does not mean the wallet is empty.",
+      stageCopy: inventory.error?.trim() || "PATH inventory could not be verified.",
+      tone: "warning",
+      panelMode: "path_needed",
+      actions: [
+        action("refresh", "Recheck PATHs"),
+        action("enter_path_manually", "Enter token ID"),
+      ],
+    });
+  }
+
+  if (inventory.held === 0) {
+    return withDefaults({
+      title: "you need a PATH",
+      detail: `No PATH found in ${walletContext}.`,
+      stageCopy: "Mint a PATH, then return here. Your THOUGHT work will be kept.",
+      tone: "warning",
+      panelMode: "path_needed",
+      actions: [action("mint_path", "Mint a PATH"), action("refresh", "Recheck")],
+    });
+  }
+
+  if (inventory.available === 0) {
+    const noun = inventory.held === 1 ? "PATH was" : "PATHs were";
+    return withDefaults({
+      title: "no PATH can mint a THOUGHT",
+      detail: `${inventory.held} ${noun} found; all THOUGHT mint units are used or unavailable.`,
+      stageCopy: "Mint a new PATH to continue.",
+      tone: "warning",
+      panelMode: "path_needed",
+      actions: [action("mint_path", "Mint a new PATH"), action("refresh", "Recheck")],
+    });
+  }
+
+  return withDefaults({
+    title: inventory.available === 1 ? "one PATH is ready" : "choose a PATH",
+    detail: inventory.available === 1
+      ? "1 PATH has a THOUGHT mint available."
+      : `${inventory.available} PATHs have a THOUGHT mint available.`,
+    stageCopy: facts.pathId
+      ? `PATH #${facts.pathId} selected.`
+      : "The selected PATH becomes part of this THOUGHT’s provenance.",
+    tone: "idle",
+    panelMode: "path_needed",
+    actions: [
+      action("continue", facts.pathId ? `Use PATH #${facts.pathId}` : "Choose PATH", !facts.pathId),
+      action("refresh", "Recheck PATHs"),
+    ],
+  });
+};
+
+const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
+  const { kind, message } = facts.error;
+
+  if (kind === "path_mint_pending") {
+    return withDefaults({
+      title: "PATH mint confirming",
+      detail: message,
+      stageCopy: "Wait for the PATH transaction to confirm. This THOUGHT stays preserved.",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [action("refresh", "Check confirmation")],
+    });
+  }
+
+  if (kind === "path_mint_chain_mismatch") {
+    return withDefaults({
+      title: "PATH minted on another network",
+      detail: message,
+      stageCopy: "Mint a PATH on the THOUGHT network to continue.",
+      tone: "warning",
+      panelMode: "path_needed",
+      actions: [action("mint_path", "Mint another PATH"), action("refresh", "Recheck")],
+    });
+  }
+
+  if (kind === "wallet_account_mismatch") {
+    return withDefaults({
+      title: "switch wallet account",
+      detail: message,
+      stageCopy: "The PATH mint is confirmed. Use its owner account to continue this THOUGHT.",
+      tone: "warning",
+      panelMode: "wallet_needed",
+      actions: facts.address
+        ? [
+            action("refresh", "Recheck account"),
+            action("disconnect_wallet", "Disconnect wallet"),
+          ]
+        : [action("connect_wallet", "Connect wallet")],
+    });
+  }
+
+  if (kind === "wrong_network") {
+    return withDefaults({
+      title: "switch network",
+      detail: `Use ${facts.chainName} to continue.`,
+      stageCopy: "Network switching is a separate wallet request.",
+      tone: "warning",
+      panelMode: "wallet_needed",
+      actions: [action("switch_network", `Switch to ${facts.chainName}`)],
+    });
+  }
+
+  if (pathRecoveryKinds.has(kind)) {
+    const path = facts.pathId ? `PATH #${facts.pathId}` : "This PATH";
+    const unavailable = kind === "path_consumed" || kind === "path_not_ready";
+    return withDefaults({
+      title: unavailable ? "PATH cannot mint a THOUGHT" : "PATH could not be verified",
+      detail: unavailable
+        ? `${path} has no THOUGHT mint available.`
+        : message || `${path} could not be verified.`,
+      stageCopy: "Choose another PATH or recheck inventory.",
+      tone: "warning",
+      panelMode: "path_needed",
+      actions: [action("choose_another", "Choose another PATH"), action("refresh", "Recheck PATHs")],
+    });
+  }
+
+  if (kind === "signature") {
+    const pending = /already pending|request.*open/i.test(message);
+    const rejected = /reject|denied|cancel/i.test(message);
+    const expired = /expired/i.test(message);
+
+    if (pending) {
+      return withDefaults({
+        title: "wallet request already open",
+        detail: "Approve or reject the existing request in your wallet, then return here.",
+        stageCopy: "Wallet request 1 of 2 · no gas",
+        tone: "warning",
+        panelMode: "path_needed",
+        activeStep: "sign",
+        completedSteps: ["path"],
+        actions: [noAction()],
+      });
+    }
+
+    return withDefaults({
+      title: expired ? "permission expired" : rejected ? "permission not signed" : "permission unavailable",
+      detail: rejected
+        ? "Nothing changed. You can try again or choose another PATH."
+        : expired
+          ? "Sign a new PATH permission to continue."
+          : message || "The PATH permission could not be created.",
+      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+      tone: rejected ? "idle" : "warning",
+      panelMode: "path_needed",
+      activeStep: "sign",
+      completedSteps: ["path"],
+      actions: [action("authorize", rejected ? "Try signature again" : "Sign PATH permission"), action("choose_another", "Change PATH")],
+    });
+  }
+
+  if (kind === "mint" && facts.authorization.signed) {
+    const recoveryCleared = /recovery check complete|waiter is detached/i.test(message);
+    const delayed = /not submitted|timed out|timeout|delayed|queued|nonce|another tab|unresolved|submission lock|recovery check complete|detached/i.test(message);
+    const rejected = /reject|denied|cancel/i.test(message);
+    if (facts.transaction.hash && !rejected && !delayed) {
+      return withDefaults({
+        title: "mint failed on-chain",
+        detail: message || "No THOUGHT was created. Recheck PATH state before retrying.",
+        stageCopy: `${shortHash(facts.transaction.hash)} · transaction failed`,
+        tone: "error",
+        panelMode: "failed",
+        activeStep: "mint",
+        completedSteps: ["path", "sign"],
+        actions: [action("view_tx", "View transaction"), action("refresh", "Recheck and retry")],
+      });
+    }
+    return withDefaults({
+      title: recoveryCleared ? "wallet retry unlocked" : delayed ? "wallet response delayed" : rejected ? "mint not submitted" : "mint transaction failed",
+      detail: recoveryCleared
+        ? "Two checks found no hash or nonce activity. Any late hash remains monitored. Confirm your wallet has no open request before retrying."
+        : delayed
+        ? "Do not open a duplicate request. Check wallet activity first."
+        : rejected
+          ? "Nothing was sent. Your PATH permission is still valid."
+          : message || "No THOUGHT was created.",
+      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      tone: rejected ? "idle" : "warning",
+      panelMode: "minting",
+      activeStep: "mint",
+      completedSteps: ["path", "sign"],
+      actions: recoveryCleared
+        ? [action("confirm_mint", "Retry mint"), action("recover_submission", "Check again")]
+        : delayed
+        ? [action("recover_submission", "Check wallet activity")]
+        : [action("confirm_mint", "Try transaction again"), action("choose_another", "Change PATH")],
+    });
+  }
+
+  return withDefaults({
+    title: kind === "thought" || kind === "spec" ? "mint unavailable" : "mint failed",
+    detail: message || "THOUGHT minting is unavailable.",
+    stageCopy: "No transaction was submitted.",
+    tone: "error",
+    panelMode: "failed",
+    actions: [action("refresh", "Recheck mint")],
+  });
+};
+
+export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
+  const path = facts.pathId ? `PATH #${facts.pathId}` : "the selected PATH";
+
+  if (facts.state === "closed") {
+    return withDefaults({
+      title: "work ready",
+      detail: !facts.mintEnabled
+        ? "THOUGHT minting is not available in this deployment."
+        : facts.address
+          ? "Ready to prepare this THOUGHT mint."
+          : "Connect wallet to mint.",
+      stageCopy: "Minting needs one available THOUGHT unit on a PATH.",
+      tone: "idle",
+      panelMode: "ready_to_mint",
+      actions: [],
+    });
+  }
+
+  if (facts.state === "thought_checking") {
+    return withDefaults({
+      title: "preparing mint",
+      detail: "Checking uniqueness, deployment, and mint state.",
+      stageCopy: "Your work is preserved while these checks run.",
+      tone: "running",
+      panelMode: "minting",
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.state === "text_taken") {
+    return withDefaults({
+      title: "this THOUGHT already exists",
+      detail: "No PATH permission or new mint is needed.",
+      stageCopy: facts.existingTokenId === null ? "Open the existing THOUGHT." : `THOUGHT #${facts.existingTokenId} is already on-chain.`,
+      tone: "success",
+      panelMode: "minted",
+      activeStep: "mint",
+      completedSteps: ["path", "sign", "mint"],
+      actions: [action("view_thought", "View THOUGHT")],
+    });
+  }
+
+  if (facts.state === "wallet_required") {
+    const noProvider = !facts.providerDetected;
+    return withDefaults({
+      title: noProvider ? "wallet unavailable" : "connect wallet",
+      detail: noProvider
+        ? "Install or enable a wallet to continue."
+        : facts.walletRequestPending
+          ? "Complete the open connection request in your wallet."
+          : "Connection reads your account and network only.",
+      stageCopy: "No signature · no transaction · no gas",
+      tone: noProvider ? "warning" : facts.walletRequestPending ? "running" : "idle",
+      panelMode: "wallet_needed",
+      actions: noProvider || facts.walletRequestPending
+        ? [noAction()]
+        : [action("connect_wallet", "Connect wallet")],
+    });
+  }
+
+  if (facts.state === "path_required") {
+    if (facts.address && facts.chainId !== facts.requiredChainId) {
+      return presentError({
+        ...facts,
+        error: { kind: "wrong_network", message: "wrong network" },
+      });
+    }
+    return presentPathInventory(facts);
+  }
+
+  if (facts.state === "path_checking") {
+    return withDefaults({
+      title: facts.pathId ? `checking PATH #${facts.pathId}` : "checking PATH",
+      detail: "Verifying ownership and an available THOUGHT mint.",
+      stageCopy: "No wallet request yet.",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.state === "path_ready") {
+    return withDefaults({
+      title: "sign PATH permission",
+      detail: `Allow the THOUGHT contract to use one THOUGHT mint from ${path}.`,
+      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+      tone: "idle",
+      panelMode: "path_needed",
+      activeStep: "sign",
+      completedSteps: ["path"],
+      actions: [action("authorize", "Sign PATH permission"), action("choose_another", "Change PATH")],
+    });
+  }
+
+  if (facts.state === "authorizing") {
+    return withDefaults({
+      title: "check your wallet",
+      detail: `Sign the permission for ${path} to continue.`,
+      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+      tone: "running",
+      panelMode: "path_needed",
+      activeStep: "sign",
+      completedSteps: ["path"],
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.state === "authorized") {
+    const expires = facts.authorization.deadline
+      ? ` Permission expires at ${new Date(Number(facts.authorization.deadline) * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}.`
+      : "";
+    return withDefaults({
+      title: "mint THOUGHT",
+      detail: `Create this THOUGHT using one THOUGHT mint from ${path}.${expires}`,
+      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      tone: "success",
+      panelMode: "minting",
+      activeStep: "mint",
+      completedSteps: ["path", "sign"],
+      actions: [action("confirm_mint", "Mint THOUGHT"), action("choose_another", "Change PATH")],
+    });
+  }
+
+  if (facts.state === "minting") {
+    if (facts.transaction.hash || facts.transaction.state === "submitted") {
+      const trackingWarning = facts.error.kind === "mint" && facts.error.message.trim()
+        ? facts.error.message.trim()
+        : "";
+      return withDefaults({
+        title: trackingWarning ? "mint tracking delayed" : "mint submitted",
+        detail: trackingWarning || (facts.transaction.hash
+          ? `${shortHash(facts.transaction.hash)} · waiting for chain confirmation.`
+          : "Waiting for chain confirmation."),
+        stageCopy: trackingWarning
+          ? "Transaction hash retained. Do not submit a duplicate."
+          : "The submitted transaction keeps tracking if the active wallet changes.",
+        tone: trackingWarning ? "warning" : "running",
+        panelMode: "minting",
+        activeStep: "mint",
+        completedSteps: ["path", "sign"],
+        actions: facts.transaction.hash ? [action("view_tx", "View transaction")] : [noAction()],
+      });
+    }
+
+    return withDefaults({
+      title: "confirm mint in wallet",
+      detail: "No transaction has been submitted yet.",
+      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      tone: "running",
+      panelMode: "minting",
+      activeStep: "mint",
+      completedSteps: ["path", "sign"],
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.state === "minted") {
+    const token = facts.existingTokenId === null ? "THOUGHT" : `THOUGHT #${facts.existingTokenId}`;
+    return withDefaults({
+      title: "THOUGHT minted",
+      detail: `${token} was created using ${path}.`,
+      stageCopy: facts.transaction.hash ? `${shortHash(facts.transaction.hash)} · confirmed` : "Confirmed on-chain.",
+      tone: "success",
+      panelMode: "minted",
+      activeStep: "mint",
+      completedSteps: ["path", "sign", "mint"],
+      actions: [
+        action("view_thought", "View THOUGHT"),
+        ...(facts.transaction.hash ? [action("view_tx", "View transaction")] : []),
+      ],
+    });
+  }
+
+  if (facts.state === "error") {
+    return presentError(facts);
+  }
+
+  return withDefaults({
+    title: "preparing mint",
+    detail: "Checking mint state.",
+    stageCopy: "Your work is preserved.",
+    tone: "running",
+    panelMode: "minting",
+    actions: [noAction()],
+  });
+};

--- a/apps/thought/src/thought-mint-presentation.ts
+++ b/apps/thought/src/thought-mint-presentation.ts
@@ -1,3 +1,5 @@
+import type { ThoughtPathAcquisitionState } from "./thought-path-acquisition";
+
 export type ThoughtMintFlowState =
   | "closed"
   | "thought_checking"
@@ -48,7 +50,8 @@ export type ThoughtMintActionId =
   | "choose_another"
   | "enter_path_manually"
   | "mint_path"
-  | "refresh"
+  | "confirm_path_mint"
+  | "view_path_tx"
   | "recover_submission"
   | "switch_network";
 
@@ -64,6 +67,7 @@ export type ThoughtMintPresentation = {
   title: string;
   detail: string;
   stageCopy: string;
+  consoleNextStep?: string;
   tone: "idle" | "running" | "success" | "warning" | "error";
   panelMode:
     | "ready_to_mint"
@@ -92,6 +96,13 @@ export type ThoughtMintFacts = {
     held: number;
     available: number;
     error?: string;
+  };
+  pathAcquisition: {
+    state: ThoughtPathAcquisitionState;
+    completed: boolean;
+    priceLabel: string;
+    txHash: string;
+    error: string;
   };
   pathId: string;
   existingTokenId: number | null;
@@ -140,6 +151,71 @@ const pathRecoveryKinds = new Set<ThoughtMintErrorKind>([
   "path_unknown",
 ]);
 
+const presentPathAcquisition = (facts: ThoughtMintFacts): ThoughtMintPresentation | null => {
+  if (facts.pathAcquisition.state === "idle") return null;
+
+  if (facts.pathAcquisition.state === "quoting") {
+    return withDefaults({
+      title: "reading $PATH price",
+      detail: "Checking the current auction price and contract wiring.",
+      stageCopy: "No wallet request yet.",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.pathAcquisition.state === "review") {
+    return withDefaults({
+      title: "you need a $PATH",
+      detail: `${facts.pathAcquisition.priceLabel} · current auction price. The wallet reads the live price again before submission.`,
+      stageCopy: "Wallet request 1 of 3 · transaction · gas applies",
+      consoleNextStep: "mint here, or explore $PATH at /path",
+      tone: "idle",
+      panelMode: "path_needed",
+      actions: [action("confirm_path_mint", `Mint $PATH for ${facts.pathAcquisition.priceLabel}`)],
+    });
+  }
+
+  if (facts.pathAcquisition.state === "awaiting_signature") {
+    return withDefaults({
+      title: "confirm $PATH mint in wallet",
+      detail: `${facts.pathAcquisition.priceLabel} · no transaction has been submitted yet.`,
+      stageCopy: "Wallet request 1 of 3 · transaction · gas applies",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [noAction()],
+    });
+  }
+
+  if (facts.pathAcquisition.state === "submitted") {
+    return withDefaults({
+      title: "$PATH mint submitted",
+      detail: facts.pathAcquisition.txHash
+        ? `${shortHash(facts.pathAcquisition.txHash)} · waiting for confirmation.`
+        : "Waiting for chain confirmation.",
+      stageCopy: "The new $PATH will be picked automatically after confirmation.",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: facts.pathAcquisition.txHash
+        ? [action("view_path_tx", "View transaction")]
+        : [noAction()],
+    });
+  }
+
+  return withDefaults({
+    title: "$PATH mint unavailable",
+    detail: facts.pathAcquisition.error || "The $PATH transaction could not be prepared.",
+    stageCopy: "No $PATH was minted.",
+    consoleNextStep: "retry here, or explore $PATH at /path",
+    tone: "warning",
+    panelMode: "path_needed",
+    actions: [
+      action("mint_path", "Try again"),
+    ],
+  });
+};
+
 const presentPathInventory = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
   const { inventory } = facts;
   const walletContext = facts.address
@@ -148,9 +224,9 @@ const presentPathInventory = (facts: ThoughtMintFacts): ThoughtMintPresentation 
 
   if (!inventory.matchesWallet || inventory.status === "idle" || inventory.status === "loading") {
     return withDefaults({
-      title: "finding your PATHs",
+      title: "finding your $PATH tokens",
       detail: `Reading ${walletContext}.`,
-      stageCopy: "Checking PATH inventory",
+      stageCopy: "Checking $PATH inventory",
       tone: "running",
       panelMode: "path_needed",
       actions: [noAction()],
@@ -159,80 +235,86 @@ const presentPathInventory = (facts: ThoughtMintFacts): ThoughtMintPresentation 
 
   if (inventory.status === "unavailable" || inventory.status === "error") {
     return withDefaults({
-      title: "PATH inventory unavailable",
-      detail: "We could not read this wallet’s PATHs. This does not mean the wallet is empty.",
-      stageCopy: inventory.error?.trim() || "PATH inventory could not be verified.",
+      title: "$PATH inventory unavailable",
+      detail: "We could not read this wallet’s $PATH tokens. This does not mean the wallet is empty.",
+      stageCopy: inventory.error?.trim() || "$PATH inventory could not be verified.",
+      consoleNextStep: "refresh wallet from the shell bar",
       tone: "warning",
       panelMode: "path_needed",
-      actions: [
-        action("refresh", "Recheck PATHs"),
-        action("enter_path_manually", "Enter token ID"),
-      ],
-    });
-  }
-
-  if (inventory.held === 0) {
-    return withDefaults({
-      title: "you need a PATH",
-      detail: `No PATH found in ${walletContext}.`,
-      stageCopy: "Mint a PATH, then return here. Your THOUGHT work will be kept.",
-      tone: "warning",
-      panelMode: "path_needed",
-      actions: [action("mint_path", "Mint a PATH"), action("refresh", "Recheck")],
+      actions: [action("enter_path_manually", "Enter token ID")],
     });
   }
 
   if (inventory.available === 0) {
-    const noun = inventory.held === 1 ? "PATH was" : "PATHs were";
+    const acquisition = presentPathAcquisition(facts);
+    if (acquisition) return acquisition;
+  }
+
+  if (inventory.held === 0) {
     return withDefaults({
-      title: "no PATH can mint a THOUGHT",
-      detail: `${inventory.held} ${noun} found; all THOUGHT mint units are used or unavailable.`,
-      stageCopy: "Mint a new PATH to continue.",
-      tone: "warning",
+      title: "you need a $PATH",
+      detail: `No $PATH found in ${walletContext}.`,
+      stageCopy: "Reading the current auction price.",
+      consoleNextStep: "mint here, or explore $PATH at /path",
+      tone: "running",
       panelMode: "path_needed",
-      actions: [action("mint_path", "Mint a new PATH"), action("refresh", "Recheck")],
+      actions: [noAction()],
+    });
+  }
+
+  if (inventory.available === 0) {
+    const noun = inventory.held === 1 ? "$PATH was" : "$PATH tokens were";
+    return withDefaults({
+      title: "no $PATH can mint a THOUGHT",
+      detail: `${inventory.held} ${noun} found; all THOUGHT mints are used or unavailable.`,
+      stageCopy: "Reading the current auction price for a new $PATH.",
+      consoleNextStep: "mint here, or explore $PATH at /path",
+      tone: "running",
+      panelMode: "path_needed",
+      actions: [noAction()],
     });
   }
 
   return withDefaults({
-    title: inventory.available === 1 ? "one PATH is ready" : "choose a PATH",
+    title: inventory.available === 1 ? "one $PATH is ready" : "pick a $PATH",
     detail: inventory.available === 1
-      ? "1 PATH has a THOUGHT mint available."
-      : `${inventory.available} PATHs have a THOUGHT mint available.`,
+      ? "1 $PATH has a THOUGHT mint available."
+      : `${inventory.available} $PATH tokens have a THOUGHT mint available.`,
     stageCopy: facts.pathId
-      ? `PATH #${facts.pathId} selected.`
-      : "The selected PATH becomes part of this THOUGHT’s provenance.",
+      ? `$PATH #${facts.pathId} picked.`
+      : "The picked $PATH becomes part of this THOUGHT’s provenance.",
     tone: "idle",
     panelMode: "path_needed",
-    actions: [
-      action("continue", facts.pathId ? `Use PATH #${facts.pathId}` : "Choose PATH", !facts.pathId),
-      action("refresh", "Recheck PATHs"),
-    ],
+    actions: [action("continue", facts.pathId ? `Use $PATH #${facts.pathId}` : "Pick $PATH", !facts.pathId)],
   });
 };
 
 const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
   const { kind, message } = facts.error;
+  const signatureRequest = facts.pathAcquisition.completed ? "Wallet request 2 of 3" : "Wallet request 1 of 2";
+  const mintRequest = facts.pathAcquisition.completed ? "Wallet request 3 of 3" : "Wallet request 2 of 2";
 
   if (kind === "path_mint_pending") {
     return withDefaults({
-      title: "PATH mint confirming",
+      title: "$PATH mint confirming",
       detail: message,
-      stageCopy: "Wait for the PATH transaction to confirm. This THOUGHT stays preserved.",
+      stageCopy: "Wait for confirmation, then refresh wallet from the shell bar.",
+      consoleNextStep: "refresh wallet from the shell bar",
       tone: "running",
       panelMode: "path_needed",
-      actions: [action("refresh", "Check confirmation")],
+      actions: [noAction()],
     });
   }
 
   if (kind === "path_mint_chain_mismatch") {
     return withDefaults({
-      title: "PATH minted on another network",
+      title: "$PATH minted on another network",
       detail: message,
-      stageCopy: "Mint a PATH on the THOUGHT network to continue.",
+      stageCopy: "Mint a $PATH on the THOUGHT network to continue.",
+      consoleNextStep: "mint another $PATH, then refresh wallet from the shell bar",
       tone: "warning",
       panelMode: "path_needed",
-      actions: [action("mint_path", "Mint another PATH"), action("refresh", "Recheck")],
+      actions: [action("mint_path", "Mint another $PATH")],
     });
   }
 
@@ -240,14 +322,12 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
     return withDefaults({
       title: "switch wallet account",
       detail: message,
-      stageCopy: "The PATH mint is confirmed. Use its owner account to continue this THOUGHT.",
+      stageCopy: "The $PATH mint is confirmed. Use its owner account to continue this THOUGHT.",
+      consoleNextStep: "switch to the $PATH owner account, then refresh wallet from the shell bar",
       tone: "warning",
       panelMode: "wallet_needed",
       actions: facts.address
-        ? [
-            action("refresh", "Recheck account"),
-            action("disconnect_wallet", "Disconnect wallet"),
-          ]
+        ? [action("disconnect_wallet", "Disconnect wallet")]
         : [action("connect_wallet", "Connect wallet")],
     });
   }
@@ -264,21 +344,23 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
   }
 
   if (pathRecoveryKinds.has(kind)) {
-    const path = facts.pathId ? `PATH #${facts.pathId}` : "This PATH";
+    const path = facts.pathId ? `$PATH #${facts.pathId}` : "This $PATH";
     const unavailable = kind === "path_consumed" || kind === "path_not_ready";
     return withDefaults({
-      title: unavailable ? "PATH cannot mint a THOUGHT" : "PATH could not be verified",
+      title: unavailable ? "$PATH cannot mint a THOUGHT" : "$PATH could not be verified",
       detail: unavailable
         ? `${path} has no THOUGHT mint available.`
         : message || `${path} could not be verified.`,
-      stageCopy: "Choose another PATH or recheck inventory.",
+      stageCopy: "Pick another $PATH, or refresh wallet from the shell bar.",
+      consoleNextStep: "pick another $PATH, or refresh wallet from the shell bar",
       tone: "warning",
       panelMode: "path_needed",
-      actions: [action("choose_another", "Choose another PATH"), action("refresh", "Recheck PATHs")],
+      actions: [action("choose_another", "Pick another $PATH")],
     });
   }
 
   if (kind === "signature") {
+    const signaturePath = facts.pathId ? `$PATH #${facts.pathId}` : "the picked $PATH";
     const pending = /already pending|request.*open/i.test(message);
     const rejected = /reject|denied|cancel/i.test(message);
     const expired = /expired/i.test(message);
@@ -287,7 +369,7 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
       return withDefaults({
         title: "wallet request already open",
         detail: "Approve or reject the existing request in your wallet, then return here.",
-        stageCopy: "Wallet request 1 of 2 · no gas",
+        stageCopy: `${signatureRequest} · no gas`,
         tone: "warning",
         panelMode: "path_needed",
         activeStep: "sign",
@@ -297,18 +379,18 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
     }
 
     return withDefaults({
-      title: expired ? "permission expired" : rejected ? "permission not signed" : "permission unavailable",
+      title: expired ? "$PATH signature expired" : rejected ? "$PATH not signed" : "$PATH signature unavailable",
       detail: rejected
-        ? "Nothing changed. You can try again or choose another PATH."
+        ? "Nothing changed. You can try again or pick another $PATH."
         : expired
-          ? "Sign a new PATH permission to continue."
-          : message || "The PATH permission could not be created.",
-      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+          ? "Sign a new $PATH permission to continue."
+          : message || "The $PATH permission could not be signed.",
+      stageCopy: `${signatureRequest} · no transaction · no gas`,
       tone: rejected ? "idle" : "warning",
       panelMode: "path_needed",
       activeStep: "sign",
       completedSteps: ["path"],
-      actions: [action("authorize", rejected ? "Try signature again" : "Sign PATH permission"), action("choose_another", "Change PATH")],
+      actions: [action("authorize", rejected ? "Try signature again" : `Sign ${signaturePath}`), action("choose_another", "Pick another $PATH")],
     });
   }
 
@@ -319,13 +401,14 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
     if (facts.transaction.hash && !rejected && !delayed) {
       return withDefaults({
         title: "mint failed on-chain",
-        detail: message || "No THOUGHT was created. Recheck PATH state before retrying.",
+        detail: message || "No THOUGHT was created. Refresh wallet state before retrying.",
         stageCopy: `${shortHash(facts.transaction.hash)} · transaction failed`,
+        consoleNextStep: "view the transaction, then refresh wallet from the shell bar",
         tone: "error",
         panelMode: "failed",
         activeStep: "mint",
         completedSteps: ["path", "sign"],
-        actions: [action("view_tx", "View transaction"), action("refresh", "Recheck and retry")],
+        actions: [action("view_tx", "View transaction")],
       });
     }
     return withDefaults({
@@ -335,9 +418,9 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
         : delayed
         ? "Do not open a duplicate request. Check wallet activity first."
         : rejected
-          ? "Nothing was sent. Your PATH permission is still valid."
+          ? "Nothing was sent. Your $PATH permission is still valid."
           : message || "No THOUGHT was created.",
-      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      stageCopy: `${mintRequest} · transaction · gas applies`,
       tone: rejected ? "idle" : "warning",
       panelMode: "minting",
       activeStep: "mint",
@@ -346,7 +429,7 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
         ? [action("confirm_mint", "Retry mint"), action("recover_submission", "Check again")]
         : delayed
         ? [action("recover_submission", "Check wallet activity")]
-        : [action("confirm_mint", "Try transaction again"), action("choose_another", "Change PATH")],
+        : [action("confirm_mint", "Try transaction again"), action("choose_another", "Pick another $PATH")],
     });
   }
 
@@ -354,14 +437,17 @@ const presentError = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
     title: kind === "thought" || kind === "spec" ? "mint unavailable" : "mint failed",
     detail: message || "THOUGHT minting is unavailable.",
     stageCopy: "No transaction was submitted.",
+    consoleNextStep: "refresh wallet from the shell bar",
     tone: "error",
     panelMode: "failed",
-    actions: [action("refresh", "Recheck mint")],
+    actions: [noAction()],
   });
 };
 
 export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresentation => {
-  const path = facts.pathId ? `PATH #${facts.pathId}` : "the selected PATH";
+  const path = facts.pathId ? `$PATH #${facts.pathId}` : "the picked $PATH";
+  const signatureRequest = facts.pathAcquisition.completed ? "Wallet request 2 of 3" : "Wallet request 1 of 2";
+  const mintRequest = facts.pathAcquisition.completed ? "Wallet request 3 of 3" : "Wallet request 2 of 2";
 
   if (facts.state === "closed") {
     return withDefaults({
@@ -371,7 +457,7 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
         : facts.address
           ? "Ready to prepare this THOUGHT mint."
           : "Connect wallet to mint.",
-      stageCopy: "Minting needs one available THOUGHT unit on a PATH.",
+      stageCopy: "Minting needs one available THOUGHT mint on a $PATH token.",
       tone: "idle",
       panelMode: "ready_to_mint",
       actions: [],
@@ -391,9 +477,10 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
 
   if (facts.state === "text_taken") {
     return withDefaults({
-      title: "this THOUGHT already exists",
-      detail: "No PATH permission or new mint is needed.",
+      title: "THOUGHT already exists",
+      detail: "This exact text is already on-chain. Each THOUGHT can be minted only once, and your $PATH was not used.",
       stageCopy: facts.existingTokenId === null ? "Open the existing THOUGHT." : `THOUGHT #${facts.existingTokenId} is already on-chain.`,
+      consoleNextStep: "reset and create a new THOUGHT",
       tone: "success",
       panelMode: "minted",
       activeStep: "mint",
@@ -432,7 +519,7 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
 
   if (facts.state === "path_checking") {
     return withDefaults({
-      title: facts.pathId ? `checking PATH #${facts.pathId}` : "checking PATH",
+      title: facts.pathId ? `checking $PATH #${facts.pathId}` : "checking $PATH",
       detail: "Verifying ownership and an available THOUGHT mint.",
       stageCopy: "No wallet request yet.",
       tone: "running",
@@ -443,14 +530,14 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
 
   if (facts.state === "path_ready") {
     return withDefaults({
-      title: "sign PATH permission",
+      title: `sign ${path}`,
       detail: `Allow the THOUGHT contract to use one THOUGHT mint from ${path}.`,
-      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+      stageCopy: `${signatureRequest} · no transaction · no gas`,
       tone: "idle",
       panelMode: "path_needed",
       activeStep: "sign",
       completedSteps: ["path"],
-      actions: [action("authorize", "Sign PATH permission"), action("choose_another", "Change PATH")],
+      actions: [action("authorize", `Sign ${path}`), action("choose_another", "Pick another $PATH")],
     });
   }
 
@@ -458,7 +545,7 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
     return withDefaults({
       title: "check your wallet",
       detail: `Sign the permission for ${path} to continue.`,
-      stageCopy: "Wallet request 1 of 2 · no transaction · no gas",
+      stageCopy: `${signatureRequest} · no transaction · no gas`,
       tone: "running",
       panelMode: "path_needed",
       activeStep: "sign",
@@ -472,14 +559,14 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
       ? ` Permission expires at ${new Date(Number(facts.authorization.deadline) * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}.`
       : "";
     return withDefaults({
-      title: "mint THOUGHT",
+      title: `${path} signed`,
       detail: `Create this THOUGHT using one THOUGHT mint from ${path}.${expires}`,
-      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      stageCopy: `${mintRequest} · transaction · gas applies`,
       tone: "success",
       panelMode: "minting",
       activeStep: "mint",
       completedSteps: ["path", "sign"],
-      actions: [action("confirm_mint", "Mint THOUGHT"), action("choose_another", "Change PATH")],
+      actions: [action("confirm_mint", "Mint THOUGHT"), action("choose_another", "Pick another $PATH")],
     });
   }
 
@@ -507,7 +594,7 @@ export const presentThoughtMint = (facts: ThoughtMintFacts): ThoughtMintPresenta
     return withDefaults({
       title: "confirm mint in wallet",
       detail: "No transaction has been submitted yet.",
-      stageCopy: "Wallet request 2 of 2 · transaction · gas applies",
+      stageCopy: `${mintRequest} · transaction · gas applies`,
       tone: "running",
       panelMode: "minting",
       activeStep: "mint",

--- a/apps/thought/src/thought-mint-submission-lock.test.ts
+++ b/apps/thought/src/thought-mint-submission-lock.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+
+import {
+  THOUGHT_MINT_SUBMISSION_LOCK_NAME,
+  createMintAttemptId,
+  waitForMintSubmissionOrRelease,
+  withMintSubmissionLock,
+} from "./thought-mint-submission-lock";
+
+const cryptoWithSequence = () => {
+  let sequence = 0;
+  return {
+    randomUUID: () => {
+      sequence += 1;
+      return `00000000-0000-4000-8000-${sequence.toString(16).padStart(12, "0")}`;
+    },
+    getRandomValues: <T extends ArrayBufferView | null>(value: T) => value,
+  };
+};
+
+export const runThoughtMintSubmissionLockTests = async () => {
+  const crypto = cryptoWithSequence();
+  const fixedNow = 1_752_624_000_000;
+  const firstId = createMintAttemptId("mint", crypto, fixedNow);
+  const secondId = createMintAttemptId("mint", crypto, fixedNow);
+  assert.notEqual(firstId, secondId, "fixed clocks still produce cross-tab unique IDs");
+  assert.match(firstId, /^[A-Za-z0-9][A-Za-z0-9-]{0,95}$/);
+
+  let requestedName = "";
+  const webLockSuccess = await withMintSubmissionLock({
+    crypto,
+    locks: {
+      request: async (name, options, callback) => {
+        requestedName = name;
+        assert.deepEqual(options, { mode: "exclusive", ifAvailable: true });
+        return callback({ name });
+      },
+    },
+  }, async (handle) => {
+    assert.equal(handle.kind, "web-lock");
+    assert.equal(handle.ownsExclusion(), true);
+    return "safe";
+  });
+  assert.equal(requestedName, THOUGHT_MINT_SUBMISSION_LOCK_NAME);
+  assert.deepEqual(webLockSuccess, { acquired: true, value: "safe" });
+
+  let busyTaskCalled = false;
+  const webLockBusy = await withMintSubmissionLock({
+    crypto,
+    locks: {
+      request: async (_name, _options, callback) => callback(null),
+    },
+  }, async () => {
+    busyTaskCalled = true;
+    return "unsafe";
+  });
+  assert.deepEqual(webLockBusy, { acquired: false, reason: "busy" });
+  assert.equal(busyTaskCalled, false, "a busy Web Lock never opens the wallet request");
+
+  let unavailableTaskCalled = false;
+  const legacyStorage = new Map<string, string>([[
+    "thought-mint-submission-lease-v1",
+    JSON.stringify({ ownerId: "legacy-tab" }),
+  ]]);
+  const noWebLocksEnvironment = {
+    crypto,
+    locks: null,
+    // Deliberately present: legacy storage must never be used as an exclusion
+    // fallback when Web Locks are unavailable.
+    storage: legacyStorage,
+  };
+  const noWebLocks = await withMintSubmissionLock(noWebLocksEnvironment, async () => {
+    unavailableTaskCalled = true;
+    return "unsafe";
+  });
+  assert.deepEqual(noWebLocks, { acquired: false, reason: "unavailable" });
+  assert.equal(unavailableTaskCalled, false, "no Web Locks means no wallet request");
+
+  let rejectedTaskCalled = false;
+  const rejectedWebLocks = await withMintSubmissionLock({
+    crypto,
+    locks: {
+      request: async () => {
+        throw new Error("Web Locks denied");
+      },
+    },
+  }, async () => {
+    rejectedTaskCalled = true;
+    return "unsafe";
+  });
+  assert.deepEqual(rejectedWebLocks, { acquired: false, reason: "unavailable" });
+  assert.equal(rejectedTaskCalled, false, "a rejected lock request fails closed");
+
+  let releaseNeverSettling!: () => void;
+  const neverSettling = new Promise<string>(() => {});
+  const releaseNeverSettlingSignal = new Promise<void>((resolve) => {
+    releaseNeverSettling = resolve;
+  });
+  const recoverableWait = waitForMintSubmissionOrRelease(
+    neverSettling,
+    releaseNeverSettlingSignal,
+  );
+  releaseNeverSettling();
+  assert.deepEqual(
+    await recoverableWait,
+    { kind: "released" },
+    "an explicitly recovered never-settling provider promise releases its exclusion waiter",
+  );
+};

--- a/apps/thought/src/thought-mint-submission-lock.ts
+++ b/apps/thought/src/thought-mint-submission-lock.ts
@@ -1,0 +1,101 @@
+export const THOUGHT_MINT_SUBMISSION_LOCK_NAME = "inshell:thought:mint-submission:v1";
+
+type LockLike = { name?: string };
+
+type LocksLike = {
+  request<T>(
+    name: string,
+    options: { mode: "exclusive"; ifAvailable: true },
+    callback: (lock: LockLike | null) => Promise<T>,
+  ): Promise<T>;
+};
+
+type CryptoLike = {
+  randomUUID?: () => string;
+  getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+};
+
+export type MintSubmissionLockHandle = Readonly<{
+  ownerId: string;
+  kind: "web-lock";
+  ownsExclusion: () => boolean;
+}>;
+
+export type MintSubmissionLockEnvironment = {
+  locks?: LocksLike | null;
+  crypto: CryptoLike;
+};
+
+export type MintSubmissionLockResult<T> =
+  | Readonly<{ acquired: true; value: T }>
+  | Readonly<{ acquired: false; reason: "busy" | "unavailable" }>;
+
+export type RecoverableMintSubmissionOutcome<T> =
+  | Readonly<{ kind: "settled"; value: T }>
+  | Readonly<{ kind: "rejected"; error: unknown }>
+  | Readonly<{ kind: "released" }>;
+
+export const waitForMintSubmissionOrRelease = async <T>(
+  submission: Promise<T>,
+  release: Promise<void>,
+): Promise<RecoverableMintSubmissionOutcome<T>> => Promise.race([
+  submission.then(
+    (value) => Object.freeze({ kind: "settled" as const, value }),
+    (error) => Object.freeze({ kind: "rejected" as const, error }),
+  ),
+  release.then(() => Object.freeze({ kind: "released" as const })),
+]);
+
+const randomHex = (crypto: CryptoLike, bytes = 16) => {
+  const values = crypto.getRandomValues(new Uint8Array(bytes));
+  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("");
+};
+
+export const createMintAttemptId = (
+  prefix: string,
+  crypto: CryptoLike,
+  now = Date.now(),
+) => {
+  const normalizedPrefix = prefix.replace(/[^A-Za-z0-9-]/g, "-").replace(/^-+/, "") || "mint";
+  const entropy = crypto.randomUUID?.().replace(/[^A-Za-z0-9-]/g, "") || randomHex(crypto);
+  return `${normalizedPrefix}-${Math.max(0, now).toString(36)}-${entropy}`.slice(0, 96);
+};
+
+export const withMintSubmissionLock = async <T>(
+  environment: MintSubmissionLockEnvironment,
+  task: (handle: MintSubmissionLockHandle) => Promise<T>,
+): Promise<MintSubmissionLockResult<T>> => {
+  const locks = environment.locks;
+  if (!locks || typeof locks.request !== "function") {
+    return Object.freeze({ acquired: false as const, reason: "unavailable" as const });
+  }
+
+  const ownerId = createMintAttemptId("mint-lock", environment.crypto);
+  let callbackStarted = false;
+  try {
+    return await locks.request(
+      THOUGHT_MINT_SUBMISSION_LOCK_NAME,
+      { mode: "exclusive", ifAvailable: true },
+      async (lock) => {
+        callbackStarted = true;
+        if (!lock) {
+          return Object.freeze({ acquired: false as const, reason: "busy" as const });
+        }
+        const value = await task(Object.freeze({
+          ownerId,
+          kind: "web-lock" as const,
+          ownsExclusion: () => true,
+        }));
+        return Object.freeze({ acquired: true as const, value });
+      },
+    );
+  } catch (error) {
+    // A browser can expose navigator.locks but reject access (for example in a
+    // restricted context). Fail closed before the wallet request. Errors from
+    // inside the protected task still belong to the normal mint error flow.
+    if (!callbackStarted) {
+      return Object.freeze({ acquired: false as const, reason: "unavailable" as const });
+    }
+    throw error;
+  }
+};

--- a/apps/thought/src/thought-mint-transaction.test.ts
+++ b/apps/thought/src/thought-mint-transaction.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+
+import {
+  classifyMintTrackingFailure,
+  createMintSubmissionContext,
+  createPendingMintTransaction,
+  mintReceiptStatusOutcome,
+  parseConflictingMintTransactions,
+  parsePendingMintTransaction,
+  parseMintTransactionReplacement,
+  pendingMintTransactionMatches,
+  planPendingMintRestore,
+  replacePendingMintTransactionHash,
+  serializeConflictingMintTransactions,
+} from "./thought-mint-transaction";
+
+const txHash = `0x${"AB".repeat(32)}`;
+const secondTxHash = `0x${"12".repeat(32)}`;
+const account = `0x${"AB".repeat(20)}`;
+const thoughtNft = `0x${"CD".repeat(20)}`;
+const workHash = `0x${"EF".repeat(32)}`;
+
+const legacyPendingRaw = JSON.stringify({
+  version: 1,
+  attemptId: " legacy-attempt ",
+  hash: txHash,
+  account,
+  chainId: 31337,
+  thoughtNft,
+  workHash,
+  pathId: "2",
+  submittedAt: 1_752_624_000_000,
+});
+
+export const runThoughtMintTransactionTests = () => {
+  const parsedLegacy = parsePendingMintTransaction(legacyPendingRaw);
+  assert(parsedLegacy, "a valid nonce-less v1 record must remain readable");
+  assert.equal(parsedLegacy.nonce, undefined);
+  assert.equal(parsedLegacy.attemptId, "legacy-attempt");
+  assert.equal(parsedLegacy.hash, txHash.toLowerCase());
+  assert.equal(parsedLegacy.account, account.toLowerCase());
+  assert.equal(Object.isFrozen(parsedLegacy), true);
+
+  const legacyMigration = planPendingMintRestore({
+    currentRaw: null,
+    legacySessionRaw: legacyPendingRaw,
+  });
+  assert.equal(legacyMigration.source, "legacy");
+  assert.deepEqual(legacyMigration.transaction, parsedLegacy);
+  assert.equal(legacyMigration.persistedRaw, JSON.stringify(parsedLegacy));
+  assert.equal(legacyMigration.removeLegacy, true);
+
+  const currentPendingRaw = JSON.stringify({
+    ...JSON.parse(legacyPendingRaw),
+    hash: secondTxHash,
+    nonce: 9,
+  });
+  const currentWins = planPendingMintRestore({
+    currentRaw: currentPendingRaw,
+    legacySessionRaw: legacyPendingRaw,
+  });
+  assert.equal(currentWins.source, "current");
+  assert.equal(currentWins.transaction?.hash, secondTxHash.toLowerCase());
+  assert.equal(currentWins.transaction?.nonce, 9);
+  assert.equal(currentWins.removeLegacy, true);
+
+  const corruptCurrentFallback = planPendingMintRestore({
+    currentRaw: "not json",
+    legacySessionRaw: legacyPendingRaw,
+  });
+  assert.equal(corruptCurrentFallback.source, "legacy");
+  assert.deepEqual(corruptCurrentFallback.transaction, parsedLegacy);
+
+  const invalidCleanup = planPendingMintRestore({
+    currentRaw: JSON.stringify({ version: 2 }),
+    legacySessionRaw: "also not json",
+  });
+  assert.deepEqual(invalidCleanup, {
+    transaction: null,
+    source: null,
+    persistedRaw: null,
+    removeLegacy: true,
+  });
+  assert.equal(
+    parsePendingMintTransaction(JSON.stringify({
+      ...JSON.parse(legacyPendingRaw),
+      nonce: -1,
+    })),
+    null,
+    "a present v1 nonce must be a non-negative safe integer",
+  );
+
+  const mutableInput = {
+    attemptId: " mint-attempt-7 ",
+    account,
+    chainId: 31337,
+    thoughtNft,
+    workHash,
+    pathId: 2n,
+    nonce: 17,
+  };
+  const submissionContext = createMintSubmissionContext(mutableInput);
+  assert.equal(Object.isFrozen(submissionContext), true);
+  assert.deepEqual(submissionContext, {
+    attemptId: "mint-attempt-7",
+    account: account.toLowerCase(),
+    chainId: 31337,
+    thoughtNft: thoughtNft.toLowerCase(),
+    workHash: workHash.toLowerCase(),
+    pathId: "2",
+    nonce: 17,
+  });
+
+  mutableInput.attemptId = "different-attempt";
+  mutableInput.account = `0x${"11".repeat(20)}`;
+  mutableInput.chainId = 1;
+  mutableInput.pathId = 99n;
+  mutableInput.nonce = 18;
+  const latePending = createPendingMintTransaction(
+    submissionContext,
+    txHash,
+    1_752_624_000_123,
+  );
+  assert.equal(Object.isFrozen(latePending), true);
+  assert.deepEqual(latePending, {
+    version: 1,
+    attemptId: "mint-attempt-7",
+    hash: txHash.toLowerCase(),
+    account: account.toLowerCase(),
+    chainId: 31337,
+    thoughtNft: thoughtNft.toLowerCase(),
+    workHash: workHash.toLowerCase(),
+    pathId: "2",
+    nonce: 17,
+    submittedAt: 1_752_624_000_123,
+  });
+  assert.equal(pendingMintTransactionMatches(latePending, txHash), true);
+  assert.equal(pendingMintTransactionMatches(latePending, secondTxHash), false);
+  const replacementPending = replacePendingMintTransactionHash(latePending, secondTxHash);
+  assert.equal(replacementPending.hash, secondTxHash.toLowerCase());
+  assert.equal(replacementPending.workHash, latePending.workHash);
+  assert.equal(replacementPending.submittedAt, latePending.submittedAt);
+  assert.equal(Object.isFrozen(replacementPending), true);
+  const conflicts = parseConflictingMintTransactions(JSON.stringify([
+    latePending,
+    replacementPending,
+    replacementPending,
+    { version: 2 },
+  ]));
+  assert.deepEqual(conflicts, [latePending, replacementPending]);
+  assert.equal(Object.isFrozen(conflicts), true);
+  assert.deepEqual(
+    parseConflictingMintTransactions(serializeConflictingMintTransactions(conflicts)),
+    conflicts,
+  );
+
+  assert.equal(mintReceiptStatusOutcome(1), "success");
+  assert.equal(mintReceiptStatusOutcome(1n), "success");
+  assert.equal(mintReceiptStatusOutcome("0x1"), "success");
+  assert.equal(mintReceiptStatusOutcome(0), "reverted");
+  assert.equal(mintReceiptStatusOutcome("0x0"), "reverted");
+  assert.equal(mintReceiptStatusOutcome(null), "unknown");
+  assert.equal(mintReceiptStatusOutcome(2), "unknown");
+
+  const repricedReplacement = parseMintTransactionReplacement({
+    code: "TRANSACTION_REPLACED",
+    reason: "repriced",
+    cancelled: false,
+    replacement: { hash: secondTxHash },
+    receipt: { hash: secondTxHash, status: 1 },
+  });
+  assert.deepEqual(repricedReplacement, {
+    cancelled: false,
+    reason: "repriced",
+    hash: secondTxHash.toLowerCase(),
+    receipt: { hash: secondTxHash, status: 1 },
+    replacement: { hash: secondTxHash },
+  });
+
+  const cancelledReplacement = {
+    code: "TRANSACTION_REPLACED",
+    reason: "cancelled",
+    cancelled: true,
+    replacement: { hash: secondTxHash },
+    receipt: { hash: secondTxHash, status: 1 },
+  };
+  assert.equal(parseMintTransactionReplacement(cancelledReplacement)?.cancelled, true);
+  assert.deepEqual(
+    classifyMintTrackingFailure(cancelledReplacement, txHash),
+    { category: "rejected", keepTracking: false },
+    "an explicitly cancelled replacement is terminal even when its cancellation receipt succeeded",
+  );
+
+  assert.deepEqual(
+    classifyMintTrackingFailure(
+      { code: "TIMEOUT", info: { error: { message: "request timed out" } } },
+      txHash,
+    ),
+    { category: "timeout", keepTracking: true },
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(new Error("wallet transaction not submitted."), txHash),
+    { category: "timeout", keepTracking: true },
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(new Error("wallet transaction not submitted."), ""),
+    { category: "timeout", keepTracking: false },
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(
+      { cause: { code: "NETWORK_ERROR", message: "socket connection lost" } },
+      txHash,
+    ),
+    { category: "transport", keepTracking: true },
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(new Error("transaction reverted."), txHash),
+    { category: "reverted", keepTracking: false },
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure({ code: 4001, message: "User rejected request" }, txHash),
+    { category: "rejected", keepTracking: true },
+    "a wallet-looking monitor error cannot erase a hash-backed transaction",
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(new Error("unexpected provider failure"), txHash),
+    { category: "other", keepTracking: true },
+    "unknown monitor failures retain a hash-backed transaction",
+  );
+  assert.deepEqual(
+    classifyMintTrackingFailure(new Error("request timed out"), "0xdead"),
+    { category: "timeout", keepTracking: false },
+    "only a complete transaction hash may retain submitted tracking",
+  );
+};

--- a/apps/thought/src/thought-mint-transaction.ts
+++ b/apps/thought/src/thought-mint-transaction.ts
@@ -120,7 +120,7 @@ const normalizeTimestamp = (value: unknown) => {
 const normalizePathId = (value: unknown) => {
   const normalized = typeof value === "bigint" ? value.toString() : String(value ?? "").trim();
   if (!POSITIVE_INTEGER_PATTERN.test(normalized)) {
-    throw new Error("invalid PATH id");
+    throw new Error("invalid $PATH id");
   }
   return normalized;
 };

--- a/apps/thought/src/thought-mint-transaction.ts
+++ b/apps/thought/src/thought-mint-transaction.ts
@@ -1,0 +1,442 @@
+export const THOUGHT_PENDING_MINT_TX_STORAGE_KEY =
+  "thought-pending-mint-transaction-v1";
+export const THOUGHT_CONFLICTING_MINT_TX_STORAGE_KEY =
+  "thought-conflicting-mint-transactions-v1";
+
+export type PendingMintTransaction = Readonly<{
+  version: 1;
+  attemptId?: string;
+  hash: string;
+  account: string;
+  chainId: number;
+  thoughtNft: string;
+  workHash: string;
+  pathId: string;
+  nonce?: number;
+  submittedAt: number;
+}>;
+
+export type MintSubmissionContext = Readonly<{
+  attemptId: string;
+  account: string;
+  chainId: number;
+  thoughtNft: string;
+  workHash: string;
+  pathId: string;
+  nonce: number;
+}>;
+
+export type NewPendingMintTransaction = PendingMintTransaction &
+  Readonly<{
+    attemptId: string;
+    nonce: number;
+  }>;
+
+export type PendingMintRestorePlan = Readonly<{
+  transaction: PendingMintTransaction | null;
+  source: "current" | "legacy" | null;
+  persistedRaw: string | null;
+  removeLegacy: boolean;
+}>;
+
+export type MintTrackingFailureCategory =
+  | "timeout"
+  | "transport"
+  | "reverted"
+  | "rejected"
+  | "other";
+
+export type MintTrackingFailure = Readonly<{
+  category: MintTrackingFailureCategory;
+  keepTracking: boolean;
+}>;
+
+export type MintReceiptStatusOutcome = "success" | "reverted" | "unknown";
+
+export type MintTransactionReplacement = Readonly<{
+  cancelled: boolean;
+  reason: string;
+  hash: string;
+  receipt: unknown | null;
+  replacement: unknown | null;
+}>;
+
+type MintErrorLike = {
+  cancelled?: unknown;
+  cause?: unknown;
+  code?: unknown;
+  data?: unknown;
+  error?: unknown;
+  info?: unknown;
+  message?: unknown;
+  originalError?: unknown;
+  reason?: unknown;
+  receipt?: unknown;
+  replacement?: unknown;
+  shortMessage?: unknown;
+  status?: unknown;
+};
+
+const TRANSACTION_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
+
+const normalizeRequiredText = (value: unknown, label: string) => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`invalid ${label}`);
+  }
+  return value.trim();
+};
+
+const normalizeHex = (value: unknown, pattern: RegExp, label: string) => {
+  const normalized = normalizeRequiredText(value, label);
+  if (!pattern.test(normalized)) {
+    throw new Error(`invalid ${label}`);
+  }
+  return normalized.toLowerCase();
+};
+
+const normalizeChainId = (value: unknown) => {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error("invalid chain id");
+  }
+  return Number(value);
+};
+
+const normalizeNonce = (value: unknown) => {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("invalid transaction nonce");
+  }
+  return Number(value);
+};
+
+const normalizeTimestamp = (value: unknown) => {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("invalid submitted timestamp");
+  }
+  return Number(value);
+};
+
+const normalizePathId = (value: unknown) => {
+  const normalized = typeof value === "bigint" ? value.toString() : String(value ?? "").trim();
+  if (!POSITIVE_INTEGER_PATTERN.test(normalized)) {
+    throw new Error("invalid PATH id");
+  }
+  return normalized;
+};
+
+const normalizeAttemptId = (value: unknown, required: boolean) => {
+  if (value === undefined && !required) return undefined;
+  return normalizeRequiredText(value, "attempt id");
+};
+
+const normalizePendingMintTransaction = (
+  value: Partial<PendingMintTransaction>,
+): PendingMintTransaction => {
+  if (value.version !== 1) {
+    throw new Error("unsupported pending mint transaction version");
+  }
+
+  const attemptId = normalizeAttemptId(value.attemptId, false);
+  const nonce = value.nonce === undefined ? undefined : normalizeNonce(value.nonce);
+  return Object.freeze({
+    version: 1,
+    ...(attemptId ? { attemptId } : {}),
+    hash: normalizeHex(value.hash, TRANSACTION_HASH_PATTERN, "transaction hash"),
+    account: normalizeHex(value.account, ADDRESS_PATTERN, "account"),
+    chainId: normalizeChainId(value.chainId),
+    thoughtNft: normalizeHex(value.thoughtNft, ADDRESS_PATTERN, "THOUGHT contract"),
+    workHash: normalizeHex(value.workHash, TRANSACTION_HASH_PATTERN, "work hash"),
+    pathId: normalizePathId(value.pathId),
+    ...(nonce === undefined ? {} : { nonce }),
+    submittedAt: normalizeTimestamp(value.submittedAt),
+  });
+};
+
+export const parsePendingMintTransaction = (
+  raw: string | null | undefined,
+): PendingMintTransaction | null => {
+  if (!raw?.trim()) return null;
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return null;
+    }
+    return normalizePendingMintTransaction(value as Partial<PendingMintTransaction>);
+  } catch {
+    return null;
+  }
+};
+
+export const serializePendingMintTransaction = (
+  transaction: PendingMintTransaction,
+) => JSON.stringify(transaction);
+
+export const parseConflictingMintTransactions = (
+  raw: string | null | undefined,
+): readonly PendingMintTransaction[] => {
+  if (!raw?.trim()) return Object.freeze([]);
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return Object.freeze([]);
+    const seen = new Set<string>();
+    const transactions = parsed.flatMap((value) => {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) return [];
+      try {
+        const transaction = normalizePendingMintTransaction(
+          value as Partial<PendingMintTransaction>,
+        );
+        if (seen.has(transaction.hash)) return [];
+        seen.add(transaction.hash);
+        return [transaction];
+      } catch {
+        return [];
+      }
+    }).slice(-8);
+    return Object.freeze(transactions);
+  } catch {
+    return Object.freeze([]);
+  }
+};
+
+export const serializeConflictingMintTransactions = (
+  transactions: readonly PendingMintTransaction[],
+) => JSON.stringify(parseConflictingMintTransactions(JSON.stringify(transactions)));
+
+export const planPendingMintRestore = ({
+  currentRaw,
+  legacySessionRaw,
+}: {
+  currentRaw: string | null;
+  legacySessionRaw: string | null;
+}): PendingMintRestorePlan => {
+  const current = parsePendingMintTransaction(currentRaw);
+  if (current) {
+    return Object.freeze({
+      transaction: current,
+      source: "current",
+      persistedRaw: serializePendingMintTransaction(current),
+      removeLegacy: legacySessionRaw !== null,
+    });
+  }
+
+  const legacy = parsePendingMintTransaction(legacySessionRaw);
+  if (legacy) {
+    return Object.freeze({
+      transaction: legacy,
+      source: "legacy",
+      persistedRaw: serializePendingMintTransaction(legacy),
+      removeLegacy: true,
+    });
+  }
+
+  return Object.freeze({
+    transaction: null,
+    source: null,
+    persistedRaw: null,
+    removeLegacy: legacySessionRaw !== null,
+  });
+};
+
+export const createMintSubmissionContext = (input: {
+  attemptId: string;
+  account: string;
+  chainId: number;
+  thoughtNft: string;
+  workHash: string;
+  pathId: string | bigint;
+  nonce: number;
+}): MintSubmissionContext => Object.freeze({
+  attemptId: normalizeAttemptId(input.attemptId, true)!,
+  account: normalizeHex(input.account, ADDRESS_PATTERN, "account"),
+  chainId: normalizeChainId(input.chainId),
+  thoughtNft: normalizeHex(input.thoughtNft, ADDRESS_PATTERN, "THOUGHT contract"),
+  workHash: normalizeHex(input.workHash, TRANSACTION_HASH_PATTERN, "work hash"),
+  pathId: normalizePathId(input.pathId),
+  nonce: normalizeNonce(input.nonce),
+});
+
+export const createPendingMintTransaction = (
+  context: MintSubmissionContext,
+  transactionHash: string,
+  submittedAt: number,
+): NewPendingMintTransaction => Object.freeze({
+  version: 1,
+  attemptId: context.attemptId,
+  hash: normalizeHex(transactionHash, TRANSACTION_HASH_PATTERN, "transaction hash"),
+  account: context.account,
+  chainId: context.chainId,
+  thoughtNft: context.thoughtNft,
+  workHash: context.workHash,
+  pathId: context.pathId,
+  nonce: context.nonce,
+  submittedAt: normalizeTimestamp(submittedAt),
+});
+
+export const pendingMintTransactionMatches = (
+  transaction: PendingMintTransaction | null | undefined,
+  hash: string | null | undefined,
+) => Boolean(
+  transaction &&
+  typeof hash === "string" &&
+  TRANSACTION_HASH_PATTERN.test(hash) &&
+  transaction.hash.toLowerCase() === hash.toLowerCase(),
+);
+
+export const replacePendingMintTransactionHash = (
+  transaction: PendingMintTransaction,
+  replacementHash: string,
+): PendingMintTransaction => normalizePendingMintTransaction({
+  ...transaction,
+  hash: replacementHash,
+});
+
+export const mintReceiptStatusOutcome = (status: unknown): MintReceiptStatusOutcome => {
+  if (status === 1 || status === 1n || status === true || status === "0x1") {
+    return "success";
+  }
+  if (status === 0 || status === 0n || status === false || status === "0x0") {
+    return "reverted";
+  }
+  return "unknown";
+};
+
+const objectValue = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+
+export const parseMintTransactionReplacement = (
+  error: unknown,
+): MintTransactionReplacement | null => {
+  const item = objectValue(error);
+  if (!item || String(item.code ?? "").toUpperCase() !== "TRANSACTION_REPLACED") {
+    return null;
+  }
+
+  const replacement = objectValue(item.replacement);
+  const receipt = objectValue(item.receipt);
+  const hashCandidates = [replacement?.hash, receipt?.hash, receipt?.transactionHash];
+  const hash = hashCandidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && TRANSACTION_HASH_PATTERN.test(candidate),
+  );
+  if (!hash) {
+    return null;
+  }
+
+  const reason = typeof item.reason === "string" ? item.reason.trim().toLowerCase() : "";
+  return Object.freeze({
+    cancelled: item.cancelled === true || reason === "cancelled" || reason === "canceled",
+    reason,
+    hash: hash.toLowerCase(),
+    receipt: receipt ?? null,
+    replacement: replacement ?? null,
+  });
+};
+
+const collectMintErrorDetails = (error: unknown) => {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  let receiptStatus: number | null = null;
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0 && visited.size < 16) {
+    const value = queue.shift();
+    if (value == null || visited.has(value)) continue;
+    visited.add(value);
+
+    if (typeof value === "string") {
+      if (value.trim()) messages.push(value.trim());
+      continue;
+    }
+    if (typeof value !== "object") continue;
+
+    const item = value as MintErrorLike;
+    for (const candidate of [item.shortMessage, item.message, item.reason]) {
+      if (typeof candidate === "string" && candidate.trim()) {
+        messages.push(candidate.trim());
+      }
+    }
+    if (typeof item.code === "string" || typeof item.code === "number") {
+      codes.push(String(item.code).toUpperCase());
+    }
+    if (item.status === 0) {
+      receiptStatus = 0;
+    }
+
+    queue.push(
+      item.error,
+      item.cause,
+      item.info,
+      item.data,
+      item.originalError,
+      item.receipt,
+    );
+  }
+
+  return {
+    codes,
+    normalized: messages.join(" ").toLowerCase(),
+    receiptStatus,
+  };
+};
+
+const includesCode = (codes: readonly string[], ...candidates: string[]) =>
+  candidates.some((candidate) => codes.includes(candidate));
+
+export const classifyMintTrackingFailure = (
+  error: unknown,
+  submittedHash: string | null | undefined,
+): MintTrackingFailure => {
+  const replacement = parseMintTransactionReplacement(error);
+  if (replacement?.cancelled) {
+    return Object.freeze({
+      category: "rejected" as const,
+      keepTracking: false,
+    });
+  }
+
+  const { codes, normalized, receiptStatus } = collectMintErrorDetails(error);
+  const hasSubmittedHash =
+    typeof submittedHash === "string" && TRANSACTION_HASH_PATTERN.test(submittedHash);
+
+  let category: MintTrackingFailureCategory = "other";
+  if (
+    receiptStatus === 0 ||
+    includesCode(codes, "CALL_EXCEPTION") ||
+    /\b(?:execution |transaction )?revert(?:ed)?\b/.test(normalized)
+  ) {
+    category = "reverted";
+  } else if (
+    includesCode(codes, "4001", "ACTION_REJECTED") ||
+    /\b(?:reject(?:ed)?|denied|cancelled|canceled)\b/.test(normalized)
+  ) {
+    category = "rejected";
+  } else if (
+    includesCode(codes, "TIMEOUT", "ETIMEDOUT") ||
+    /\b(?:timeout|timed out|time out)\b|not submitted/.test(normalized)
+  ) {
+    category = "timeout";
+  } else if (
+    includesCode(
+      codes,
+      "NETWORK_ERROR",
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+    ) ||
+    /network|socket|connection|failed to fetch|temporarily unavailable|missing response/.test(
+      normalized,
+    )
+  ) {
+    category = "transport";
+  }
+
+  return Object.freeze({
+    category,
+    keepTracking: hasSubmittedHash && category !== "reverted",
+  });
+};

--- a/apps/thought/src/thought-mint-ui.ts
+++ b/apps/thought/src/thought-mint-ui.ts
@@ -13,22 +13,18 @@ export type ThoughtAuthorizationErrorPresentation = {
 };
 
 export const THOUGHT_V2_MINT_UNAVAILABLE_COPY =
-  "Minting unavailable: this THOUGHT V2 build has no approved onchain deployment yet.";
+  "Minting unavailable: this THOUGHT V2 build has no approved on-chain deployment yet.";
 
 type ThoughtWorkReadyPresentationInput = {
   mintEnabled: boolean;
-  walletConnected: boolean;
 };
 
 export const getThoughtWorkReadyPresentation = ({
   mintEnabled,
-  walletConnected,
 }: ThoughtWorkReadyPresentationInput) => ({
   canMint: mintEnabled,
   detail: mintEnabled
-    ? walletConnected
-      ? "ready to mint"
-      : "connect wallet to mint"
+    ? "ready to mint"
     : THOUGHT_V2_MINT_UNAVAILABLE_COPY,
 });
 
@@ -143,7 +139,7 @@ export const formatThoughtAuthorizationError = (
       /unsupported (?:method|operation)|method not found|does not support.*(?:sign|personal_sign)|personal_sign.*(?:unsupported|unavailable)/.test(normalized)
     )
   ) {
-    return { message: "wallet does not support PATH authorization.", kind: "signature" };
+    return { message: "wallet cannot sign the $PATH permission.", kind: "signature" };
   }
   if (
     isWalletStage &&
@@ -158,15 +154,15 @@ export const formatThoughtAuthorizationError = (
     return { message: "THOUGHT preparation unavailable.", kind: "thought" };
   }
   if (stage === "nonce") {
-    return { message: "PATH authorization unavailable.", kind: "signature" };
+    return { message: "$PATH signature unavailable.", kind: "signature" };
   }
   if (stage === "wallet") {
     return { message: "signing wallet unavailable. reconnect wallet.", kind: "signature" };
   }
-  return { message: "authorization failed.", kind: "signature" };
+  return { message: "signature failed.", kind: "signature" };
 };
 
-// The THOUGHT creation surface owns PATH selection, authorization, and minting.
+// The THOUGHT creation surface owns $PATH selection, signing, and minting.
 // Keep its default flow inside the control panel; `sheet` only supports legacy
 // surfaces that opt into it explicitly.
 export const THOUGHT_PANEL_MINT_UI_MODE: MintFlowUiMode = "dock";

--- a/apps/thought/src/thought-mint-ui.ts
+++ b/apps/thought/src/thought-mint-ui.ts
@@ -1,5 +1,17 @@
 export type MintFlowUiMode = "sheet" | "cli" | "dock";
 
+export type ThoughtAuthorizationStage =
+  | "preparing"
+  | "wallet"
+  | "nonce"
+  | "digest"
+  | "signature";
+
+export type ThoughtAuthorizationErrorPresentation = {
+  message: string;
+  kind: "thought" | "spec" | "signature" | "wrong_network";
+};
+
 export const THOUGHT_V2_MINT_UNAVAILABLE_COPY =
   "Minting unavailable: this THOUGHT V2 build has no approved onchain deployment yet.";
 
@@ -19,6 +31,140 @@ export const getThoughtWorkReadyPresentation = ({
       : "connect wallet to mint"
     : THOUGHT_V2_MINT_UNAVAILABLE_COPY,
 });
+
+type WalletErrorLike = {
+  cause?: unknown;
+  code?: unknown;
+  data?: unknown;
+  error?: unknown;
+  info?: unknown;
+  message?: unknown;
+  originalError?: unknown;
+  reason?: unknown;
+  shortMessage?: unknown;
+};
+
+const collectAuthorizationErrorDetails = (error: unknown) => {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0 && visited.size < 12) {
+    const value = queue.shift();
+    if (value == null || visited.has(value)) continue;
+    visited.add(value);
+
+    if (typeof value === "string") {
+      if (value.trim()) messages.push(value.trim());
+      continue;
+    }
+    if (typeof value !== "object") continue;
+
+    const item = value as WalletErrorLike;
+    for (const candidate of [item.shortMessage, item.message, item.reason]) {
+      if (typeof candidate === "string" && candidate.trim()) {
+        messages.push(candidate.trim());
+      }
+    }
+    if (typeof item.code === "string" || typeof item.code === "number") {
+      codes.push(String(item.code).toUpperCase());
+    }
+
+    queue.push(
+      item.error,
+      item.cause,
+      (item.info as WalletErrorLike | undefined)?.error,
+      (item.data as WalletErrorLike | undefined)?.error,
+      (item.data as WalletErrorLike | undefined)?.originalError,
+    );
+  }
+
+  return {
+    codes,
+    messages,
+    normalized: messages.join(" ").toLowerCase(),
+    primaryMessage: messages[0] ?? "",
+  };
+};
+
+export const formatThoughtAuthorizationError = (
+  error: unknown,
+  stage: ThoughtAuthorizationStage,
+): ThoughtAuthorizationErrorPresentation => {
+  const { codes, normalized, primaryMessage } = collectAuthorizationErrorDetails(error);
+  const isWalletStage = stage === "wallet" || stage === "signature";
+
+  if (
+    /provenance (?:is )?\d+\s*\/\s*\d+ bytes|provenance (?:is )?.*too large|provenance too large/.test(normalized)
+  ) {
+    return {
+      message: primaryMessage || "provenance too large.",
+      kind: "thought",
+    };
+  }
+  if (/^spec\b/.test(primaryMessage.toLowerCase()) || normalized.includes("thought.md")) {
+    return { message: primaryMessage, kind: "spec" };
+  }
+  if (
+    isWalletStage &&
+    (
+      codes.includes("4001") ||
+      codes.includes("ACTION_REJECTED") ||
+      /user (?:rejected|denied|cancelled|canceled)/.test(normalized)
+    )
+  ) {
+    return { message: "signature rejected in wallet.", kind: "signature" };
+  }
+  if (
+    isWalletStage &&
+    (
+      codes.includes("-32002") ||
+      /already (?:processing|pending)|request is pending/.test(normalized)
+    )
+  ) {
+    return { message: "signature request already pending in wallet.", kind: "signature" };
+  }
+  if (
+    isWalletStage &&
+    (
+      codes.includes("NETWORK_ERROR") ||
+      /wrong network|network changed|chain changed|chain id.*mismatch/.test(normalized)
+    )
+  ) {
+    return { message: "wrong network.", kind: "wrong_network" };
+  }
+  if (
+    isWalletStage &&
+    (
+      codes.includes("4200") ||
+      codes.includes("-32601") ||
+      codes.includes("UNSUPPORTED_OPERATION") ||
+      /unsupported (?:method|operation)|method not found|does not support.*(?:sign|personal_sign)|personal_sign.*(?:unsupported|unavailable)/.test(normalized)
+    )
+  ) {
+    return { message: "wallet does not support PATH authorization.", kind: "signature" };
+  }
+  if (
+    isWalletStage &&
+    (
+      codes.includes("4100") ||
+      /wallet.*locked|unknown account|account.*(?:changed|unavailable|not found)|not connected|unauthorized/.test(normalized)
+    )
+  ) {
+    return { message: "signing wallet unavailable. reconnect wallet.", kind: "signature" };
+  }
+  if (stage === "preparing") {
+    return { message: "THOUGHT preparation unavailable.", kind: "thought" };
+  }
+  if (stage === "nonce") {
+    return { message: "PATH authorization unavailable.", kind: "signature" };
+  }
+  if (stage === "wallet") {
+    return { message: "signing wallet unavailable. reconnect wallet.", kind: "signature" };
+  }
+  return { message: "authorization failed.", kind: "signature" };
+};
 
 // The THOUGHT creation surface owns PATH selection, authorization, and minting.
 // Keep its default flow inside the control panel; `sheet` only supports legacy

--- a/apps/thought/src/thought-path-acquisition.test.ts
+++ b/apps/thought/src/thought-path-acquisition.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import {
+  parsePendingThoughtPathAcquisition,
+  pendingThoughtPathAcquisitionMatches,
+  serializePendingThoughtPathAcquisition,
+  withThoughtPathAcquisitionLock,
+} from "./thought-path-acquisition";
+
+const pending = {
+  version: 1 as const,
+  account: "0x1111111111111111111111111111111111111111",
+  chainId: 31337,
+  auction: "0x2222222222222222222222222222222222222222",
+  pathNft: "0x3333333333333333333333333333333333333333",
+  workHash: `0x${"44".repeat(32)}`,
+  txHash: `0x${"55".repeat(32)}`,
+  updatedAt: 1_000,
+};
+
+export const runThoughtPathAcquisitionTests = async () => {
+  {
+    assert.deepEqual(
+      parsePendingThoughtPathAcquisition(
+        serializePendingThoughtPathAcquisition(pending),
+        pending.updatedAt,
+      ),
+      pending,
+    );
+  }
+
+  {
+    assert.equal(
+      parsePendingThoughtPathAcquisition(pending, pending.updatedAt + 8 * 24 * 60 * 60 * 1_000),
+      null,
+    );
+    assert.equal(
+      pendingThoughtPathAcquisitionMatches(pending, {
+        account: pending.account,
+        chainId: pending.chainId,
+        auction: "0x9999999999999999999999999999999999999999",
+        pathNft: pending.pathNft,
+        workHash: pending.workHash,
+      }),
+      false,
+    );
+  }
+
+  {
+    assert.deepEqual(
+      await withThoughtPathAcquisitionLock(null, async () => "unused"),
+      { acquired: false, reason: "unsupported" },
+    );
+    assert.deepEqual(
+      await withThoughtPathAcquisitionLock(
+        {
+          request: async (_name, _options, callback) => callback(null),
+        },
+        async () => "unused",
+      ),
+      { acquired: false, reason: "busy" },
+    );
+  }
+};

--- a/apps/thought/src/thought-path-acquisition.ts
+++ b/apps/thought/src/thought-path-acquisition.ts
@@ -1,0 +1,141 @@
+export const THOUGHT_PATH_ACQUISITION_STORAGE_KEY =
+  "inshell:thought:path-acquisition:v1";
+
+export type ThoughtPathAcquisitionState =
+  | "idle"
+  | "quoting"
+  | "review"
+  | "awaiting_signature"
+  | "submitted"
+  | "error";
+
+export type PendingThoughtPathAcquisition = Readonly<{
+  version: 1;
+  account: string;
+  chainId: number;
+  auction: string;
+  pathNft: string;
+  workHash: string;
+  txHash: string;
+  updatedAt: number;
+}>;
+
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+const PENDING_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+
+const parseJson = (value: unknown) => {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+export const parsePendingThoughtPathAcquisition = (
+  value: unknown,
+  now = Date.now(),
+): PendingThoughtPathAcquisition | null => {
+  const parsed = parseJson(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    candidate.version !== 1 ||
+    typeof candidate.account !== "string" ||
+    !ADDRESS_PATTERN.test(candidate.account) ||
+    typeof candidate.chainId !== "number" ||
+    !Number.isSafeInteger(candidate.chainId) ||
+    candidate.chainId <= 0 ||
+    typeof candidate.auction !== "string" ||
+    !ADDRESS_PATTERN.test(candidate.auction) ||
+    typeof candidate.pathNft !== "string" ||
+    !ADDRESS_PATTERN.test(candidate.pathNft) ||
+    typeof candidate.workHash !== "string" ||
+    !HASH_PATTERN.test(candidate.workHash) ||
+    typeof candidate.txHash !== "string" ||
+    !HASH_PATTERN.test(candidate.txHash) ||
+    typeof candidate.updatedAt !== "number" ||
+    !Number.isSafeInteger(candidate.updatedAt) ||
+    candidate.updatedAt <= 0 ||
+    now - candidate.updatedAt > PENDING_TTL_MS
+  ) {
+    return null;
+  }
+
+  return Object.freeze({
+    version: 1 as const,
+    account: candidate.account.toLowerCase(),
+    chainId: candidate.chainId,
+    auction: candidate.auction.toLowerCase(),
+    pathNft: candidate.pathNft.toLowerCase(),
+    workHash: candidate.workHash.toLowerCase(),
+    txHash: candidate.txHash.toLowerCase(),
+    updatedAt: candidate.updatedAt,
+  });
+};
+
+export const serializePendingThoughtPathAcquisition = (
+  value: PendingThoughtPathAcquisition,
+) => {
+  const parsed = parsePendingThoughtPathAcquisition(value, value.updatedAt);
+  if (!parsed) throw new Error("invalid pending $PATH acquisition");
+  return JSON.stringify(parsed);
+};
+
+export const pendingThoughtPathAcquisitionMatches = (
+  pending: PendingThoughtPathAcquisition,
+  expected: Readonly<{
+    account: string;
+    chainId: number;
+    auction: string;
+    pathNft: string;
+    workHash: string;
+  }>,
+) =>
+  pending.account === expected.account.toLowerCase() &&
+  pending.chainId === expected.chainId &&
+  pending.auction === expected.auction.toLowerCase() &&
+  pending.pathNft === expected.pathNft.toLowerCase() &&
+  pending.workHash === expected.workHash.toLowerCase();
+
+type PathMintLockManager = {
+  request<T>(
+    name: string,
+    options: { mode: "exclusive"; ifAvailable: true },
+    callback: (lock: unknown | null) => Promise<T>,
+  ): Promise<T>;
+};
+
+export type ThoughtPathAcquisitionLockResult<T> =
+  | Readonly<{ acquired: true; value: T }>
+  | Readonly<{ acquired: false; reason: "busy" | "unsupported" }>;
+
+export const withThoughtPathAcquisitionLock = async <T>(
+  locks: PathMintLockManager | null | undefined,
+  task: () => Promise<T>,
+): Promise<ThoughtPathAcquisitionLockResult<T>> => {
+  if (!locks || typeof locks.request !== "function") {
+    return Object.freeze({ acquired: false as const, reason: "unsupported" as const });
+  }
+
+  let callbackStarted = false;
+  try {
+    return await locks.request(
+      "inshell:thought:path-acquisition-submit:v1",
+      { mode: "exclusive", ifAvailable: true },
+      async (lock) => {
+        callbackStarted = true;
+        if (!lock) {
+          return Object.freeze({ acquired: false as const, reason: "busy" as const });
+        }
+        return Object.freeze({ acquired: true as const, value: await task() });
+      },
+    );
+  } catch (error) {
+    if (!callbackStarted) {
+      return Object.freeze({ acquired: false as const, reason: "unsupported" as const });
+    }
+    throw error;
+  }
+};

--- a/apps/thought/src/thought-preview-policy.ts
+++ b/apps/thought/src/thought-preview-policy.ts
@@ -2,6 +2,12 @@ export type PreviewMode = "auto" | "wallet" | "off";
 export type PreviewProviderKind = "frontend-renderer" | "wallet" | "preview-endpoint" | "none";
 export type PreviewStatus = "not_attempted" | "unavailable" | "failed" | "accepted";
 
+export type ThoughtByteLimitUsage = {
+  line: "prompt" | "agent output" | "model return";
+  usedBytes: number;
+  maxBytes: number;
+};
+
 export const THOUGHT_PREVIEW_MODE_STORAGE_KEY = "thought-preview-mode";
 export const THOUGHT_CURRENT_CANDIDATE_STORAGE_KEY = "thought-current-candidate";
 export const THOUGHT_PREVIEW_CACHE_LIMIT = 80;
@@ -26,6 +32,14 @@ export type ThoughtCandidatePrevalidation =
 const encoder = new TextEncoder();
 
 const byteLength = (value: string) => encoder.encode(value).length;
+
+export const thoughtByteLimitPercentage = (usage: ThoughtByteLimitUsage) =>
+  Math.round((usage.usedBytes / usage.maxBytes) * 100);
+
+export const formatThoughtByteLimitUsage = (usage: ThoughtByteLimitUsage) => {
+  const line = usage.line === "agent output" ? "Agent output" : usage.line;
+  return `${line}: ${thoughtByteLimitPercentage(usage)}% used · ${usage.usedBytes} / ${usage.maxBytes} UTF-8 bytes`;
+};
 
 export const previewModes = ["auto", "wallet", "off"] as const;
 

--- a/apps/thought/src/thought-shell.tsx
+++ b/apps/thought/src/thought-shell.tsx
@@ -96,7 +96,11 @@ const disconnectedWalletNote = (chainId: number) => {
   return undefined;
 };
 
-export const mountThoughtShell = (element: HTMLElement, expectedChainId: number) => {
+export const mountThoughtShell = (
+  element: HTMLElement,
+  expectedChainId: number,
+  onWalletRefresh?: () => void | Promise<void>,
+) => {
   if (shellRoot) return;
   shellRoot = createRoot(element);
   shellRoot.render(
@@ -106,6 +110,7 @@ export const mountThoughtShell = (element: HTMLElement, expectedChainId: number)
         active="thought"
         expectedChainId={expectedChainId}
         disconnectedWalletNote={disconnectedWalletNote(expectedChainId)}
+        onWalletRefresh={onWalletRefresh}
       />
     </WalletProvider>,
   );

--- a/apps/thought/src/thought-text-policy.ts
+++ b/apps/thought/src/thought-text-policy.ts
@@ -1,0 +1,224 @@
+import type { ThoughtV2LineKind, ThoughtV2Measure } from "./thought-v2-renderer";
+
+export type ThoughtTextPolicyLine = ThoughtV2LineKind | "agent output";
+
+export type ThoughtTextPolicyIssue = {
+  title: string;
+  detail: string;
+  nextStep: string;
+};
+
+const codePointLabel = (codePoint: number) =>
+  `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
+
+const codePointPosition = (value: string, target: number) => {
+  const index = Array.from(value).findIndex(
+    (character) => character.codePointAt(0) === target,
+  );
+  return index < 0 ? undefined : index + 1;
+};
+
+const invalidSurrogatePosition = (value: string) => {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return index + 1;
+      index += 1;
+      continue;
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff) return index + 1;
+  }
+  return undefined;
+};
+
+const isAgentOutput = (line: ThoughtTextPolicyLine) => line === "agent output";
+const displayLine = (line: ThoughtTextPolicyLine) => isAgentOutput(line) ? "Agent output" : line;
+
+const editNextStep = (line: ThoughtTextPolicyLine, promptStep: string) =>
+  isAgentOutput(line)
+    ? "reset and run the Agent again; output is never auto-corrected"
+    : promptStep;
+
+const describedCodePoint = (codePoint: number) => {
+  if (codePoint === 0x0009) return "tab";
+  if (codePoint === 0x000a) return "line feed";
+  if (codePoint === 0x000d) return "carriage return";
+  if (codePoint === 0x00a0) return "no-break space";
+  if (codePoint === 0x200b) return "zero-width space";
+  if (codePoint === 0xfeff) return "zero-width no-break space";
+  return "character";
+};
+
+const isWhitespaceCodePoint = (codePoint: number) =>
+  (codePoint >= 0x0009 && codePoint <= 0x000d) ||
+  codePoint === 0x0085 ||
+  codePoint === 0x00a0 ||
+  codePoint === 0x1680 ||
+  (codePoint >= 0x2000 && codePoint <= 0x200a) ||
+  codePoint === 0x2028 ||
+  codePoint === 0x2029 ||
+  codePoint === 0x202f ||
+  codePoint === 0x205f ||
+  codePoint === 0x3000;
+
+const isInvisibleCodePoint = (codePoint: number) =>
+  codePoint === 0x00ad ||
+  codePoint === 0x034f ||
+  codePoint === 0x061c ||
+  (codePoint >= 0x115f && codePoint <= 0x1160) ||
+  (codePoint >= 0x17b4 && codePoint <= 0x17b5) ||
+  (codePoint >= 0x180b && codePoint <= 0x180f) ||
+  (codePoint >= 0x200b && codePoint <= 0x200f) ||
+  (codePoint >= 0x202a && codePoint <= 0x202e) ||
+  (codePoint >= 0x2060 && codePoint <= 0x206f) ||
+  codePoint === 0x3164 ||
+  (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+  codePoint === 0xfeff ||
+  codePoint === 0xffa0 ||
+  (codePoint >= 0xfff0 && codePoint <= 0xfff8) ||
+  (codePoint >= 0x1bca0 && codePoint <= 0x1bca3) ||
+  (codePoint >= 0x1d173 && codePoint <= 0x1d17a) ||
+  (codePoint >= 0xe0000 && codePoint <= 0xe0fff);
+
+const issueForCodePoint = (
+  value: string,
+  line: ThoughtTextPolicyLine,
+  error: string,
+): ThoughtTextPolicyIssue | null => {
+  const match = error.match(/U\+([0-9A-F]+)/i);
+  if (!match) return null;
+  const codePoint = Number.parseInt(match[1]!, 16);
+  const label = codePointLabel(codePoint);
+  const position = codePointPosition(value, codePoint);
+  const location = position ? ` at character ${position}` : "";
+  const described = describedCodePoint(codePoint);
+  const detail = `${displayLine(line)} contains ${described} ${label}${location}`;
+
+  if (codePoint === 0x0009) {
+    return {
+      title: "tab not allowed",
+      detail,
+      nextStep: editNextStep(line, `replace ${label}${location} with a regular space`),
+    };
+  }
+  if (
+    codePoint === 0x000a ||
+    codePoint === 0x000d ||
+    codePoint === 0x2028 ||
+    codePoint === 0x2029
+  ) {
+    return {
+      title: "line break not allowed",
+      detail,
+      nextStep: editNextStep(line, `delete the line break${location}`),
+    };
+  }
+  if (isWhitespaceCodePoint(codePoint)) {
+    return {
+      title: "unsupported whitespace",
+      detail,
+      nextStep: editNextStep(
+        line,
+        `replace ${label}${location} with a regular space or delete it`,
+      ),
+    };
+  }
+  if (isInvisibleCodePoint(codePoint)) {
+    return {
+      title: "invisible character",
+      detail,
+      nextStep: editNextStep(line, `delete ${label}${location}`),
+    };
+  }
+  if (/control character/i.test(error)) {
+    return {
+      title: "control character",
+      detail,
+      nextStep: editNextStep(line, `delete ${label}${location}`),
+    };
+  }
+  return {
+    title: "unsupported character",
+    detail,
+    nextStep: editNextStep(line, `delete or replace ${label}${location}`),
+  };
+};
+
+export const describeThoughtTextPolicyIssue = ({
+  value,
+  line,
+  measure,
+  maxBytes,
+}: {
+  value: string;
+  line: ThoughtTextPolicyLine;
+  measure: ThoughtV2Measure;
+  maxBytes: number;
+}): ThoughtTextPolicyIssue | null => {
+  if (measure.errors.length === 0) return null;
+  const label = displayLine(line);
+
+  if (measure.byteLength > maxBytes) {
+    const percentage = Math.round((measure.byteLength / maxBytes) * 100);
+    return {
+      title: "text too long",
+      detail: `${label}: ${percentage}% used · ${measure.byteLength} / ${maxBytes} UTF-8 bytes`,
+      nextStep: editNextStep(line, `reduce ${line} to ${maxBytes} UTF-8 bytes or less`),
+    };
+  }
+
+  if (measure.errors.some((error) => /line is empty/.test(error))) {
+    return {
+      title: "text empty",
+      detail: `${label} contains 0 UTF-8 bytes`,
+      nextStep: editNextStep(line, `enter a ${line}`),
+    };
+  }
+
+  const startsWithSpace = value.startsWith(" ");
+  const endsWithSpace = value.endsWith(" ");
+  if (startsWithSpace || endsWithSpace) {
+    const title = startsWithSpace && endsWithSpace
+      ? "outer spaces"
+      : startsWithSpace
+        ? "leading space"
+        : "trailing space";
+    const detail = startsWithSpace && endsWithSpace
+      ? `${label} starts and ends with U+0020`
+      : startsWithSpace
+        ? `${label} starts with U+0020`
+        : `${label} ends with U+0020`;
+    const promptStep = startsWithSpace && endsWithSpace
+      ? "delete the outer spaces"
+      : startsWithSpace
+        ? "delete the first space"
+        : "delete the final space";
+    return {
+      title,
+      detail,
+      nextStep: editNextStep(line, promptStep),
+    };
+  }
+
+  if (measure.errors.some((error) => /invalid surrogate/.test(error))) {
+    const position = invalidSurrogatePosition(value);
+    const location = position ? ` at character ${position}` : "";
+    return {
+      title: "invalid character",
+      detail: `${label} contains an unpaired UTF-16 surrogate${location}`,
+      nextStep: editNextStep(line, `delete or replace the invalid character${location}`),
+    };
+  }
+
+  for (const error of measure.errors) {
+    const issue = issueForCodePoint(value, line, error);
+    if (issue) return issue;
+  }
+
+  return {
+    title: "text invalid",
+    detail: `${label}: ${measure.errors.join("; ")}`,
+    nextStep: editNextStep(line, `edit the ${line} to match THOUGHT V2 text rules`),
+  };
+};

--- a/apps/thought/src/thought-v2-local-deployment.ts
+++ b/apps/thought/src/thought-v2-local-deployment.ts
@@ -1,0 +1,57 @@
+export const THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY =
+  "local THOUGHT V2 deployment unavailable.";
+
+export const THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY =
+  "local THOUGHT V2 deployment mismatch.";
+
+export const isThoughtV2LocalDeploymentError = (message: string) =>
+  message === THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY ||
+  message === THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY;
+
+type VerifyThoughtV2LocalDeploymentOptions<Anchors> = {
+  contractAddresses: readonly string[];
+  readCode: (address: string) => Promise<string>;
+  readAnchors: () => Promise<Anchors>;
+  anchorsMatch: (anchors: Anchors) => boolean;
+};
+
+const hasContractCode = (code: string) => /^0x[0-9a-f]+$/i.test(code) && !/^0x0*$/i.test(code);
+
+export const verifyThoughtV2LocalDeployment = async <Anchors>({
+  contractAddresses,
+  readCode,
+  readAnchors,
+  anchorsMatch,
+}: VerifyThoughtV2LocalDeploymentOptions<Anchors>) => {
+  if (contractAddresses.length === 0) {
+    throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY);
+  }
+
+  let codes: string[];
+  try {
+    codes = await Promise.all(contractAddresses.map((address) => readCode(address)));
+  } catch {
+    throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY);
+  }
+
+  if (!codes.every(hasContractCode)) {
+    throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY);
+  }
+
+  let anchors: Anchors;
+  try {
+    anchors = await readAnchors();
+  } catch {
+    throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY);
+  }
+
+  let matches = false;
+  try {
+    matches = anchorsMatch(anchors);
+  } catch {
+    matches = false;
+  }
+  if (!matches) {
+    throw new Error(THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY);
+  }
+};

--- a/apps/thought/src/thought-v2-local-release.ts
+++ b/apps/thought/src/thought-v2-local-release.ts
@@ -23,8 +23,8 @@ export const THOUGHT_V2_LOCAL_RELEASE = {
   },
   chainId: 31337,
   protocol: {
-    protocolReleaseId: "0xcab9cb82294d90e90d60203b27195c4daa75ea365f3d9b249caf5cd4006d6673",
-    manifestKeccak256: "0xc46e1b3dbab5128bc4af98bc009dca3e45e6903c8263e0eb49cb5eb32fc16e0d",
+    protocolReleaseId: "0xea4493c669fc366e224e66a43233e1e97efecd18568ef494dfc31b4a3c961b65",
+    manifestKeccak256: "0x305f59465c93edf46e5ab0ca372b017f6cba5c98052e695ae6b9ca5778515d4b",
     creativeSpec: {
       id: "inshell.thought.v2",
       path: "THOUGHT.v2.md",
@@ -43,7 +43,7 @@ export const THOUGHT_V2_LOCAL_RELEASE = {
     rendererProfile: {
       id: "inshell.thought.svg.v2.binary-weave-32",
       path: "thought.renderer.v2.profile.json",
-      keccak256: "0xbce80f7dc9c4f4cf4c6bdda3df41647f9bf193d6352d594a182971e1e3045443",
+      keccak256: "0x6c124e260dcbfe801614b89da24bb31d407303e7cd93cc3e6a6ac372c862de88",
     },
   } satisfies ThoughtV2ProtocolBinding,
   spec: {
@@ -55,11 +55,11 @@ export const THOUGHT_V2_LOCAL_RELEASE = {
     byteLength: 2811,
   },
   contracts: {
-    pathNft: "0x8A93d247134d91e0de6f96547cB0204e5BE8e5D8",
-    thoughtNft: "0x6C2d83262fF84cBaDb3e416D527403135D757892",
-    thoughtSpecRegistry: "0x927b167526bAbB9be047421db732C663a0b77B11",
-    thoughtRenderer: "0x638A246F0Ec8883eF68280293FFE8Cfbabe61B44",
-    protocolRegistry: "0x01c1DeF3b91672704716159C9041Aeca392DdFfb",
+    pathNft: "0x2e8880cAdC08E9B438c6052F5ce3869FBd6cE513",
+    thoughtNft: "0xa779C1D17bC5230c07afdC51376CAC1cb3Dd5314",
+    thoughtSpecRegistry: "0x4DAf17c8142A483B2E2348f56ae0F2cFDAe22ceE",
+    thoughtRenderer: "0x618fB9dbd2BD6eb968B4c1af36af6CB0b45310Ec",
+    protocolRegistry: "0x24d41dbc3d60d0784f8a937c59FBDe51440D5140",
   },
 } as const;
 

--- a/apps/thought/src/works.ts
+++ b/apps/thought/src/works.ts
@@ -100,6 +100,18 @@ export type WorkStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 export const THOUGHT_WORKS_STORAGE_KEY = "thought-works";
 export const THOUGHT_WORKS_LIMIT = 80;
+export const THOUGHT_SAVED_WORK_PROMPT_MAX_CHARS = 42;
+
+export const formatSavedWorkPromptLabel = (
+  prompt: string,
+  maxChars = THOUGHT_SAVED_WORK_PROMPT_MAX_CHARS,
+) => {
+  const normalized = prompt.trim().replace(/\s+/g, " ") || "untitled prompt";
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+};
 
 const isWorkAgentEvidence = (value: unknown): value is ThoughtV2LocalAgentEvidence => {
   if (typeof value !== "object" || value === null) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "pnpm --filter @inshell/home test && pnpm run test:thought-runtime",
     "test:fast": "pnpm --filter @inshell/home test:fast",
     "test:presepolia": "pnpm --filter @inshell/home test:presepolia",
-    "test:thought-runtime": "node --import tsx scripts/test-thought-runtime.ts && node --import tsx scripts/test-thought-agent-client.ts",
+    "test:thought-runtime": "node --import tsx scripts/test-thought-runtime.ts && node --import tsx scripts/test-thought-agent-client.ts && node --test scripts/thought-panel-ui.test.mjs",
     "test:thought-agent-client": "node --import tsx scripts/test-thought-agent-client.ts",
     "test:thought-agent-client:live": "node --import tsx scripts/test-thought-agent-client-live.ts",
     "test:unit": "pnpm --filter @inshell/home test:unit",

--- a/packages/inshell-shell/src/index.tsx
+++ b/packages/inshell-shell/src/index.tsx
@@ -14,10 +14,12 @@ export type InshellTopBarProps = {
   expectedChainId?: number;
   compact?: boolean;
   disconnectedWalletNote?: string;
+  onWalletRefresh?: () => void | Promise<void>;
 };
 
 export type InshellWalletModalProps = {
   expectedChainId?: number;
+  onRefresh?: () => void | Promise<void>;
 };
 
 export type InshellWalletPickerProps = {
@@ -79,7 +81,7 @@ export function InshellWalletPicker({
   );
 }
 
-export function InshellWalletModal({ expectedChainId }: InshellWalletModalProps) {
+export function InshellWalletModal({ expectedChainId, onRefresh }: InshellWalletModalProps) {
   const {
     address,
     chain,
@@ -111,6 +113,7 @@ export function InshellWalletModal({ expectedChainId }: InshellWalletModalProps)
     setNotice("");
     try {
       await refreshWallet();
+      await onRefresh?.();
       setNotice("wallet refreshed.");
     } catch (error) {
       setNotice(String((error as any)?.message ?? "wallet refresh failed."));
@@ -211,6 +214,7 @@ export function InshellTopBar({
   expectedChainId,
   compact,
   disconnectedWalletNote,
+  onWalletRefresh,
 }: InshellTopBarProps) {
   const {
     address,
@@ -344,7 +348,7 @@ export function InshellTopBar({
           </button>
           {open ? (
             isConnected ? (
-              <InshellWalletModal expectedChainId={expectedChainId} />
+              <InshellWalletModal expectedChainId={expectedChainId} onRefresh={onWalletRefresh} />
             ) : connectors.length ? (
               <>
                 <InshellWalletPicker
@@ -354,7 +358,7 @@ export function InshellTopBar({
                 {notice ? <p className="inshell-wallet-picker__notice">{notice}</p> : null}
               </>
             ) : (
-              <InshellWalletModal expectedChainId={expectedChainId} />
+              <InshellWalletModal expectedChainId={expectedChainId} onRefresh={onWalletRefresh} />
             )
           ) : null}
         </div>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,22 @@
 export type SurfaceId = "path" | "thought";
 
 export {
+  PATH_MINT_RETURN_STORAGE_KEY_PREFIX,
+  PATH_MINT_RETURN_TTL_MS,
+  isPathMintHandoffId,
+  parsePathMintReturnRecord,
+  pathMintReturnStorageKey,
+  readPathMintReturnRecord,
+  removePathMintReturnRecord,
+  writePathMintReturnRecord,
+} from "./pathMintReturn";
+export type {
+  PathMintReturnRecord,
+  PathMintReturnStatus,
+  PathMintReturnStorageHost,
+} from "./pathMintReturn";
+
+export {
   installInshellAnonymousAnalytics,
   trackInshellAnonymousAnalytics,
 } from "./anonymousAnalytics";

--- a/packages/shared/src/pathMintReturn.ts
+++ b/packages/shared/src/pathMintReturn.ts
@@ -1,0 +1,228 @@
+export const PATH_MINT_RETURN_STORAGE_KEY_PREFIX =
+  "inshell:path-mint-return:v1:";
+export const PATH_MINT_RETURN_TTL_MS = 86_400_000;
+
+export type PathMintReturnStatus = "submitted" | "confirmed";
+
+export type PathMintReturnRecord = {
+  version: 1;
+  handoffId: string;
+  status: PathMintReturnStatus;
+  account: string;
+  chainId: number;
+  txHash: string;
+  tokenId?: string;
+  baselineTokenId?: number | null;
+  updatedAt: number;
+};
+
+type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+export type PathMintReturnStorageHost = {
+  localStorage?: StorageLike | null;
+  sessionStorage?: StorageLike | null;
+};
+
+const HANDOFF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,95}$/;
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const EVM_TRANSACTION_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+const TOKEN_ID_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+
+export function isPathMintHandoffId(value: unknown): value is string {
+  return typeof value === "string" && HANDOFF_ID_PATTERN.test(value);
+}
+
+export function pathMintReturnStorageKey(handoffId: string): string | null {
+  return isPathMintHandoffId(handoffId)
+    ? `${PATH_MINT_RETURN_STORAGE_KEY_PREFIX}${handoffId}`
+    : null;
+}
+
+function parseStoredValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function parsePathMintReturnRecord(
+  value: unknown,
+  expectedHandoffId?: string,
+): PathMintReturnRecord | null {
+  const parsed = parseStoredValue(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.version !== 1) return null;
+  if (!isPathMintHandoffId(candidate.handoffId)) return null;
+  if (
+    expectedHandoffId !== undefined &&
+    candidate.handoffId !== expectedHandoffId
+  ) {
+    return null;
+  }
+  if (candidate.status !== "submitted" && candidate.status !== "confirmed") {
+    return null;
+  }
+  if (
+    typeof candidate.account !== "string" ||
+    !EVM_ADDRESS_PATTERN.test(candidate.account)
+  ) {
+    return null;
+  }
+  if (
+    typeof candidate.chainId !== "number" ||
+    !Number.isSafeInteger(candidate.chainId) ||
+    candidate.chainId <= 0
+  ) {
+    return null;
+  }
+  if (
+    typeof candidate.txHash !== "string" ||
+    !EVM_TRANSACTION_HASH_PATTERN.test(candidate.txHash)
+  ) {
+    return null;
+  }
+  if (
+    candidate.tokenId !== undefined &&
+    (typeof candidate.tokenId !== "string" ||
+      !TOKEN_ID_PATTERN.test(candidate.tokenId))
+  ) {
+    return null;
+  }
+  if (
+    candidate.baselineTokenId !== undefined &&
+    candidate.baselineTokenId !== null &&
+    (typeof candidate.baselineTokenId !== "number" ||
+      !Number.isSafeInteger(candidate.baselineTokenId) ||
+      candidate.baselineTokenId < 0)
+  ) {
+    return null;
+  }
+  if (
+    typeof candidate.updatedAt !== "number" ||
+    !Number.isSafeInteger(candidate.updatedAt) ||
+    candidate.updatedAt <= 0 ||
+    (candidate.status === "confirmed" &&
+      Date.now() - candidate.updatedAt > PATH_MINT_RETURN_TTL_MS)
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    handoffId: candidate.handoffId,
+    status: candidate.status,
+    account: candidate.account.toLowerCase(),
+    chainId: candidate.chainId,
+    txHash: candidate.txHash.toLowerCase(),
+    ...(candidate.tokenId === undefined
+      ? {}
+      : { tokenId: candidate.tokenId as string }),
+    ...(candidate.baselineTokenId === undefined
+      ? {}
+      : { baselineTokenId: candidate.baselineTokenId as number | null }),
+    updatedAt: candidate.updatedAt,
+  };
+}
+
+function storageGet(storage: StorageLike | null | undefined, key: string): string | null {
+  try {
+    return storage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(
+  storage: StorageLike | null | undefined,
+  key: string,
+  value: string,
+): boolean {
+  try {
+    if (!storage) return false;
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function storageRemove(storage: StorageLike | null | undefined, key: string): void {
+  try {
+    storage?.removeItem(key);
+  } catch {
+    // Browser storage is an optimization; callers keep their in-memory state.
+  }
+}
+
+export function readPathMintReturnRecord(
+  host: PathMintReturnStorageHost,
+  handoffId: string,
+): PathMintReturnRecord | null {
+  const key = pathMintReturnStorageKey(handoffId);
+  if (!key) return null;
+
+  const localRecord = parsePathMintReturnRecord(
+    storageGet(host.localStorage, key),
+    handoffId,
+  );
+  const sessionRecord = parsePathMintReturnRecord(
+    storageGet(host.sessionStorage, key),
+    handoffId,
+  );
+  const record =
+    localRecord && sessionRecord
+      ? localRecord.updatedAt === sessionRecord.updatedAt
+        ? localRecord.status === "confirmed"
+          ? localRecord
+          : sessionRecord
+        : localRecord.updatedAt > sessionRecord.updatedAt
+          ? localRecord
+          : sessionRecord
+      : localRecord ?? sessionRecord;
+  if (!record) {
+    storageRemove(host.localStorage, key);
+    storageRemove(host.sessionStorage, key);
+    return null;
+  }
+
+  // Keep one freshest durable copy whenever local storage is writable.
+  if (storageSet(host.localStorage, key, JSON.stringify(record))) {
+    storageRemove(host.sessionStorage, key);
+  }
+  return record;
+}
+
+export function writePathMintReturnRecord(
+  host: PathMintReturnStorageHost,
+  value: PathMintReturnRecord,
+): boolean {
+  const record = parsePathMintReturnRecord(value, value.handoffId);
+  if (!record) return false;
+  const key = pathMintReturnStorageKey(record.handoffId);
+  if (!key) return false;
+  const serialized = JSON.stringify(record);
+
+  if (storageSet(host.localStorage, key, serialized)) {
+    storageRemove(host.sessionStorage, key);
+    return true;
+  }
+  return storageSet(host.sessionStorage, key, serialized);
+}
+
+export function removePathMintReturnRecord(
+  host: PathMintReturnStorageHost,
+  handoffId: string,
+): void {
+  const key = pathMintReturnStorageKey(handoffId);
+  if (!key) return;
+  storageRemove(host.localStorage, key);
+  storageRemove(host.sessionStorage, key);
+}

--- a/scripts/smoke-thought-v2-anvil.ts
+++ b/scripts/smoke-thought-v2-anvil.ts
@@ -93,7 +93,15 @@ const runSmoke = async () => {
 
   const latestBlock = await provider.getBlock("latest");
   assert(latestBlock, "latest Anvil block unavailable");
-  const deadline = BigInt(latestBlock.timestamp) + 3600n;
+  // A persistent Anvil node can sit idle long enough for its latest mined block
+  // to trail wall-clock time by more than the authorization TTL. Anvil advances
+  // the next block to wall-clock time, so a deadline based only on the stale
+  // head can already be expired by the time gas estimation runs.
+  const wallClockTimestamp = BigInt(Math.floor(Date.now() / 1000));
+  const authorizationBaseTimestamp = BigInt(latestBlock.timestamp) > wallClockTimestamp
+    ? BigInt(latestBlock.timestamp)
+    : wallClockTimestamp;
+  const deadline = authorizationBaseTimestamp + 3600n;
   const nonce = await pathNft.getConsumeNonce(minter);
   const consumeTypehash = id(
     "ConsumeAuthorization(address pathNft,uint256 chainId,uint256 pathId,bytes32 movement,address claimer,address executor,uint256 nonce,uint256 deadline)",

--- a/scripts/test-thought-runtime.ts
+++ b/scripts/test-thought-runtime.ts
@@ -30,6 +30,10 @@ import {
   THOUGHT_V2_MINT_UNAVAILABLE_COPY,
 } from "../apps/thought/src/thought-mint-ui";
 import { buildThoughtConsoleLines } from "../apps/thought/src/thought-console";
+import { runThoughtConsoleTests } from "../apps/thought/src/thought-console.test";
+import { runThoughtMintPresentationTests } from "../apps/thought/src/thought-mint-presentation.test";
+import { runThoughtMintTransactionTests } from "../apps/thought/src/thought-mint-transaction.test";
+import { runThoughtMintSubmissionLockTests } from "../apps/thought/src/thought-mint-submission-lock.test";
 import { sanitizeWorkRecord } from "../apps/thought/src/works";
 import {
   canonicalThoughtTitle,
@@ -616,9 +620,8 @@ assert.deepEqual(
   [
     "[21:50:02] mint error",
     THOUGHT_V2_MINT_UNAVAILABLE_COPY,
-    "next: retry / reset",
   ],
-  "console must reduce mint failures to status, useful detail, and next actions",
+  "console must retain the outcome without projecting live controls",
 );
 
 assert.deepEqual(
@@ -631,7 +634,6 @@ assert.deepEqual(
   [
     "[09:10:11] work ready",
     "connect wallet to mint",
-    "next: mint / reset",
   ],
   "console must keep work-ready guidance concise",
 );
@@ -658,6 +660,11 @@ assert.deepEqual(
   ["[09:10:13] minted"],
   "console must not repeat a detail that matches its title",
 );
+
+runThoughtConsoleTests();
+runThoughtMintPresentationTests();
+runThoughtMintTransactionTests();
+await runThoughtMintSubmissionLockTests();
 
 assert.equal(
   buildThoughtRuntimePrompt("make it quiet"),

--- a/scripts/test-thought-runtime.ts
+++ b/scripts/test-thought-runtime.ts
@@ -24,6 +24,7 @@ import {
 } from "../apps/thought/src/thought-preview-policy";
 import { createThoughtPollWakeScheduler } from "../apps/thought/src/thought-poll-wake";
 import {
+  formatThoughtAuthorizationError,
   getThoughtWorkReadyPresentation,
   THOUGHT_PANEL_MINT_UI_MODE,
   THOUGHT_V2_MINT_UNAVAILABLE_COPY,
@@ -414,6 +415,112 @@ assert.deepEqual(
     detail: "connect wallet to mint",
   },
   "work-ready UI may request a wallet only when minting is enabled and none is connected",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    { code: 4001, message: "User rejected the request." },
+    "signature",
+  ),
+  { message: "signature rejected in wallet.", kind: "signature" },
+  "only a confirmed wallet rejection may use rejected copy",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    {
+      code: "ACTION_REJECTED",
+      shortMessage: "user rejected action",
+      info: { error: { code: 4001, message: "User denied message signature" } },
+    },
+    "signature",
+  ),
+  { message: "signature rejected in wallet.", kind: "signature" },
+  "nested ethers wallet rejections must stay recognizable",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    { code: -32002, message: "Request already pending" },
+    "signature",
+  ),
+  { message: "signature request already pending in wallet.", kind: "signature" },
+  "a pending wallet request must not be presented as rejected",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(new Error("could not decode result data"), "nonce"),
+  { message: "PATH authorization unavailable.", kind: "signature" },
+  "a nonce RPC failure must not be presented as a wallet rejection",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    { code: "NETWORK_ERROR", shortMessage: "network changed" },
+    "nonce",
+  ),
+  { message: "PATH authorization unavailable.", kind: "signature" },
+  "a PATH RPC network failure must not blame the signing wallet",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    { code: -32600, message: "request rejected by RPC" },
+    "nonce",
+  ),
+  { message: "PATH authorization unavailable.", kind: "signature" },
+  "an RPC-level request rejection must not be presented as a user rejection",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    { code: "NETWORK_ERROR", shortMessage: "network changed" },
+    "wallet",
+  ),
+  { message: "wrong network.", kind: "wrong_network" },
+  "wallet network changes need the existing network recovery flow",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError({}, "signature"),
+  { message: "authorization failed.", kind: "signature" },
+  "unknown authorization failures must never claim the wallet rejected them",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(new Error("spec mismatch."), "preparing"),
+  { message: "spec mismatch.", kind: "spec" },
+  "spec errors must retain their concise actionable copy",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    new Error("mint blocked. provenance too large. 9000 / 8192 bytes."),
+    "preparing",
+  ),
+  {
+    message: "mint blocked. provenance too large. 9000 / 8192 bytes.",
+    kind: "thought",
+  },
+  "provenance size errors must retain their measured copy",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    new Error("provenance is 20001/20000 bytes"),
+    "preparing",
+  ),
+  { message: "provenance is 20001/20000 bytes", kind: "thought" },
+  "the local V2 provenance limit wording must remain visible",
+);
+
+assert.deepEqual(
+  formatThoughtAuthorizationError(
+    new Error("THOUGHT.md request timed out."),
+    "preparing",
+  ),
+  { message: "THOUGHT.md request timed out.", kind: "spec" },
+  "THOUGHT.md failures must retain the spec recovery path",
 );
 
 assert.deepEqual(

--- a/scripts/test-thought-runtime.ts
+++ b/scripts/test-thought-runtime.ts
@@ -47,6 +47,12 @@ import {
   type ThoughtV2LocalRuntimeFacts,
 } from "../apps/thought/src/thought-v2-local-release";
 import {
+  THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY,
+  THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY,
+  isThoughtV2LocalDeploymentError,
+  verifyThoughtV2LocalDeployment,
+} from "../apps/thought/src/thought-v2-local-deployment";
+import {
   THOUGHT_V2_LOCAL_AGENT_OUTPUT_SCHEMA,
   buildThoughtV2LocalAgentProcess,
   buildThoughtV2LocalAgentResult,
@@ -321,6 +327,83 @@ assert.equal(isThoughtV2LocalMintRuntime({
   ...localRuntimeFacts,
   protocolReleaseId: `0x${"00".repeat(32)}`,
 }), false);
+
+let localDeploymentAnchorReads = 0;
+const verifyLocalDeployment = (codes: readonly string[], anchorsMatch = true) =>
+  verifyThoughtV2LocalDeployment({
+    contractAddresses: codes.map((_, index) => `contract-${index}`),
+    readCode: async (address) => codes[Number(address.split("-")[1])],
+    readAnchors: async () => {
+      localDeploymentAnchorReads += 1;
+      return { anchorsMatch };
+    },
+    anchorsMatch: (anchors) => anchors.anchorsMatch,
+  });
+
+await assert.rejects(
+  verifyThoughtV2LocalDeployment({
+    contractAddresses: [],
+    readCode: async () => "0x1234",
+    readAnchors: async () => ({ anchorsMatch: true }),
+    anchorsMatch: (anchors) => anchors.anchorsMatch,
+  }),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY.replaceAll(".", "\\.")),
+);
+
+await assert.rejects(
+  verifyThoughtV2LocalDeployment({
+    contractAddresses: ["contract-0"],
+    readCode: async () => {
+      throw new Error("RPC unavailable");
+    },
+    readAnchors: async () => ({ anchorsMatch: true }),
+    anchorsMatch: (anchors) => anchors.anchorsMatch,
+  }),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY.replaceAll(".", "\\.")),
+  "code-read failures must become stable deployment-unavailable copy",
+);
+
+localDeploymentAnchorReads = 0;
+await assert.rejects(
+  verifyLocalDeployment(["0x1234", "0x"]),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY.replaceAll(".", "\\.")),
+);
+assert.equal(
+  localDeploymentAnchorReads,
+  0,
+  "local deployment ABI reads must not run when any contract has no bytecode",
+);
+
+localDeploymentAnchorReads = 0;
+await assert.rejects(
+  verifyThoughtV2LocalDeployment({
+    contractAddresses: ["contract-0"],
+    readCode: async () => "0x1234",
+    readAnchors: async () => {
+      localDeploymentAnchorReads += 1;
+      throw new Error('could not decode result data (method="thoughtRenderer")');
+    },
+    anchorsMatch: () => true,
+  }),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY.replaceAll(".", "\\.")),
+  "ABI decode failures must become stable deployment-unavailable copy",
+);
+assert.equal(localDeploymentAnchorReads, 1);
+
+await assert.rejects(
+  verifyLocalDeployment(["0x1234"], false),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY.replaceAll(".", "\\.")),
+);
+
+await verifyLocalDeployment(["0x1234"]);
+await assert.rejects(
+  verifyLocalDeployment(["0x"]),
+  new RegExp(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY.replaceAll(".", "\\.")),
+  "a later local-node reset must be detected after an earlier successful verification",
+);
+assert.equal(isThoughtV2LocalDeploymentError(THOUGHT_V2_LOCAL_DEPLOYMENT_UNAVAILABLE_COPY), true);
+assert.equal(isThoughtV2LocalDeploymentError(THOUGHT_V2_LOCAL_DEPLOYMENT_MISMATCH_COPY), true);
+assert.equal(isThoughtV2LocalDeploymentError("path list unavailable."), false);
 assert.equal(
   THOUGHT_V2_PROTOCOL_RELEASE.deployment.v2MintEnabled,
   false,

--- a/scripts/test-thought-runtime.ts
+++ b/scripts/test-thought-runtime.ts
@@ -18,9 +18,11 @@ import {
   measureThoughtLine,
 } from "../packages/thought-agent-protocol/src/index";
 import {
+  formatThoughtByteLimitUsage,
   normalizePreviewMode,
   prevalidateThoughtCandidate,
   previewUnavailableCliLines,
+  thoughtByteLimitPercentage,
 } from "../apps/thought/src/thought-preview-policy";
 import { createThoughtPollWakeScheduler } from "../apps/thought/src/thought-poll-wake";
 import {
@@ -32,9 +34,13 @@ import {
 import { buildThoughtConsoleLines } from "../apps/thought/src/thought-console";
 import { runThoughtConsoleTests } from "../apps/thought/src/thought-console.test";
 import { runThoughtMintPresentationTests } from "../apps/thought/src/thought-mint-presentation.test";
+import { runThoughtPathAcquisitionTests } from "../apps/thought/src/thought-path-acquisition.test";
 import { runThoughtMintTransactionTests } from "../apps/thought/src/thought-mint-transaction.test";
 import { runThoughtMintSubmissionLockTests } from "../apps/thought/src/thought-mint-submission-lock.test";
-import { sanitizeWorkRecord } from "../apps/thought/src/works";
+import {
+  formatSavedWorkPromptLabel,
+  sanitizeWorkRecord,
+} from "../apps/thought/src/works";
 import {
   canonicalThoughtTitle,
   thoughtProtocolText,
@@ -63,11 +69,16 @@ import {
   parseThoughtV2LocalAgentResult,
 } from "../apps/thought/src/thought-v2-local-agent";
 import {
+  buildThoughtAgentFixtureLine,
+  shouldUseThoughtAgentFixture,
+} from "../apps/thought/src/thought-agent-fixture";
+import {
   THOUGHT_V2_ARTIFACT,
   THOUGHT_V2_RENDER_CONTRACT,
   buildThoughtV2Svg,
   measureThoughtV2Line,
 } from "../apps/thought/src/thought-v2-renderer";
+import { describeThoughtTextPolicyIssue } from "../apps/thought/src/thought-text-policy";
 import {
   JSON_RPC_NO_BATCH_OPTIONS,
   createSingleRequestJsonRpcProvider,
@@ -142,6 +153,38 @@ const localAgentEvidence = {
   adapter: "codex",
   rawResponseSha256: "a".repeat(64),
 };
+assert.equal(
+  shouldUseThoughtAgentFixture({ dev: true, hostname: "127.0.0.1", search: "" }),
+  true,
+  "local dev defaults to the fast Agent fixture path",
+);
+assert.equal(
+  shouldUseThoughtAgentFixture({ dev: true, hostname: "localhost", search: "?agent=live" }),
+  false,
+  "the operator can explicitly restore the live Agent path",
+);
+assert.equal(
+  shouldUseThoughtAgentFixture({ dev: false, hostname: "127.0.0.1", search: "?agent=fixture" }),
+  false,
+  "production builds cannot enable Agent fixtures",
+);
+assert.equal(
+  shouldUseThoughtAgentFixture({ dev: true, hostname: "preview.inshell.art", search: "?agent=fixture" }),
+  false,
+  "non-local deployments cannot enable Agent fixtures",
+);
+assert.equal(
+  buildThoughtAgentFixtureLine("claude", "fixture-nonce"),
+  "fixture claude fixture-nonce",
+);
+assert.equal(
+  formatSavedWorkPromptLabel("  a prompt   with spaces  "),
+  "a prompt with spaces",
+);
+assert.equal(
+  formatSavedWorkPromptLabel("abcdefghijklmnopqrstuvwxyz", 12),
+  "abcdefghi...",
+);
 const storedCodexWork = sanitizeWorkRecord({
   id: 1,
   title: declaredLocalAgentEnvelope.agentLine,
@@ -478,7 +521,7 @@ assert.equal(
 );
 
 assert.deepEqual(
-  getThoughtWorkReadyPresentation({ mintEnabled: false, walletConnected: true }),
+  getThoughtWorkReadyPresentation({ mintEnabled: false }),
   {
     canMint: false,
     detail: THOUGHT_V2_MINT_UNAVAILABLE_COPY,
@@ -487,21 +530,12 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
-  getThoughtWorkReadyPresentation({ mintEnabled: true, walletConnected: true }),
+  getThoughtWorkReadyPresentation({ mintEnabled: true }),
   {
     canMint: true,
     detail: "ready to mint",
   },
-  "work-ready UI must recognize an already connected wallet",
-);
-
-assert.deepEqual(
-  getThoughtWorkReadyPresentation({ mintEnabled: true, walletConnected: false }),
-  {
-    canMint: true,
-    detail: "connect wallet to mint",
-  },
-  "work-ready UI may request a wallet only when minting is enabled and none is connected",
+  "work-ready UI must stay independent from wallet state",
 );
 
 assert.deepEqual(
@@ -537,7 +571,7 @@ assert.deepEqual(
 
 assert.deepEqual(
   formatThoughtAuthorizationError(new Error("could not decode result data"), "nonce"),
-  { message: "PATH authorization unavailable.", kind: "signature" },
+  { message: "$PATH signature unavailable.", kind: "signature" },
   "a nonce RPC failure must not be presented as a wallet rejection",
 );
 
@@ -546,7 +580,7 @@ assert.deepEqual(
     { code: "NETWORK_ERROR", shortMessage: "network changed" },
     "nonce",
   ),
-  { message: "PATH authorization unavailable.", kind: "signature" },
+  { message: "$PATH signature unavailable.", kind: "signature" },
   "a PATH RPC network failure must not blame the signing wallet",
 );
 
@@ -555,7 +589,7 @@ assert.deepEqual(
     { code: -32600, message: "request rejected by RPC" },
     "nonce",
   ),
-  { message: "PATH authorization unavailable.", kind: "signature" },
+  { message: "$PATH signature unavailable.", kind: "signature" },
   "an RPC-level request rejection must not be presented as a user rejection",
 );
 
@@ -570,8 +604,8 @@ assert.deepEqual(
 
 assert.deepEqual(
   formatThoughtAuthorizationError({}, "signature"),
-  { message: "authorization failed.", kind: "signature" },
-  "unknown authorization failures must never claim the wallet rejected them",
+  { message: "signature failed.", kind: "signature" },
+  "unknown signature failures must never claim the wallet rejected them",
 );
 
 assert.deepEqual(
@@ -628,12 +662,12 @@ assert.deepEqual(
   buildThoughtConsoleLines({
     time: "09:10:11",
     title: "work ready",
-    detail: "connect wallet to mint",
+    detail: "ready to mint",
     actions: ["mint", "reset"],
   }),
   [
     "[09:10:11] work ready",
-    "connect wallet to mint",
+    "ready to mint",
   ],
   "console must keep work-ready guidance concise",
 );
@@ -654,15 +688,31 @@ assert.deepEqual(
 assert.deepEqual(
   buildThoughtConsoleLines({
     time: "09:10:13",
+    title: "text too long",
+    detail: "prompt: 120% used · 77 / 64 UTF-8 bytes",
+    nextStep: "reduce prompt to 64 UTF-8 bytes or less",
+  }),
+  [
+    "[09:10:13] text too long",
+    "prompt: 120% used · 77 / 64 UTF-8 bytes",
+    "next: reduce prompt to 64 UTF-8 bytes or less",
+  ],
+  "console warnings must include one concise suggested next step",
+);
+
+assert.deepEqual(
+  buildThoughtConsoleLines({
+    time: "09:10:14",
     title: "minted",
     detail: "Minted",
   }),
-  ["[09:10:13] minted"],
+  ["[09:10:14] minted"],
   "console must not repeat a detail that matches its title",
 );
 
 runThoughtConsoleTests();
 runThoughtMintPresentationTests();
+await runThoughtPathAcquisitionTests();
 runThoughtMintTransactionTests();
 await runThoughtMintSubmissionLockTests();
 
@@ -877,6 +927,14 @@ const validCandidate = prevalidateThoughtCandidate("quiet green sky", {
 });
 assert.equal(validCandidate.ok, true);
 assert.equal(validCandidate.canonical, "QUIET GREEN SKY");
+assert.equal(
+  thoughtByteLimitPercentage({ line: "agent output", usedBytes: 77, maxBytes: 64 }),
+  120,
+);
+assert.equal(
+  formatThoughtByteLimitUsage({ line: "agent output", usedBytes: 77, maxBytes: 64 }),
+  "Agent output: 120% used · 77 / 64 UTF-8 bytes",
+);
 
 for (const [label, raw, reasonCode] of [
   ["blank", "  ", 1],
@@ -953,5 +1011,55 @@ assert(!carouselThoughtV2Svg.includes("<animateTransform"));
 assert.deepEqual(measureThoughtV2Line("Bad prompt 你好", "prompt").errors, []);
 assert.deepEqual(measureThoughtV2Line("bad Agent مرحبا", "agent").errors, []);
 assert.deepEqual(measureThoughtV2Line("double  space", "prompt").errors, []);
+
+assert.deepEqual(
+  describeThoughtTextPolicyIssue({
+    value: "keep exact bytes ",
+    line: "prompt",
+    measure: measureThoughtV2Line("keep exact bytes ", "prompt"),
+    maxBytes: 64,
+  }),
+  {
+    title: "trailing space",
+    detail: "prompt ends with U+0020",
+    nextStep: "delete the final space",
+  },
+);
+assert.deepEqual(
+  describeThoughtTextPolicyIssue({
+    value: "zero\u200Bwidth",
+    line: "prompt",
+    measure: measureThoughtV2Line("zero\u200Bwidth", "prompt"),
+    maxBytes: 64,
+  }),
+  {
+    title: "invisible character",
+    detail: "prompt contains zero-width space U+200B at character 5",
+    nextStep: "delete U+200B at character 5",
+  },
+);
+assert.deepEqual(
+  describeThoughtTextPolicyIssue({
+    value: "Agent answer ",
+    line: "agent output",
+    measure: measureThoughtV2Line("Agent answer ", "agent"),
+    maxBytes: 64,
+  }),
+  {
+    title: "trailing space",
+    detail: "Agent output ends with U+0020",
+    nextStep: "reset and run the Agent again; output is never auto-corrected",
+  },
+);
+assert.equal(
+  describeThoughtTextPolicyIssue({
+    value: "double  space",
+    line: "prompt",
+    measure: measureThoughtV2Line("double  space", "prompt"),
+    maxBytes: 64,
+  }),
+  null,
+  "valid internal spaces must remain byte-identical",
+);
 
 console.log("[test-thought-runtime] OK");

--- a/scripts/thought-panel-ui.test.mjs
+++ b/scripts/thought-panel-ui.test.mjs
@@ -5,29 +5,123 @@ import test from "node:test";
 const indexHtml = await readFile(new URL("../apps/thought/index.html", import.meta.url), "utf8");
 const thoughtCss = await readFile(new URL("../apps/thought/src/style.css", import.meta.url), "utf8");
 const thoughtMain = await readFile(new URL("../apps/thought/src/main.ts", import.meta.url), "utf8");
+const thoughtConsole = await readFile(
+  new URL("../apps/thought/src/thought-console.ts", import.meta.url),
+  "utf8",
+);
+const thoughtMintPresentation = await readFile(
+  new URL("../apps/thought/src/thought-mint-presentation.ts", import.meta.url),
+  "utf8",
+);
+const thoughtTextPolicy = await readFile(
+  new URL("../apps/thought/src/thought-text-policy.ts", import.meta.url),
+  "utf8",
+);
+const thoughtShell = await readFile(
+  new URL("../apps/thought/src/thought-shell.tsx", import.meta.url),
+  "utf8",
+);
+const inshellShell = await readFile(
+  new URL("../packages/inshell-shell/src/index.tsx", import.meta.url),
+  "utf8",
+);
 
 const ruleBody = (selector) => {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = thoughtCss.match(new RegExp(`${escapedSelector}\\s*\\{([^}]+)\\}`));
+  const match = thoughtCss.match(new RegExp(`(?:^|\\n)${escapedSelector}\\s*\\{([^}]+)\\}`));
   assert.ok(match, `missing CSS rule: ${selector}`);
   return match[1];
 };
 
-test("mint panel presents wallet context before controls", () => {
-  const promptIndex = indexHtml.indexOf('id="thought-dock"');
-  const walletIndex = indexHtml.indexOf('id="thought-wallet-strip"');
+test("Work owns prompt and CTAs before sibling Mint and Save/Load panels", () => {
+  const workIndex = indexHtml.indexOf('id="thought-dock"');
+  const promptIndex = indexHtml.indexOf('id="thought-dock-prompt"');
   const actionIndex = indexHtml.indexOf('id="thought-dock-action-area"');
-  const pathIndex = indexHtml.indexOf('id="thought-dock-path"');
+  const mintIndex = indexHtml.indexOf('id="thought-dock-path"');
+  const worksIndex = indexHtml.indexOf('id="thought-dock-works"');
+  const consoleIndex = indexHtml.indexOf('id="thought-dock-details"');
 
-  assert.ok(promptIndex >= 0, "prompt composer is present");
-  assert.ok(walletIndex > promptIndex, "wallet context follows the work prompt");
-  assert.ok(actionIndex > walletIndex, "wallet context precedes current actions");
-  assert.ok(pathIndex > walletIndex, "wallet context precedes the mint stage");
-  assert.match(indexHtml, /id="thought-wallet-strip"[\s\S]*?aria-label="Mint wallet context"/);
+  assert.ok(workIndex >= 0, "Work panel is present");
+  assert.ok(promptIndex > workIndex, "Work contains the prompt");
+  assert.ok(actionIndex > promptIndex, "Work actions follow the prompt");
+  assert.ok(mintIndex > actionIndex, "Mint follows Work");
+  assert.ok(worksIndex > mintIndex, "Save/Load is a sibling after Mint");
+  assert.ok(consoleIndex > worksIndex, "Console follows the control panels");
+  assert.match(indexHtml, /id="thought-dock" class="thought-dock" aria-label="THOUGHT work"/);
+  assert.match(indexHtml, /id="thought-dock-action-area"[\s\S]*?aria-label="THOUGHT work actions"/);
+  assert.match(indexHtml, /id="thought-dock-path"\s+class="thought-dock-path thought-path-panel is-hidden"/);
+  assert.match(indexHtml, /id="thought-dock-works"\s+class="thought-dock-works is-hidden"/);
+  assert.match(indexHtml, /id="thought-dock-works-select"[\s\S]*?aria-labelledby="thought-dock-works-label"/);
+  assert.match(indexHtml, /id="thought-dock-details"[\s\S]*?aria-label="THOUGHT console"/);
+  assert.doesNotMatch(indexHtml, /thought-wallet-strip|Mint wallet context/);
+  assert.doesNotMatch(thoughtCss, /\.thought-wallet-strip/);
+  assert.doesNotMatch(thoughtMain, /thoughtWalletStrip|WalletStripView/);
 });
 
-test("dock and compatibility sheet share the PATH SIGN MINT spine", () => {
-  const expectedSteps = /<ol[^>]+aria-label="THOUGHT mint progress"[^>]*>\s*<li data-step="select">PATH<\/li>\s*<li data-step="authorize">SIGN<\/li>\s*<li data-step="confirm">MINT<\/li>\s*<\/ol>/g;
+test("desktop panel stack shares the canvas top and bottom edges", () => {
+  assert.match(thoughtCss, /--thought-panel-row-alignment:\s*center/);
+  assert.match(
+    ruleBody(".thought-panel"),
+    /align-self:\s*var\(--thought-panel-row-alignment\)/,
+  );
+  assert.match(
+    thoughtCss,
+    /@media \(max-width: 900px\)[\s\S]*?--thought-panel-row-alignment:\s*stretch/,
+  );
+});
+
+test("Save/Load uses prompt-labelled one-line options and loads the selected canvas work", () => {
+  assert.match(indexHtml, /aria-label="THOUGHT load a saved work"/);
+  assert.match(thoughtMain, /thoughtDockWorksLabel\.textContent = "load a saved work"/);
+  assert.match(thoughtMain, /placeholder\.textContent = works\.length \? "load a saved work" : "no saved works"/);
+  assert.doesNotMatch(thoughtMain, /"select a saved work"/);
+  assert.doesNotMatch(thoughtMain, /thoughtDockWorksLabel\.textContent = `saved works/);
+  assert.match(
+    thoughtMain,
+    /kind: "work_library_opened",\s*title: "load a saved work",\s*detail: "Saved works use this browser's local storage\. They are not on-chain or synced across browsers or devices\."/,
+  );
+  assert.match(indexHtml, /id="thought-dock-works"[\s\S]*?class="thought-dock-select-wrap"[\s\S]*?class="thought-dock-select-arrow"/);
+  const worksBody = ruleBody(".thought-dock-works");
+  const selectBody = ruleBody(".thought-dock-select");
+  const selectArrowBody = ruleBody(".thought-dock-select-arrow");
+  const selectArrowGlyphBody = ruleBody(".thought-dock-select-arrow::before");
+  assert.match(worksBody, /padding:\s*var\(--thought-panel-section-padding\)/);
+  assert.match(worksBody, /border:\s*0/);
+  assert.match(worksBody, /background:\s*var\(--panel\)/);
+  assert.match(selectBody, /overflow:\s*hidden/);
+  assert.match(selectBody, /text-overflow:\s*ellipsis/);
+  assert.match(selectBody, /white-space:\s*nowrap/);
+  assert.match(selectBody, /appearance:\s*none/);
+  assert.match(selectArrowBody, /inset-inline-end:\s*var\(--thought-mint-hairline-width\)/);
+  assert.match(selectArrowBody, /pointer-events:\s*none/);
+  assert.match(selectArrowGlyphBody, /width:\s*calc\(var\(--font-size-12\) \/ 2\)/);
+  assert.match(selectArrowGlyphBody, /height:\s*calc\(var\(--font-size-12\) \/ 2\)/);
+  assert.match(thoughtMain, /option\.textContent = formatSavedWorkPromptLabel\(work\.prompt \|\| work\.runContext\.prompt\)/);
+  assert.match(thoughtMain, /thoughtDockWorksSelect\.addEventListener\("change"[\s\S]*?loadWorkRecord\(work\)/);
+  assert.match(thoughtMain, /const loadWorkRecord =[\s\S]*?syncCurrentWorkVisual\(\{ suppressWarning: true \}\)/);
+  const saveStart = thoughtMain.indexOf("const saveCurrentWorkFromDock =");
+  const saveEnd = thoughtMain.indexOf("const loadWorkRecord =", saveStart);
+  const saveBody = thoughtMain.slice(saveStart, saveEnd);
+  assert.doesNotMatch(saveBody, /workLibraryRevealed|mintDockRevealed/);
+});
+
+test("THOUGHT panel copy uses canonical product terms", () => {
+  const productCopy = [indexHtml, thoughtMain, thoughtMintPresentation].join("\n");
+  assert.doesNotMatch(productCopy, /load a work/);
+  assert.doesNotMatch(productCopy, /\$PATHs/);
+  assert.doesNotMatch(productCopy, /THOUGHT (?:mint )?unit/);
+  assert.doesNotMatch(productCopy, /["'`][^"'`\n]*\bonchain\b[^"'`\n]*["'`]/);
+  assert.match(productCopy, /load a saved work/);
+  assert.match(productCopy, /THOUGHT mint available/);
+  assert.match(productCopy, /on-chain/);
+  assert.doesNotMatch(productCopy, /choose an agent\.|agent result schema invalid\.|agent request (?:timed out|failed)\./);
+  assert.match(productCopy, /choose an Agent\.|Agent result schema invalid\.|Agent request (?:timed out|failed)\./);
+  assert.doesNotMatch(productCopy, /agent output:/);
+  assert.match(productCopy, /Agent output:/);
+});
+
+test("dock and compatibility sheet share the PICK SIGN MINT spine", () => {
+  const expectedSteps = /<ol[^>]+aria-label="THOUGHT mint progress"[^>]*>\s*<li data-step="select">PICK<\/li>\s*<li data-step="authorize">SIGN<\/li>\s*<li data-step="confirm">MINT<\/li>\s*<\/ol>/g;
   assert.equal([...indexHtml.matchAll(expectedSteps)].length, 2);
 
   const dockFlowIndex = indexHtml.indexOf('id="thought-dock-path-flow"');
@@ -37,6 +131,45 @@ test("dock and compatibility sheet share the PATH SIGN MINT spine", () => {
 
   assert.ok(dockFlowIndex < inventoryIndex, "dock progress precedes its active PATH stage");
   assert.ok(sheetFlowIndex < sheetFieldIndex, "sheet progress precedes its active PATH stage");
+  assert.match(thoughtMintPresentation, /title: inventory\.available === 1 \? "one \$PATH is ready" : "pick a \$PATH"/);
+  assert.match(thoughtMintPresentation, /stageCopy: "Pick another \$PATH, or refresh wallet from the shell bar\."/);
+  assert.match(thoughtMain, /placeholder\.textContent = "pick a \$PATH"/);
+  assert.match(thoughtMain, /return "pick another \$PATH or refresh wallet from the shell bar"/);
+  assert.match(thoughtConsole, /\$PATH pick and permission cleared/);
+  assert.doesNotMatch(thoughtMintPresentation, /(?<!\$)\bPATHs?\b/);
+  assert.doesNotMatch(thoughtMain, /(?:select|choose) \$PATH \/ authorize \/ confirm\./i);
+});
+
+test("shell-bar refresh is the only manual wallet and $PATH inventory refresh control", () => {
+  assert.doesNotMatch(thoughtMintPresentation, /action\("refresh"/);
+  assert.doesNotMatch(thoughtMain, /mintSheetAction\("refresh"|action === "refresh"|refreshMintSheetPath/);
+  assert.doesNotMatch(thoughtMintPresentation, /Recheck/i);
+  assert.match(inshellShell, /await refreshWallet\(\);\s*await onRefresh\?\.\(\);/);
+  assert.match(thoughtShell, /onWalletRefresh=\{onWalletRefresh\}/);
+  assert.match(thoughtMain, /mountThoughtShell\(thoughtShellRoot, THOUGHT_CHAIN_ID, \(\) => refreshThoughtWalletFromShell\(\)\)/);
+  assert.match(
+    thoughtMain,
+    /async function refreshThoughtWalletFromShell\(\)[\s\S]*?refreshPathInventoryForCurrentWallet\(\{ force: true \}\)/,
+  );
+});
+
+test("Console preserves shell-refresh notices after mint-panel Recheck removal", () => {
+  assert.match(
+    thoughtMintPresentation,
+    /consoleNextStep\?: string/,
+  );
+  assert.match(
+    thoughtMintPresentation,
+    /title: "\$PATH inventory unavailable"[\s\S]*?consoleNextStep: "refresh wallet from the shell bar"/,
+  );
+  assert.match(
+    thoughtMintPresentation,
+    /title: "\$PATH mint confirming"[\s\S]*?consoleNextStep: "refresh wallet from the shell bar"/,
+  );
+  assert.match(
+    thoughtMain,
+    /presentation\.consoleNextStep \|\| presentation\.tone === "warning"[\s\S]*?nextStep: presentationNextStep/,
+  );
 });
 
 test("integrated mint stage has one atomic announcement and a stable region name", () => {
@@ -46,7 +179,7 @@ test("integrated mint stage has one atomic announcement and a stable region name
   );
   assert.match(
     indexHtml,
-    /class="thought-mint-step" role="status" aria-live="polite" aria-atomic="true"/,
+    /class="thought-mint-step is-hidden"\s+role="status"\s+aria-live="polite"\s+aria-atomic="true"/,
   );
   assert.doesNotMatch(
     indexHtml,
@@ -58,15 +191,28 @@ test("integrated mint stage has one atomic announcement and a stable region name
   );
 });
 
-test("SIGN and MINT review stays compact behind a native disclosure", () => {
+test("Mint keeps stable status and actions while prose stays in Console", () => {
+  assert.match(indexHtml, /id="thought-dock-path-title" class="thought-mint-step__title"/);
+  assert.doesNotMatch(indexHtml, /thought-dock-path-detail|thought-dock-path-status|thought-dock-path-review|thought-dock-path-provenance/);
+  assert.match(thoughtMain, /presentation\.tone === "running"[\s\S]*?appendThoughtProgressEllipsis\(thoughtDockPathTitle/);
+  assert.doesNotMatch(thoughtMain, /thoughtDockPathDetail|syncMintDockReview|getMintDockPathStatusCopy/);
+  assert.match(thoughtMain, /const base = \{[\s\S]*?detail: presentation\.detail/);
+  assert.match(thoughtMain, /thoughtDockPathTitle\.dataset\.tone = presentation\.tone/);
   assert.match(
-    indexHtml,
-    /<details id="thought-dock-path-review"[^>]*>[\s\S]*?<summary id="thought-dock-path-review-summary">review wallet request<\/summary>/,
+    thoughtCss,
+    /\.thought-mint-step__title\[data-tone="warning"\][\s\S]*?color:\s*var\(--thought-panel-secondary-text\)/,
   );
-  assert.match(thoughtMain, /const syncMintDockReview = \(\) =>/);
-  assert.match(thoughtMain, /review signature request · 1 of 2/);
-  assert.match(thoughtMain, /review mint transaction · 2 of 2/);
-  assert.match(thoughtMain, /thoughtDockPathReview\.open = false/);
+  assert.match(
+    ruleBody('.thought-mint-step__title[data-tone="error"]'),
+    /color:\s*var\(--thought-panel-error-text\)/,
+  );
+});
+
+test("THOUGHT mint requirement explains the $PATH permission model", () => {
+  assert.match(
+    thoughtMain,
+    /1 THOUGHT requires 1 available \$PATH\. \$PATH is the permission token for Inshell’s three fully on-chain movements for Agent Art\./,
+  );
 });
 
 test("mint progress and active stage have compact component styling", () => {
@@ -77,56 +223,363 @@ test("mint progress and active stage have compact component styling", () => {
     assert.match(body, /gap:\s*var\(--thought-mint-progress-gap\)/);
   }
 
-  const walletBody = ruleBody(".thought-wallet-strip");
-  assert.match(walletBody, /border-block:\s*var\(--thought-mint-hairline-width\) solid var\(--panel-border\)/);
-
+  const workBody = ruleBody(".thought-dock");
+  assert.match(workBody, /grid-template-areas:\s*"input"\s*"actions"/);
+  assert.match(workBody, /row-gap:\s*var\(--thought-path-picker-gap\)/);
+  assert.match(workBody, /padding:\s*var\(--thought-panel-section-padding\)/);
+  assert.match(workBody, /background:\s*var\(--panel\)/);
   const pathBody = ruleBody(".thought-dock-path");
-  assert.match(pathBody, /border:\s*var\(--thought-mint-hairline-width\) solid var\(--panel-border\)/);
-  assert.match(pathBody, /background:\s*var\(--panel-soft\)/);
+  assert.match(pathBody, /border:\s*0/);
+  assert.match(pathBody, /background:\s*var\(--panel\)/);
+  const groupBody = ruleBody(".thought-dock-control-area");
+  assert.match(groupBody, /gap:\s*var\(--thought-panel-control-gap\)/);
+  assert.match(groupBody, /padding:\s*0/);
+  assert.match(groupBody, /background:\s*transparent/);
+  assert.match(ruleBody(".thought-panel__body"), /gap:\s*var\(--thought-panel-console-gap\)/);
+  assert.match(thoughtCss, /--thought-panel-control-gap:\s*10px/);
+  assert.match(thoughtCss, /--thought-panel-console-gap:\s*22px/);
 });
 
-test("PATH inventory is bounded and collapses after selection", () => {
-  const pickerBody = ruleBody(".thought-dock-path-inventory-list");
-  assert.match(pickerBody, /max-height:\s*var\(--thought-path-picker-max-height\)/);
-  assert.match(pickerBody, /overflow-y:\s*auto/);
-  assert.match(pickerBody, /overscroll-behavior:\s*contain/);
+test("$PATH inventory select has no default and advances on selection", () => {
+  const inventoryPickerStart = thoughtMain.indexOf("const shouldUsePathInventoryPicker");
+  const inventoryPickerEnd = thoughtMain.indexOf("const focusMintDockStage", inventoryPickerStart);
+  const inventoryPickerBody = thoughtMain.slice(inventoryPickerStart, inventoryPickerEnd);
+  assert.match(inventoryPickerBody, /mintFlowState === "path_required"/);
+  assert.doesNotMatch(inventoryPickerBody, /mintFlowState === "path_ready"/);
 
-  const inventorySelectStart = thoughtMain.indexOf("const shouldUsePathInventorySelect");
-  const inventorySelectEnd = thoughtMain.indexOf("const focusMintDockStage", inventorySelectStart);
-  const inventorySelectBody = thoughtMain.slice(inventorySelectStart, inventorySelectEnd);
-  assert.match(inventorySelectBody, /mintFlowState === "path_required"/);
-  assert.match(inventorySelectBody, /mintFlowData\.pathId === null/);
-  assert.doesNotMatch(inventorySelectBody, /mintFlowState === "path_ready"/);
-
+  assert.doesNotMatch(
+    thoughtMain,
+    /!mintFlowData\.pathIdInput && mintFlowState === "path_required"[\s\S]*?applyMintPathInputValue\(availableItems\[0\]\.pathId\.toString\(\)\)/,
+    "inventory refresh must not preselect a $PATH",
+  );
+  assert.match(
+    indexHtml,
+    /id="thought-dock-path-inventory"[\s\S]*?class="thought-dock-select-wrap"[\s\S]*?id="thought-dock-path-inventory-select"[\s\S]*?class="thought-dock-select"[\s\S]*?class="thought-dock-select-arrow"/,
+  );
+  assert.match(thoughtMain, /placeholder\.textContent = "pick a \$PATH"/);
+  assert.match(thoughtMain, /placeholder\.disabled = true/);
+  assert.match(thoughtMain, /select\.value = available\.some\([\s\S]*?\? selectedValue\s*:\s*""/);
   assert.match(
     thoughtMain,
-    /availableItems\.length === 1[\s\S]*?!mintFlowData\.pathIdInput[\s\S]*?await checkPathEligibility\(\)/,
-    "single available PATH remains auto-selected",
+    /thoughtDockPathInventorySelect\.addEventListener\("change"[\s\S]*?handlePathInventorySelectChange\(thoughtDockPathInventorySelect\)/,
+  );
+  const selectItemStart = thoughtMain.indexOf("const selectPathInventoryItem =");
+  const selectItemEnd = thoughtMain.indexOf("const isMintPathFieldVisible", selectItemStart);
+  assert.match(
+    thoughtMain.slice(selectItemStart, selectItemEnd),
+    /void checkPathEligibility\(\)/,
+    "selecting a $PATH immediately validates it and advances the flow",
+  );
+  assert.match(
+    thoughtMain,
+    /config\.action !== "enter_path_manually" && config\.action !== "continue"/,
+    "the integrated picker has no redundant confirmation CTA",
+  );
+  assert.match(
+    thoughtMain,
+    /\(mintFlowState === "path_required" && pathInventoryVisible\) \|\|[\s\S]*?mintFlowState === "path_ready"[\s\S]*?thoughtDockMintStep\.classList\.toggle\("is-hidden", hideRedundantPathStatus\)/,
+    "the redundant status row stays hidden for the $PATH picker and SIGN CTA",
+  );
+  assert.doesNotMatch(thoughtMain, /classList\.toggle\("is-hidden", presentation\.activeStep === "path"\)/);
+  assert.doesNotMatch(indexHtml, /id="thought-dock-path-(?:field|box|options)"/);
+  assert.doesNotMatch(thoughtMain, /thoughtDockPath(?:Field|Box|Options)/);
+  assert.doesNotMatch(thoughtCss, /\.thought-dock-path-(?:field|input)/);
+  for (const compatibilityId of [
+    "mint-sheet-path-field",
+    "mint-sheet-path-box",
+    "mint-sheet-path-options",
+    "mint-sheet-path-select",
+  ]) {
+    assert.match(indexHtml, new RegExp(`id="${compatibilityId}"`));
+  }
+  assert.match(
+    thoughtMain,
+    /getMintSheetActionConfigs\(\)[\s\S]*?config\.action !== "enter_path_manually" && config\.action !== "continue"/,
+    "the integrated dock exposes neither manual input nor redundant confirmation",
   );
 });
 
+test("$PATH inventory uses a secondary white label and the shared select style", () => {
+  assert.match(
+    indexHtml,
+    /id="thought-dock-path-inventory-label"\s+class="thought-dock-label thought-dock-label--secondary"/,
+  );
+  assert.match(thoughtCss, /--thought-panel-secondary-text:\s*#ffffff/);
+  assert.match(
+    ruleBody(".thought-dock-label--secondary"),
+    /color:\s*var\(--thought-panel-secondary-text\)/,
+  );
+  assert.match(ruleBody(".thought-dock-select"), /border:\s*var\(--thought-mint-hairline-width\) solid var\(--accent\)/);
+  assert.equal((indexHtml.match(/class="thought-dock-select"/g) ?? []).length, 2);
+  assert.equal((indexHtml.match(/class="thought-dock-select-arrow"/g) ?? []).length, 2);
+});
+
 test("panel controls expose visible focus and action hierarchy", () => {
-  assert.match(indexHtml, /id="thought-dock-path-title"[^>]*tabindex="-1"/);
+  assert.doesNotMatch(indexHtml, /id="thought-dock-path-title"[^>]*tabindex/);
+  assert.match(thoughtCss, /--thought-focus-ring-width:\s*1px/);
+  assert.match(thoughtCss, /--thought-focus-ring-offset:\s*1px/);
+  assert.match(thoughtCss, /--thought-focus-ring-color:\s*var\(--thought-panel-interactive\)/);
   assert.match(thoughtCss, /:focus-visible[\s\S]*?outline:\s*var\(--thought-focus-ring-width\) solid var\(--thought-focus-ring-color\)/);
   assert.match(thoughtMain, /const focusMintDockStage = \(preference:/);
   assert.match(thoughtMain, /const focusRestoredMintElement = \(element: HTMLElement\) =>/);
-  assert.match(thoughtMain, /focusRestoredMintElement\(thoughtDockPathTitle\)/);
+  assert.doesNotMatch(thoughtMain, /focusRestoredMintElement\(thoughtDockPathTitle\)/);
+  assert.match(thoughtMain, /focusRestoredMintElement\(thoughtDockPathInventorySelect\)/);
   assert.match(thoughtCss, /\.thought-panel \.thought-dock-path \.is-focus-restored/);
 
   const secondaryBody = ruleBody(".thought-dock-button--secondary");
   const tertiaryBody = ruleBody(".thought-dock-button--tertiary");
   assert.match(secondaryBody, /background:\s*transparent/);
   assert.match(secondaryBody, /color:\s*var\(--thought-panel-accent-text\)/);
-  assert.match(tertiaryBody, /border-color:\s*transparent/);
-  assert.match(tertiaryBody, /color:\s*var\(--muted\)/);
+  assert.match(tertiaryBody, /border-color:\s*var\(--accent-border\)/);
+  assert.match(tertiaryBody, /color:\s*var\(--thought-panel-accent-text\)/);
   assert.doesNotMatch(ruleBody(".thought-dock-button"), /text-transform/);
 });
 
-test("dark panel text uses dedicated accessible contrast tokens", () => {
-  assert.match(thoughtCss, /--thought-panel-accent-text:\s*#00a000/);
+test("Work uses monochrome interactive and disabled CTAs", () => {
+  const renderStart = thoughtMain.indexOf("const renderThoughtDock = () =>");
+  const renderEnd = thoughtMain.indexOf("const syncThoughtDock = () =>", renderStart);
+  const renderBody = thoughtMain.slice(renderStart, renderEnd);
+  const buttonStart = thoughtMain.indexOf("const thoughtDockButton = (");
+  const buttonEnd = thoughtMain.indexOf("const assertDockRailView", buttonStart);
+  const buttonBody = thoughtMain.slice(buttonStart, buttonEnd);
+
+  assert.doesNotMatch(thoughtMain, /thoughtDockStatusChip|thought-dock-status-label/);
+  assert.match(renderBody, /const railHidden = rail\.actions\.length === 0/);
+  assert.doesNotMatch(renderBody, /rail\.status|rail\.tone|thought-dock-status/);
+  assert.match(buttonBody, /button\.className = "thought-dock-button thought-work-cta"/);
+  assert.doesNotMatch(buttonBody, /thought-work-cta--secondary/);
+  assert.doesNotMatch(thoughtMain, /variant:\s*"secondary"/);
+  assert.match(
+    ruleBody(".thought-panel"),
+    /--accent:\s*var\(--thought-panel-interactive\)/,
+  );
+  assert.match(
+    ruleBody(".thought-panel"),
+    /--accent-border:\s*var\(--thought-panel-interactive\)/,
+  );
+  assert.match(
+    thoughtCss,
+    /\.thought-dock-action-rail \.thought-work-cta,[\s\S]*?border-color:\s*var\(--accent\);[\s\S]*?background:\s*transparent;[\s\S]*?color:\s*var\(--thought-panel-accent-text\)/,
+  );
+  assert.match(
+    thoughtCss,
+    /--thought-button-disabled-text:\s*var\(--thought-panel-subtle-text\)/,
+  );
+  const disabledBody = ruleBody(".thought-dock-action-rail .thought-work-cta:disabled");
+  assert.match(disabledBody, /border-color:\s*var\(--thought-button-disabled-text\)/);
+  assert.match(disabledBody, /background:\s*transparent/);
+  assert.match(disabledBody, /color:\s*var\(--thought-button-disabled-text\)/);
+  assert.match(disabledBody, /opacity:\s*1/);
+  assert.match(buttonBody, /button\.setAttribute\("aria-expanded", String\(options\.expanded\)\)/);
+  assert.doesNotMatch(thoughtCss, /\.thought-work-cta\[aria-expanded="true"\]/);
+  assert.match(ruleBody(".thought-dock"), /row-gap:\s*var\(--thought-path-picker-gap\)/);
+  assert.match(ruleBody(".thought-dock-action-rail"), /grid-auto-rows:\s*var\(--thought-dock-chip-height\)/);
+});
+
+test("Work prompt never renders the panel-wide focus frame", () => {
+  assert.match(
+    thoughtCss,
+    /\.thought-dock-input:focus,\s*\.thought-panel \.thought-panel__body \.thought-dock-input:focus-visible\s*\{\s*outline:\s*none/,
+  );
+  assert.match(ruleBody(".thought-dock-input"), /border:\s*0/);
+});
+
+test("Work CTAs appear without an entrance animation", () => {
+  assert.doesNotMatch(thoughtMain, /animateThoughtDockRailEntry|thought-dock-chip-enter-delay/);
+  assert.doesNotMatch(thoughtCss, /thought-dock-chip-enter|@keyframes thought-dock-chip-enter/);
+  assert.match(thoughtMain, /const shouldRenderRail = nextRailSignature !== thoughtDockRailSignature/);
+});
+
+test("Work lifecycle messages move into Console history", () => {
+  const recordStart = thoughtMain.indexOf("const recordThoughtDockConsoleTransition =");
+  const recordEnd = thoughtMain.indexOf("const thoughtDockRunFromStored", recordStart);
+  const recordBody = thoughtMain.slice(recordStart, recordEnd);
+
+  for (const state of [
+    "agent_select",
+    "creating_run",
+    "opening_agent",
+    "claim_authorization",
+    "waiting_for_agent",
+    "agent_returned",
+    "previewing",
+  ]) {
+    assert.match(recordBody, new RegExp(`state\\.kind === "${state}"`));
+  }
+  assert.match(recordBody, /title:\s*rail\.status\.replace/);
+  assert.match(recordBody, /emitThoughtConsoleEvent\(/);
+});
+
+test("active process messages share one animated ellipsis", () => {
+  for (const kind of [
+    "work_creating_run",
+    "work_opening_agent",
+    "work_waiting_for_agent",
+    "work_previewing",
+    "wallet_connection_requested",
+    "authorization_requested",
+    "transaction_requested",
+    "transaction_submitted",
+    "path_mint_returned",
+    "path_mint_handoff",
+  ]) {
+    assert.match(thoughtMain, new RegExp(`"${kind}"`));
+  }
+  assert.match(thoughtMain, /entry\.id === newestEntry\?\.id && isThoughtConsoleProgressActive/);
+  assert.match(thoughtMain, /entry\.kind === "work_claim_authorization" && entry\.title === "Codex authorized"/);
+  assert.match(thoughtMain, /presentation\.tone === "running"[\s\S]*?appendThoughtProgressEllipsis/);
+  assert.match(thoughtCss, /@keyframes thought-progress-ellipsis-dot/);
+  assert.match(ruleBody(".thought-progress-ellipsis"), /white-space:\s*nowrap/);
+  assert.match(ruleBody(".thought-progress-ellipsis.is-active .thought-progress-ellipsis__dot"), /animation:/);
+  assert.match(thoughtCss, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation:\s*none/);
+});
+
+test("panel interaction colors are monochrome in both themes", () => {
+  assert.match(thoughtCss, /--thought-panel-interactive:\s*#ffffff/);
+  assert.match(thoughtCss, /--thought-panel-on-interactive:\s*#000000/);
+  assert.match(thoughtCss, /--thought-panel-accent-text:\s*var\(--thought-panel-interactive\)/);
+  assert.match(
+    thoughtCss,
+    /@media \(prefers-color-scheme: light\)[\s\S]*?--thought-panel-interactive:\s*#000000;[\s\S]*?--thought-panel-on-interactive:\s*#ffffff/,
+  );
+  assert.doesNotMatch(thoughtCss, /--thought-panel-accent-text:\s*#00a000/);
   assert.match(thoughtCss, /--thought-panel-subtle-text:\s*#9ca3af/);
   assert.match(ruleBody(".thought-mint-step__title"), /var\(--thought-panel-accent-text\)/);
   assert.match(ruleBody(".thought-dock-path-flow"), /var\(--thought-panel-subtle-text\)/);
+});
+
+test("Console history keeps the same text intensity as the current attempt", () => {
+  assert.doesNotMatch(thoughtCss, /--thought-console-history-opacity/);
+  assert.doesNotMatch(thoughtCss, /\.thought-dock-status-screen__entry:not\(\.is-current-attempt\)/);
+  assert.match(thoughtCss, /--thought-console-text-opacity:\s*0\.5/);
+  assert.match(
+    ruleBody(".thought-dock-status-screen__line"),
+    /opacity:\s*var\(--thought-console-text-opacity\)/,
+  );
+});
+
+test("Console uses theme-aware text for every tone", () => {
+  const consoleBody = ruleBody(".thought-dock-status-screen");
+  assert.match(thoughtCss, /--thought-console-text:\s*#ffffff/);
+  assert.match(
+    thoughtCss,
+    /@media \(prefers-color-scheme: light\)[\s\S]*?--thought-console-text:\s*var\(--text\)/,
+  );
+  assert.doesNotMatch(consoleBody, /--thought-console-text:/);
+  assert.match(consoleBody, /color:\s*var\(--thought-console-text\)/);
+
+  for (const selector of [
+    ".thought-dock-status-screen__line",
+    ".thought-dock-status-screen__line--heading",
+    ".thought-dock-status-screen__line--error",
+    ".thought-dock-status-screen__line--success",
+  ]) {
+    assert.match(ruleBody(selector), /color:\s*var\(--thought-console-text\)/);
+  }
+});
+
+test("Console warnings use one stable muted yellow in both themes", () => {
+  assert.match(
+    thoughtCss,
+    /--thought-console-warning-text:\s*#8b731c/,
+  );
+  assert.match(
+    thoughtCss,
+    /--thought-console-warning-opacity:\s*1/,
+  );
+  assert.match(
+    ruleBody(".thought-dock-status-screen__line--warning"),
+    /color:\s*var\(--thought-console-warning-text\)/,
+  );
+  assert.match(
+    ruleBody(".thought-dock-status-screen__line--warning"),
+    /opacity:\s*var\(--thought-console-warning-opacity\)/,
+  );
+  assert.doesNotMatch(thoughtCss, /thought-console-warning-flash|is-warning-flash/);
+  assert.doesNotMatch(thoughtMain, /activeThoughtConsoleWarningFlashes|is-warning-flash/);
+  assert.doesNotMatch(thoughtMain, /review this warning, then retry/);
+  assert.match(
+    thoughtMain,
+    /if \(title\.includes\("path"\)\) \{[\s\S]*?return "pick another \$PATH or refresh wallet from the shell bar";[\s\S]*?return undefined;/,
+    "warnings without a concrete recovery action must not invent a next step",
+  );
+});
+
+test("text-too-long rejection is a byte-usage warning", () => {
+  assert.match(thoughtMain, /title:\s*state\.issue\?\.title \?\? \(textTooLong \? "text too long" : "work rejected"\)/);
+  assert.match(thoughtMain, /tone:\s*state\.issue \|\| textTooLong \? "warning" : "error"/);
+  assert.match(thoughtMain, /error\.previewReasonCode === 3 && error\.byteLimit/);
+  assert.match(thoughtMain, /formatThoughtByteLimitUsage\(error\.byteLimit\)/);
+  assert.match(
+    thoughtMain,
+    /reduce prompt to \$\{THOUGHT_V2_PROTOCOL_RELEASE\.limits\.promptMaxBytes\} UTF-8 bytes or less/,
+  );
+  assert.match(
+    thoughtMain,
+    /input\.tone === "warning" \|\| input\.tone === "error"[\s\S]*?suggestedThoughtConsoleNextStep\(input\)/,
+  );
+  assert.match(thoughtMain, /thoughtConsoleNextStepForPresentation\(presentation\)/);
+  assert.match(
+    thoughtMain,
+    /const rejectInvalidThoughtDockPrompt = \(prompt: string\)[\s\S]*?measureThoughtV2Line\(prompt, "prompt"\)/,
+  );
+  assert.match(thoughtMain, /describeThoughtTextPolicyIssue\(\{[\s\S]*?value: prompt,[\s\S]*?line: "prompt"/);
+  assert.match(thoughtTextPolicy, /\? "leading space"[\s\S]*?: "trailing space"/);
+  assert.match(thoughtTextPolicy, /ends with U\+0020/);
+  assert.match(thoughtTextPolicy, /output is never auto-corrected/);
+  assert.match(thoughtMain, /const deriveThoughtV2VisibleLine = \(value: string\): string => value/);
+  assert.match(
+    thoughtMain,
+    /const openThoughtDockAgentSelect = \(\) => \{[\s\S]*?const prompt = thoughtDockPrompt\.value;\s*if \(rejectInvalidThoughtDockPrompt\(prompt\)\)/,
+  );
+  assert.match(
+    thoughtMain,
+    /if \(rejectInvalidThoughtDockPrompt\(prompt\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?setThoughtDockState\(\{ kind: "agent_select", prompt \}\)/,
+  );
+});
+
+test("Console exposes a thin scrollbar only when its content overflows", () => {
+  const consoleBody = ruleBody(".thought-dock-status-screen");
+  assert.match(consoleBody, /overflow-y:\s*auto/);
+  assert.match(
+    consoleBody,
+    /scrollbar-color:\s*var\(--detail-scrollbar-thumb\) var\(--detail-scrollbar-track\)/,
+  );
+  assert.match(consoleBody, /scrollbar-width:\s*thin/);
+  assert.doesNotMatch(consoleBody, /scrollbar-width:\s*none/);
+
+  const scrollbarBody = ruleBody(".thought-dock-status-screen::-webkit-scrollbar");
+  assert.match(scrollbarBody, /width:\s*8px/);
+  assert.doesNotMatch(scrollbarBody, /display:\s*none/);
+  assert.match(
+    ruleBody(".thought-dock-status-screen::-webkit-scrollbar-track"),
+    /background:\s*var\(--detail-scrollbar-track\)/,
+  );
+  assert.match(
+    ruleBody(".thought-dock-status-screen::-webkit-scrollbar-thumb"),
+    /background:\s*var\(--detail-scrollbar-thumb\)/,
+  );
+});
+
+test("Console keeps the newest time group at the top without reversing causal order", () => {
+  assert.match(
+    thoughtMain,
+    /const newestFirstThoughtConsoleEntries = \(entries: ThoughtConsoleEntry\[\]\) => \{[\s\S]*?if \(currentGroup\?\.at\(-1\)\?\.time === entry\.time\) \{[\s\S]*?return timeGroups\.reverse\(\)\.flat\(\);/,
+  );
+  assert.match(
+    thoughtMain,
+    /const entries = newestFirstThoughtConsoleEntries\(thoughtConsoleHistory\.entries\)\.map\(\(entry\) => \{/,
+  );
+  assert.match(thoughtMain, /element\.dataset\.consoleEntryId = entry\.id/);
+  assert.match(
+    thoughtMain,
+    /const hasNewLatestEntry = newestEntry\?\.id !== previousNewestEntryId;[\s\S]*?if \(hasNewLatestEntry \|\| wasPinnedToLatest\) \{[\s\S]*?thoughtDockDetails\.scrollTop = 0;/,
+  );
+  assert.match(
+    thoughtMain,
+    /else \{\s*thoughtDockDetails\.scrollTop = previousScrollTop;\s*\}/,
+    "rerenders must preserve the reader's position when no new entry arrives",
+  );
 });
 
 test("console rendering is read-only and mint attempts survive navigation", () => {
@@ -136,14 +589,14 @@ test("console rendering is read-only and mint attempts survive navigation", () =
   const renderBody = thoughtMain.slice(renderStart, renderEnd);
   assert.doesNotMatch(renderBody, /emitThoughtConsoleEvent|recordMintConsoleState|appendThoughtConsoleEvent/);
 
-  assert.match(thoughtMain, /createMintSubmissionContext\(\{[\s\S]*?attemptId:\s*mintAttemptId/);
+  assert.match(thoughtMain, /createMintSubmissionContext\(\{[\s\S]*?attemptId:\s*payload\.attemptId/);
   assert.match(thoughtMain, /pendingMintTransaction\s*=\s*createPendingMintTransaction\(submission, tx\.hash/);
   assert.match(thoughtMain, /mintAttemptId\s*=\s*pending\.attemptId\?\.trim\(\)\s*\|\|\s*retainedAttemptId/);
   assert.match(thoughtMain, /await mintThoughtDockWork\(\{[\s\S]*?attemptId:\s*mintAttemptId,[\s\S]*?pathId:\s*confirmedReturn\?\.tokenId/);
-  assert.match(thoughtMain, /pathMintHandoffStorageKey\(handoff\.attemptId\)/);
-  assert.match(thoughtMain, /work:\s*\{\s*output:\s*currentOutputText,[\s\S]*?workId:\s*currentWorkId/);
+  assert.match(thoughtMain, /serializePendingThoughtPathAcquisition\(pending\)/);
+  assert.match(thoughtMain, /workHash:\s*workHash\.toLowerCase\(\),[\s\S]*?txHash:\s*tx\.hash\.toLowerCase\(\)/);
   assert.match(thoughtMain, /const confirmedReturn = returnRecord\?\.status === "confirmed"/);
-  assert.match(thoughtMain, /PATH was minted to \$\{shortHex\(confirmedReturn\.account\)\}; select that account in your wallet to continue\./);
+  assert.match(thoughtMain, /\$PATH was minted to \$\{shortHex\(confirmedReturn\.account\)\}; select that account in your wallet to continue\./);
   const handoffReadStart = thoughtMain.indexOf("const readPathMintHandoff");
   const handoffReadEnd = thoughtMain.indexOf("const readStoredThoughtWorks", handoffReadStart);
   assert.ok(handoffReadStart >= 0 && handoffReadEnd > handoffReadStart, "handoff reader is present");
@@ -156,19 +609,182 @@ test("console rendering is read-only and mint attempts survive navigation", () =
   assert.match(thoughtMain, /mintFlowUiMode === "sheet"[\s\S]*?closeMintSheet\(\)/);
 });
 
+test("Codex launch errors keep their actionable message in Console", () => {
+  const runStart = thoughtMain.indexOf("const runThoughtDockAdapter = async");
+  const runEnd = thoughtMain.indexOf("const updateThoughtDockRunState =", runStart);
+  const runBody = thoughtMain.slice(runStart, runEnd);
+
+  assert.match(runBody, /setThoughtDockState\(\{ kind: "failed", message \}\)/);
+  assert.doesNotMatch(runBody, /details:\s*"Try again\."/);
+});
+
+test("local Agent fixture mode keeps work generation independent from Anvil", () => {
+  const runStart = thoughtMain.indexOf("const runThoughtDockAdapter = async");
+  const runEnd = thoughtMain.indexOf("const updateThoughtDockRunState =", runStart);
+  const runBody = thoughtMain.slice(runStart, runEnd);
+
+  assert.match(thoughtMain, /const THOUGHT_AGENT_FIXTURE_MODE = shouldUseThoughtAgentFixture/);
+  assert.match(runBody, /if \(!THOUGHT_AGENT_FIXTURE_MODE && !adapter\.canDeepLink\)/);
+  assert.match(
+    runBody,
+    /const payload = await buildThoughtDockRunPayload\(prompt\);[\s\S]*?if \(THOUGHT_AGENT_FIXTURE_MODE\) \{[\s\S]*?await runThoughtDockFixtureAdapter\(adapterId, prompt, payload, runSessionId\)/,
+  );
+  assert.match(
+    thoughtMain,
+    /const runThoughtDockFixtureAdapter =[\s\S]*?handleThoughtDockReturnedWork\(run, agentLine, payload, runSessionId\)/,
+    "the fixture must rejoin the normal return and mint-readiness pipeline",
+  );
+  assert.match(
+    thoughtMain,
+    /const selectThoughtPreviewProvider = async \(\) => \{[\s\S]*?if \(THOUGHT_AGENT_FIXTURE_MODE\) \{\s*return \{ provider: createFrontendPreviewProvider\(\), reason: "" \};/,
+    "fixture returns must use the deterministic browser preview instead of an Anvil contract read",
+  );
+  assert.match(
+    thoughtMain,
+    /const ensureThoughtDockActiveSpec = async \(\) => \{\s*if \(THOUGHT_AGENT_FIXTURE_MODE && shouldUseBundledThoughtSpecFallback\(\)\) \{[\s\S]*?activeThoughtSpec = buildBundledActiveThoughtSpec\(\);/,
+    "fixture runs must use the bundled release spec before trying an Anvil registry read",
+  );
+  assert.match(thoughtMain, /title: `\$\{thoughtAgentProductLabel\(adapterId\)\} fixture return`/);
+});
+
+test("Work owns mutually exclusive Mint and Load disclosures", () => {
+  assert.doesNotMatch(thoughtMain, /\{ kind: "minting"; work: ThoughtDockWorkView \}/);
+  assert.doesNotMatch(thoughtMain, /setThoughtDockState\(\{ kind: "minting"/);
+  assert.doesNotMatch(thoughtMain, /thoughtDock\.hidden\s*=/);
+  assert.match(thoughtMain, /let mintDockRevealed = false/);
+  assert.match(thoughtMain, /const mintPanelOpen = mintDockRevealed/);
+  assert.match(thoughtMain, /workReady\.canMint && workMintReadiness\.ready/);
+  assert.match(
+    thoughtMain,
+    /revealMintDock\(\);[\s\S]*?kind: "mint_requirement"[\s\S]*?title: "to mint THOUGHT"[\s\S]*?detail: "1 THOUGHT requires 1 available \$PATH\. \$PATH is the permission token for Inshell’s three fully on-chain movements for Agent Art\."[\s\S]*?tone: "warning"[\s\S]*?syncThoughtDock\(\);\s*void mintThoughtDockWork\(\)/,
+    "the Work Mint CTA explains the PATH requirement before starting the mint flow",
+  );
+  assert.match(
+    thoughtMain,
+    /mintPanelOpen \? "mint ↓" : "mint"[\s\S]*?mintPanelOpen \? "collapse Mint panel"[\s\S]*?mintDockRevealed = false;[\s\S]*?\{ expanded: mintPanelOpen \}/,
+    "the Work Mint CTA becomes a clickable expanded disclosure that can collapse Mint",
+  );
+  assert.match(
+    thoughtMain,
+    /const revealMintDock = \(\) => \{\s*mintDockRevealed = true;\s*workLibraryRevealed = false;\s*writeCurrentOutputSession\(\);\s*\}/,
+    "revealing Mint closes Load and persists with the current Work",
+  );
+  assert.match(
+    thoughtMain,
+    /loadPanelOpen \? "load ↓" : "load"[\s\S]*?workLibraryRevealed = !loadPanelOpen;[\s\S]*?mintDockRevealed = false;[\s\S]*?\{ expanded: loadPanelOpen \}/,
+    "Load is a clickable disclosure and opening it closes Mint",
+  );
+  assert.match(
+    thoughtMain,
+    /currentWorkSaved \? "saved" : "save"[\s\S]*?currentWorkSaved \? "current work is saved" : "save current work"/,
+    "saved Work uses an explicit saved state label",
+  );
+  const mintedCase = thoughtMain.slice(
+    thoughtMain.indexOf('case "minted"'),
+    thoughtMain.indexOf('case "run_access_needed"'),
+  );
+  assert.match(mintedCase, /dockRailAction\("view"/);
+  assert.match(mintedCase, /dockRailAction\(\s*"save"/);
+  assert.match(mintedCase, /loadAction\(\)/);
+  assert.match(mintedCase, /resetAction\(\)/);
+  assert.match(mintedCase, /maxActions: 4/);
+  assert.match(thoughtMain, /mintFlowState = "thought_checking";[\s\S]*?setThoughtDockState\(\{ kind: "work_ready", work \}\)/);
+  assert.match(thoughtMain, /const isVisible = mintDockRevealed/);
+  assert.match(
+    thoughtMain,
+    /mintDockRevealed: candidate\.mintDockRevealed === true/,
+    "legacy Work snapshots default to hidden while revealed snapshots restore",
+  );
+  assert.match(
+    thoughtMain,
+    /workId: currentWorkId,\s*mintDockRevealed,/,
+    "the Mint disclosure state is stored inside the current Work snapshot",
+  );
+  assert.match(
+    thoughtMain,
+    /currentWorkId = stored\.workId;\s*mintDockRevealed = stored\.mintDockRevealed;\s*runState = "output_ready"/,
+    "the Mint disclosure state restores before the Work UI is rendered",
+  );
+  assert.match(
+    thoughtMain,
+    /if \(!resumedPendingMint && !resumedPathMint\) \{\s*if \(mintDockRevealed\) \{\s*await mintThoughtDockWork\(\)/,
+    "refresh safely rebuilds the visible Mint flow for the restored Work",
+  );
+
+  const resetMintFlowStart = thoughtMain.indexOf("const resetMintFlow =");
+  const resetMintFlowEnd = thoughtMain.indexOf("const resetMintRuntimeState =", resetMintFlowStart);
+  assert.doesNotMatch(
+    thoughtMain.slice(resetMintFlowStart, resetMintFlowEnd),
+    /mintDockRevealed/,
+    "mint workflow resets do not hide a revealed panel",
+  );
+
+  for (const [startMarker, endMarker] of [
+    ["const setAgentOutput =", "const hasCurrentContractWorkSvg ="],
+    ["const loadWorkRecord =", "const isThoughtRunContext ="],
+    ["const resetThought =", "const base64UrlEncode ="],
+  ]) {
+    const start = thoughtMain.indexOf(startMarker);
+    const end = thoughtMain.indexOf(endMarker, start);
+    assert.match(
+      thoughtMain.slice(start, end),
+      /mintDockRevealed = false/,
+      `${startMarker} starts a hidden Mint panel for the new Work boundary`,
+    );
+  }
+
+  const resetThoughtStart = thoughtMain.indexOf("const resetThought =");
+  const resetThoughtEnd = thoughtMain.indexOf("const base64UrlEncode =", resetThoughtStart);
+  assert.match(
+    thoughtMain.slice(resetThoughtStart, resetThoughtEnd),
+    /mintDockRevealed = false;\s*workLibraryRevealed = false;/,
+    "Reset collapses both Mint and Load panels",
+  );
+
+  const handoffRestoreStart = thoughtMain.indexOf("const restorePathMintHandoffWork =");
+  const handoffRestoreEnd = thoughtMain.indexOf("const pathTokenIdFromMintReceipt =", handoffRestoreStart);
+  assert.match(
+    thoughtMain.slice(handoffRestoreStart, handoffRestoreEnd),
+    /mintDockRevealed = true;\s*writeCurrentOutputSession\(\)/,
+    "returning from same-origin PATH mint keeps the Mint panel revealed",
+  );
+});
+
 test("mint submission and recovery keep one durable hash", () => {
+  const pathCheckStart = thoughtMain.indexOf("const checkPathEligibility = async");
+  const pathCheckEnd = thoughtMain.indexOf("const authorizeMint = async", pathCheckStart);
+  const pathCheckBody = thoughtMain.slice(pathCheckStart, pathCheckEnd);
+  assert.ok(pathCheckStart >= 0 && pathCheckEnd > pathCheckStart);
+  assert.ok(pathCheckBody.indexOf("await rebuildFinalMintProvenance()") >= 0);
+  assert.ok(pathCheckBody.indexOf('mintFlowState = "path_ready"') >= 0);
+  assert.ok(
+    pathCheckBody.indexOf("await rebuildFinalMintProvenance()") <
+      pathCheckBody.indexOf('mintFlowState = "path_ready"'),
+    "final V2 provenance must validate before the panel offers SIGN",
+  );
+
   const authorizeStart = thoughtMain.indexOf("const authorizeMint = async");
   const authorizeEnd = thoughtMain.indexOf("type MintTransactionResponse", authorizeStart);
   const authorizeBody = thoughtMain.slice(authorizeStart, authorizeEnd);
   assert.ok(authorizeStart >= 0 && authorizeEnd > authorizeStart);
+  assert.doesNotMatch(authorizeBody, /readPathEligibility|rebuildFinalMintProvenance/);
+  assert.ok(authorizeBody.indexOf('mintFlowState = "authorizing"') >= 0);
   assert.ok(
     authorizeBody.indexOf("mintAuthorizationInFlight = true") <
-      authorizeBody.indexOf("await readPathEligibility"),
-    "authorization locks synchronously before its first eligibility read",
+      authorizeBody.indexOf('mintFlowState = "authorizing"'),
+    "authorization locks synchronously before the wallet phase",
+  );
+  assert.ok(
+    authorizeBody.indexOf('mintFlowState = "authorizing"') <
+      authorizeBody.indexOf(
+        "recordCurrentMintConsoleState()",
+        authorizeBody.indexOf('mintFlowState = "authorizing"'),
+      ),
+    "the wallet-request console event must be recorded only after entering the real wallet phase",
   );
 
   const confirmStart = thoughtMain.indexOf("const confirmMint = async");
-  const confirmEnd = thoughtMain.indexOf("const pathMintUrl", confirmStart);
+  const confirmEnd = thoughtMain.indexOf("const readPathAcquisitionQuote", confirmStart);
   const confirmBody = thoughtMain.slice(confirmStart, confirmEnd);
   assert.ok(confirmStart >= 0 && confirmEnd > confirmStart);
   assert.match(confirmBody, /if \(mintTransactionInFlight\)/);
@@ -189,10 +805,75 @@ test("mint submission and recovery keep one durable hash", () => {
   assert.match(thoughtMain, /appendConflictingMintTransaction\(returnedTransaction\)[\s\S]*?startConflictingMintReceiptMonitor\(returnedTransaction/);
   assert.match(thoughtMain, /const recoverUnresolvedMintSubmission[\s\S]*?getTransactionCount\(unresolved\.submission\.account, "latest"\)[\s\S]*?getTransactionCount\(unresolved\.submission\.account, "pending"\)/);
   assert.match(thoughtMain, /firstNonceSnapshot[\s\S]*?MINT_RECOVERY_NONCE_RECHECK_MS[\s\S]*?secondNonceSnapshot[\s\S]*?releaseLockAfterRecovery\(\)/);
-  assert.match(thoughtMain, /mintFlowData\.errorKind === "path_mint_chain_mismatch"[\s\S]*?mintAttemptId = nextMintAttemptId\("path"\)/);
+  assert.match(thoughtMain, /readPathAcquisitionQuote[\s\S]*?adapterPathNft\.toLowerCase\(\) !== PATH_NFT_ADDRESS\.toLowerCase\(\)/);
   assert.match(thoughtMain, /window\.addEventListener\("storage"[\s\S]*?event\.newValue === null[\s\S]*?return/);
-  assert.match(thoughtMain, /const resetThought = [\s\S]*?if \(blockPendingMintMutation\(\)\)/);
-  assert.match(thoughtMain, /const setAgentOutput = [\s\S]*?if \(blockPendingMintMutation\(\)\)/);
+  assert.match(thoughtMain, /const resetThought = [\s\S]*?blockPendingMintMutation\(\) \|\| blockPendingPathAcquisitionMutation\(\)/);
+  assert.match(thoughtMain, /const setAgentOutput = [\s\S]*?blockPendingMintMutation\(\) \|\| blockPendingPathAcquisitionMutation\(\)/);
+});
+
+test("current work verifies THOUGHT uniqueness before PICK and before submission", () => {
+  const preflightStart = thoughtMain.indexOf("const preflightCurrentThoughtExistence = async");
+  const preflightEnd = thoughtMain.indexOf("const handlePendingTx = async", preflightStart);
+  const preflightBody = thoughtMain.slice(preflightStart, preflightEnd);
+  assert.ok(preflightStart >= 0 && preflightEnd > preflightStart);
+  assert.match(preflightBody, /await verifyLocalThoughtV2Deployment\(\)/);
+  assert.match(preflightBody, /await textHashFromContract\(checkedText\)/);
+  assert.match(preflightBody, /await lookupExistingThoughtToken\(token, textHash\)/);
+  assert.match(preflightBody, /currentOutputText !== checkedText[\s\S]*?mintFlowState !== "closed"/);
+  assert.match(preflightBody, /mintFlowData\.existingTokenId = Number\(existingTokenId\)[\s\S]*?mintFlowState = "text_taken"/);
+  assert.doesNotMatch(preflightBody, /refreshWalletState|refreshPathInventory|authorizeMint/);
+
+  for (const [startMarker, endMarker] of [
+    ["const loadWorkRecord =", "const isThoughtRunContext ="],
+    ["const restoreCurrentOutputSession =", "const recordThoughtRun ="],
+    ["const promotePreviewedCandidateToWork =", "const completeThoughtRunFromModelReturn ="],
+  ]) {
+    const start = thoughtMain.indexOf(startMarker);
+    const end = thoughtMain.indexOf(endMarker, start);
+    assert.match(
+      thoughtMain.slice(start, end),
+      /void preflightCurrentThoughtExistence\(\)/,
+      `${startMarker} starts the read-only uniqueness preflight`,
+    );
+  }
+
+  const resolvedStateStart = thoughtMain.indexOf("const getResolvedThoughtDockState =");
+  const resolvedStateEnd = thoughtMain.indexOf("type ThoughtWorkMintReadiness", resolvedStateStart);
+  assert.match(
+    thoughtMain.slice(resolvedStateStart, resolvedStateEnd),
+    /mintFlowState === "text_taken"[\s\S]*?kind: "minted"[\s\S]*?existing: true/,
+    "an existing token replaces mint controls with the success rail",
+  );
+
+  const openStart = thoughtMain.indexOf("const openMintFlow = async");
+  const openEnd = thoughtMain.indexOf("type PathEligibilityResult", openStart);
+  const openBody = thoughtMain.slice(openStart, openEnd);
+  assert.ok(
+    openBody.indexOf("lookupExistingThoughtToken") < openBody.indexOf("refreshWalletState"),
+    "Mint click checks uniqueness before reading wallet or $PATH inventory",
+  );
+
+  const confirmStart = thoughtMain.indexOf("const confirmMint = async");
+  const confirmEnd = thoughtMain.indexOf("const readPathAcquisitionQuote", confirmStart);
+  const confirmBody = thoughtMain.slice(confirmStart, confirmEnd);
+  assert.ok(
+    confirmBody.indexOf("lookupExistingThoughtToken(readToken, payload.workHash)") <
+      confirmBody.indexOf('getTransactionCount(signerAddress, "pending")'),
+    "the race guard rechecks uniqueness before opening the transaction request",
+  );
+});
+
+test("PICK can acquire the exact V2 $PATH without leaving THOUGHT", () => {
+  assert.match(thoughtMintPresentation, /state === "review"[\s\S]*?Wallet request 1 of 3[\s\S]*?confirm_path_mint[\s\S]*?Mint \$PATH for/);
+  assert.match(thoughtMintPresentation, /consoleNextStep: "mint here, or explore \$PATH at \/path"/);
+  assert.doesNotMatch(thoughtMintPresentation, /action\("explore_path"/);
+  assert.match(thoughtMain, /availableItems\.length === 0[\s\S]*?pathAcquisitionState === "idle"[\s\S]*?handleMintPath\(\)/);
+  assert.match(thoughtMain, /action === "mint_path"[\s\S]*?handleMintPath\(\{ submit: true \}\)/);
+  assert.match(thoughtMain, /const readPathAcquisitionQuote = async[\s\S]*?auction\.mintAdapter\(\)[\s\S]*?adapter\.pathNft\(\)[\s\S]*?wiringFrozen/);
+  assert.match(thoughtMain, /withThoughtPathAcquisitionLock\([\s\S]*?auction\.bid\(quote\.price, \{ value: quote\.price \}\)/);
+  assert.match(thoughtMain, /writePendingPathAcquisition\(pending\)[\s\S]*?monitorPendingPathAcquisition/);
+  assert.match(thoughtMain, /pathTokenIdFromMintReceipt\(receipt, pending\.account\)[\s\S]*?refreshPathInventoryForCurrentWallet\(\{ force: true \}\)[\s\S]*?checkPathEligibility\(\)/);
+  assert.doesNotMatch(thoughtMain, /window\.location\.assign\(pathMintUrl\(\)\)/);
 });
 
 test("submitted PATH return is promoted only by an explicit successful receipt", () => {

--- a/scripts/thought-panel-ui.test.mjs
+++ b/scripts/thought-panel-ui.test.mjs
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const indexHtml = await readFile(new URL("../apps/thought/index.html", import.meta.url), "utf8");
+const thoughtCss = await readFile(new URL("../apps/thought/src/style.css", import.meta.url), "utf8");
+const thoughtMain = await readFile(new URL("../apps/thought/src/main.ts", import.meta.url), "utf8");
+
+const ruleBody = (selector) => {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = thoughtCss.match(new RegExp(`${escapedSelector}\\s*\\{([^}]+)\\}`));
+  assert.ok(match, `missing CSS rule: ${selector}`);
+  return match[1];
+};
+
+test("mint panel presents wallet context before controls", () => {
+  const promptIndex = indexHtml.indexOf('id="thought-dock"');
+  const walletIndex = indexHtml.indexOf('id="thought-wallet-strip"');
+  const actionIndex = indexHtml.indexOf('id="thought-dock-action-area"');
+  const pathIndex = indexHtml.indexOf('id="thought-dock-path"');
+
+  assert.ok(promptIndex >= 0, "prompt composer is present");
+  assert.ok(walletIndex > promptIndex, "wallet context follows the work prompt");
+  assert.ok(actionIndex > walletIndex, "wallet context precedes current actions");
+  assert.ok(pathIndex > walletIndex, "wallet context precedes the mint stage");
+  assert.match(indexHtml, /id="thought-wallet-strip"[\s\S]*?aria-label="Mint wallet context"/);
+});
+
+test("dock and compatibility sheet share the PATH SIGN MINT spine", () => {
+  const expectedSteps = /<ol[^>]+aria-label="THOUGHT mint progress"[^>]*>\s*<li data-step="select">PATH<\/li>\s*<li data-step="authorize">SIGN<\/li>\s*<li data-step="confirm">MINT<\/li>\s*<\/ol>/g;
+  assert.equal([...indexHtml.matchAll(expectedSteps)].length, 2);
+
+  const dockFlowIndex = indexHtml.indexOf('id="thought-dock-path-flow"');
+  const inventoryIndex = indexHtml.indexOf('id="thought-dock-path-inventory"');
+  const sheetFlowIndex = indexHtml.indexOf('id="mint-sheet-flow"');
+  const sheetFieldIndex = indexHtml.indexOf('id="mint-sheet-path-field"');
+
+  assert.ok(dockFlowIndex < inventoryIndex, "dock progress precedes its active PATH stage");
+  assert.ok(sheetFlowIndex < sheetFieldIndex, "sheet progress precedes its active PATH stage");
+});
+
+test("integrated mint stage has one atomic announcement and a stable region name", () => {
+  assert.match(
+    indexHtml,
+    /id="thought-dock-path"[\s\S]*?aria-label="THOUGHT mint"/,
+  );
+  assert.match(
+    indexHtml,
+    /class="thought-mint-step" role="status" aria-live="polite" aria-atomic="true"/,
+  );
+  assert.doesNotMatch(
+    indexHtml,
+    /id="thought-dock-path-status"[^>]*aria-live/,
+  );
+  assert.doesNotMatch(
+    indexHtml,
+    /id="thought-dock-details"[^>]*aria-live/,
+  );
+});
+
+test("SIGN and MINT review stays compact behind a native disclosure", () => {
+  assert.match(
+    indexHtml,
+    /<details id="thought-dock-path-review"[^>]*>[\s\S]*?<summary id="thought-dock-path-review-summary">review wallet request<\/summary>/,
+  );
+  assert.match(thoughtMain, /const syncMintDockReview = \(\) =>/);
+  assert.match(thoughtMain, /review signature request · 1 of 2/);
+  assert.match(thoughtMain, /review mint transaction · 2 of 2/);
+  assert.match(thoughtMain, /thoughtDockPathReview\.open = false/);
+});
+
+test("mint progress and active stage have compact component styling", () => {
+  for (const selector of [".thought-dock-path-flow", ".mint-sheet-flow"]) {
+    const body = ruleBody(selector);
+    assert.match(body, /display:\s*grid/);
+    assert.match(body, /grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/);
+    assert.match(body, /gap:\s*var\(--thought-mint-progress-gap\)/);
+  }
+
+  const walletBody = ruleBody(".thought-wallet-strip");
+  assert.match(walletBody, /border-block:\s*var\(--thought-mint-hairline-width\) solid var\(--panel-border\)/);
+
+  const pathBody = ruleBody(".thought-dock-path");
+  assert.match(pathBody, /border:\s*var\(--thought-mint-hairline-width\) solid var\(--panel-border\)/);
+  assert.match(pathBody, /background:\s*var\(--panel-soft\)/);
+});
+
+test("PATH inventory is bounded and collapses after selection", () => {
+  const pickerBody = ruleBody(".thought-dock-path-inventory-list");
+  assert.match(pickerBody, /max-height:\s*var\(--thought-path-picker-max-height\)/);
+  assert.match(pickerBody, /overflow-y:\s*auto/);
+  assert.match(pickerBody, /overscroll-behavior:\s*contain/);
+
+  const inventorySelectStart = thoughtMain.indexOf("const shouldUsePathInventorySelect");
+  const inventorySelectEnd = thoughtMain.indexOf("const focusMintDockStage", inventorySelectStart);
+  const inventorySelectBody = thoughtMain.slice(inventorySelectStart, inventorySelectEnd);
+  assert.match(inventorySelectBody, /mintFlowState === "path_required"/);
+  assert.match(inventorySelectBody, /mintFlowData\.pathId === null/);
+  assert.doesNotMatch(inventorySelectBody, /mintFlowState === "path_ready"/);
+
+  assert.match(
+    thoughtMain,
+    /availableItems\.length === 1[\s\S]*?!mintFlowData\.pathIdInput[\s\S]*?await checkPathEligibility\(\)/,
+    "single available PATH remains auto-selected",
+  );
+});
+
+test("panel controls expose visible focus and action hierarchy", () => {
+  assert.match(indexHtml, /id="thought-dock-path-title"[^>]*tabindex="-1"/);
+  assert.match(thoughtCss, /:focus-visible[\s\S]*?outline:\s*var\(--thought-focus-ring-width\) solid var\(--thought-focus-ring-color\)/);
+  assert.match(thoughtMain, /const focusMintDockStage = \(preference:/);
+  assert.match(thoughtMain, /const focusRestoredMintElement = \(element: HTMLElement\) =>/);
+  assert.match(thoughtMain, /focusRestoredMintElement\(thoughtDockPathTitle\)/);
+  assert.match(thoughtCss, /\.thought-panel \.thought-dock-path \.is-focus-restored/);
+
+  const secondaryBody = ruleBody(".thought-dock-button--secondary");
+  const tertiaryBody = ruleBody(".thought-dock-button--tertiary");
+  assert.match(secondaryBody, /background:\s*transparent/);
+  assert.match(secondaryBody, /color:\s*var\(--thought-panel-accent-text\)/);
+  assert.match(tertiaryBody, /border-color:\s*transparent/);
+  assert.match(tertiaryBody, /color:\s*var\(--muted\)/);
+  assert.doesNotMatch(ruleBody(".thought-dock-button"), /text-transform/);
+});
+
+test("dark panel text uses dedicated accessible contrast tokens", () => {
+  assert.match(thoughtCss, /--thought-panel-accent-text:\s*#00a000/);
+  assert.match(thoughtCss, /--thought-panel-subtle-text:\s*#9ca3af/);
+  assert.match(ruleBody(".thought-mint-step__title"), /var\(--thought-panel-accent-text\)/);
+  assert.match(ruleBody(".thought-dock-path-flow"), /var\(--thought-panel-subtle-text\)/);
+});
+
+test("console rendering is read-only and mint attempts survive navigation", () => {
+  const renderStart = thoughtMain.indexOf("const renderThoughtDockDetails");
+  const renderEnd = thoughtMain.indexOf("const getResolvedThoughtDockState", renderStart);
+  assert.ok(renderStart >= 0 && renderEnd > renderStart, "console render function is present");
+  const renderBody = thoughtMain.slice(renderStart, renderEnd);
+  assert.doesNotMatch(renderBody, /emitThoughtConsoleEvent|recordMintConsoleState|appendThoughtConsoleEvent/);
+
+  assert.match(thoughtMain, /createMintSubmissionContext\(\{[\s\S]*?attemptId:\s*mintAttemptId/);
+  assert.match(thoughtMain, /pendingMintTransaction\s*=\s*createPendingMintTransaction\(submission, tx\.hash/);
+  assert.match(thoughtMain, /mintAttemptId\s*=\s*pending\.attemptId\?\.trim\(\)\s*\|\|\s*retainedAttemptId/);
+  assert.match(thoughtMain, /await mintThoughtDockWork\(\{[\s\S]*?attemptId:\s*mintAttemptId,[\s\S]*?pathId:\s*confirmedReturn\?\.tokenId/);
+  assert.match(thoughtMain, /pathMintHandoffStorageKey\(handoff\.attemptId\)/);
+  assert.match(thoughtMain, /work:\s*\{\s*output:\s*currentOutputText,[\s\S]*?workId:\s*currentWorkId/);
+  assert.match(thoughtMain, /const confirmedReturn = returnRecord\?\.status === "confirmed"/);
+  assert.match(thoughtMain, /PATH was minted to \$\{shortHex\(confirmedReturn\.account\)\}; select that account in your wallet to continue\./);
+  const handoffReadStart = thoughtMain.indexOf("const readPathMintHandoff");
+  const handoffReadEnd = thoughtMain.indexOf("const readStoredThoughtWorks", handoffReadStart);
+  assert.ok(handoffReadStart >= 0 && handoffReadEnd > handoffReadStart, "handoff reader is present");
+  assert.doesNotMatch(
+    thoughtMain.slice(handoffReadStart, handoffReadEnd),
+    /removePathMintHandoff/,
+    "reading a valid handoff must not consume it",
+  );
+  assert.match(thoughtMain, /if \(resumeSucceeded\) \{[\s\S]*?removePathMintReturnRecord\([\s\S]*?removePathMintHandoff\(handoff\.attemptId\)/);
+  assert.match(thoughtMain, /mintFlowUiMode === "sheet"[\s\S]*?closeMintSheet\(\)/);
+});
+
+test("mint submission and recovery keep one durable hash", () => {
+  const authorizeStart = thoughtMain.indexOf("const authorizeMint = async");
+  const authorizeEnd = thoughtMain.indexOf("type MintTransactionResponse", authorizeStart);
+  const authorizeBody = thoughtMain.slice(authorizeStart, authorizeEnd);
+  assert.ok(authorizeStart >= 0 && authorizeEnd > authorizeStart);
+  assert.ok(
+    authorizeBody.indexOf("mintAuthorizationInFlight = true") <
+      authorizeBody.indexOf("await readPathEligibility"),
+    "authorization locks synchronously before its first eligibility read",
+  );
+
+  const confirmStart = thoughtMain.indexOf("const confirmMint = async");
+  const confirmEnd = thoughtMain.indexOf("const pathMintUrl", confirmStart);
+  const confirmBody = thoughtMain.slice(confirmStart, confirmEnd);
+  assert.ok(confirmStart >= 0 && confirmEnd > confirmStart);
+  assert.match(confirmBody, /if \(mintTransactionInFlight\)/);
+  assert.ok(
+    confirmBody.indexOf("mintTransactionInFlight = true") <
+      confirmBody.indexOf("await rebuildFinalMintProvenance"),
+    "transaction submission locks synchronously before preparation awaits",
+  );
+  assert.match(confirmBody, /const payload = Object\.freeze\(\{/);
+  assert.match(confirmBody, /ethereum\.request\(\{ method: "eth_accounts" \}\)[\s\S]*?ethereum\.request\(\{ method: "eth_chainId" \}\)/);
+  assert.match(confirmBody, /const competingPending = pendingMintTransaction \?\? readPendingMintTransaction\(\);[\s\S]*?const txPromise/);
+  assert.match(confirmBody, /await withMintSubmissionLock\([\s\S]*?lock\.ownsExclusion\(\)[\s\S]*?const txPromise/);
+  assert.match(confirmBody, /walletMintSubmitPromiseUnresolved = true[\s\S]*?waitForMintSubmissionOrRelease\([\s\S]*?void txPromise\.then\([\s\S]*?walletMintSubmitPromiseUnresolved = false/);
+
+  assert.match(thoughtMain, /const clearPendingMintTransactionIfMatches[\s\S]*?pendingMintTransactionMatches\(pendingMintTransaction, expectedHash\)/);
+  assert.match(thoughtMain, /mintReceiptStatusOutcome\(result\.receipt\.status\)[\s\S]*?receiptOutcome !== "success"/);
+  assert.match(thoughtMain, /parseMintTransactionReplacement\(error\)[\s\S]*?migratePendingMintTransactionHash/);
+  assert.match(thoughtMain, /appendConflictingMintTransaction\(returnedTransaction\)[\s\S]*?startConflictingMintReceiptMonitor\(returnedTransaction/);
+  assert.match(thoughtMain, /const recoverUnresolvedMintSubmission[\s\S]*?getTransactionCount\(unresolved\.submission\.account, "latest"\)[\s\S]*?getTransactionCount\(unresolved\.submission\.account, "pending"\)/);
+  assert.match(thoughtMain, /firstNonceSnapshot[\s\S]*?MINT_RECOVERY_NONCE_RECHECK_MS[\s\S]*?secondNonceSnapshot[\s\S]*?releaseLockAfterRecovery\(\)/);
+  assert.match(thoughtMain, /mintFlowData\.errorKind === "path_mint_chain_mismatch"[\s\S]*?mintAttemptId = nextMintAttemptId\("path"\)/);
+  assert.match(thoughtMain, /window\.addEventListener\("storage"[\s\S]*?event\.newValue === null[\s\S]*?return/);
+  assert.match(thoughtMain, /const resetThought = [\s\S]*?if \(blockPendingMintMutation\(\)\)/);
+  assert.match(thoughtMain, /const setAgentOutput = [\s\S]*?if \(blockPendingMintMutation\(\)\)/);
+});
+
+test("submitted PATH return is promoted only by an explicit successful receipt", () => {
+  const checkStart = thoughtMain.indexOf("const checkSubmittedPathMintReturn");
+  const checkEnd = thoughtMain.indexOf("const resumePathMintHandoff", checkStart);
+  const checkBody = thoughtMain.slice(checkStart, checkEnd);
+  assert.ok(checkStart >= 0 && checkEnd > checkStart);
+  assert.match(checkBody, /provider\.getTransactionReceipt\(record\.txHash\)/);
+  assert.match(checkBody, /outcome === "reverted"[\s\S]*?removePathMintReturnRecord/);
+  assert.match(checkBody, /outcome === "success"[\s\S]*?status: "confirmed"[\s\S]*?writePathMintReturnRecord/);
+  assert.match(checkBody, /return \{ outcome: "pending" as const, record \}/);
+  assert.match(thoughtMain, /let resumeSucceeded =[\s\S]*?mintFlowState === "path_ready"/);
+});


### PR DESCRIPTION
## What changed

- completes the THOUGHT work, mint, load, and console panel architecture
- integrates the PICK → SIGN → MINT wallet flow, including in-place $PATH acquisition
- preserves work and panel state across refresh, adds saved-work loading, and keeps Console history concise
- adds local Agent fixtures, text-policy guidance, wallet refresh integration, and canonical product terminology
- hardens duplicate THOUGHT checks and pending mint/$PATH transaction recovery

## Impact

The THOUGHT surface now has a stable, conventional wallet UX with the panel system treated as feature-complete for this milestone.

## Validation

- `pnpm run check` (all gates passed; the Agent client listener was rerun outside the sandbox)
- 327 home/unit tests passed
- 34 THOUGHT runtime/panel tests passed
- `pnpm run build:home`
- `pnpm run pub-boundary:check`
- `gitleaks detect --no-git --redact` on changed source roots
- `gitleaks detect --redact --log-opts=origin/main..HEAD`
- `git diff --check origin/staging...HEAD`