### PR TITLE
Harden THOUGHT SVG preview rendering

### DIFF
--- a/apps/thought/src/helpers/download-svg.ts
+++ b/apps/thought/src/helpers/download-svg.ts
@@ -9,40 +9,6 @@ function downloadBlob(blob: Blob, filename: string) {
     URL.revokeObjectURL(url);
 }
 
-function parseSVG(svgString: string): SVGSVGElement {
-    const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
-    const svg = doc.documentElement as unknown as SVGSVGElement;
-
-    // Ensure namespaces
-    if (!svg.getAttribute("xmlns")) svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-    if (!svg.getAttribute("xmlns:xlink")) svg.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
-
-    return svg;
-}
-
-function getSvgSize(svg: SVGSVGElement): { width: number; height: number } {
-    // Prefer explicit width/height; fallback to viewBox
-    const wAttr = svg.getAttribute("width");
-    const hAttr = svg.getAttribute("height");
-    if (wAttr && hAttr) {
-        return { width: Number(wAttr), height: Number(hAttr) };
-    }
-    const vb = svg.getAttribute("viewBox");
-    if (vb) {
-        const [, , w, h] = vb.split(/\s+/).map(Number);
-        return { width: w, height: h };
-    }
-    // Fallback
-    return { width: 1024, height: 1024 };
-}
-
 export function DownloadSVG(svgCode: string, filename = "thought.svg") {
-    const svg = parseSVG(svgCode);
-    // Optional: lock explicit pixel size from viewBox to avoid scaling surprises
-    const { width, height } = getSvgSize(svg);
-    svg.setAttribute("width", String(width));
-    svg.setAttribute("height", String(height));
-
-    const serialized = new XMLSerializer().serializeToString(svg);
-    downloadBlob(new Blob([serialized], { type: "image/svg+xml;charset=utf-8" }), filename);
+    downloadBlob(new Blob([svgCode], { type: "image/svg+xml;charset=utf-8" }), filename);
 }

--- a/apps/thought/src/svg-lab.css
+++ b/apps/thought/src/svg-lab.css
@@ -309,7 +309,8 @@ body.thought-v2-lab-body {
 }
 
 .svg-lab--v2 .svg-lab__preview,
-.svg-lab--v2 .svg-lab__preview svg {
+.svg-lab--v2 .svg-lab__preview svg,
+.svg-lab--v2 .svg-lab__preview img {
   display: block;
   width: 100%;
   height: 100%;
@@ -377,7 +378,8 @@ body.thought-v2-lab-body {
   place-items: stretch;
 }
 
-.svg-lab__fixture-canvas svg {
+.svg-lab__fixture-canvas svg,
+.svg-lab__fixture-canvas img {
   display: block;
   width: 100%;
   height: 100%;
@@ -449,7 +451,8 @@ body.thought-v2-lab-body .svg-lab--v2 .svg-lab__preview-frame {
 }
 
 body.thought-v2-lab-body .svg-lab--v2 .svg-lab__preview,
-body.thought-v2-lab-body .svg-lab--v2 .svg-lab__preview svg {
+body.thought-v2-lab-body .svg-lab--v2 .svg-lab__preview svg,
+body.thought-v2-lab-body .svg-lab--v2 .svg-lab__preview img {
   width: 100%;
   height: 100%;
 }

--- a/apps/thought/src/thought-v2-lab.ts
+++ b/apps/thought/src/thought-v2-lab.ts
@@ -98,6 +98,13 @@ const fixtureProvenanceJson = (fixture: ThoughtV2TextFixture, agent: string) =>
 const provenanceHref = (provenanceJson: string) =>
   `data:application/json;charset=utf-8,${encodeURIComponent(provenanceJson)}`;
 
+const renderSvgImage = (container: HTMLElement, svg: string, alt: string) => {
+  const image = document.createElement("img");
+  image.alt = alt;
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  container.replaceChildren(image);
+};
+
 const renderRawSvgToPreview = (svg: string, validMeta: string): boolean => {
   const trimmed = svg.trim();
   if (!trimmed) {
@@ -106,22 +113,13 @@ const renderRawSvgToPreview = (svg: string, validMeta: string): boolean => {
     return false;
   }
 
-  const documentSvg = new DOMParser().parseFromString(trimmed, "image/svg+xml");
-  const parseError = documentSvg.querySelector("parsererror");
-  if (parseError) {
+  if (!trimmed.startsWith("<svg") || !trimmed.endsWith("</svg>")) {
     preview.replaceChildren();
-    meta.textContent = `raw svg parse error | ${parseError.textContent?.replace(/\s+/g, " ").trim() ?? "invalid svg"}`;
+    meta.textContent = "raw svg must contain one complete svg element";
     return false;
   }
 
-  const svgElement = documentSvg.documentElement;
-  if (svgElement.localName.toLowerCase() !== "svg") {
-    preview.replaceChildren();
-    meta.textContent = "raw svg must start with an svg element";
-    return false;
-  }
-
-  preview.replaceChildren(document.importNode(svgElement, true));
+  renderSvgImage(preview, trimmed, "THOUGHT V2 SVG preview");
   meta.textContent = validMeta;
   return true;
 };
@@ -136,11 +134,12 @@ const renderFixtureCard = (fixture: ThoughtV2TextFixture, index: number): HTMLEl
   canvas.setAttribute("aria-label", `${fixture.name} fixture preview`);
 
   try {
-    canvas.innerHTML = buildThoughtV2Svg({
+    const fixtureSvg = buildThoughtV2Svg({
       promptLine: fixture.promptLine,
       agentLine: fixture.agentLine,
       ...fixedRender,
     });
+    renderSvgImage(canvas, fixtureSvg, `${fixture.name} fixture preview`);
   } catch (error) {
     canvas.textContent = error instanceof Error ? error.message : "render failed";
   }


### PR DESCRIPTION
## Summary
- render editable and fixture SVGs as isolated image resources instead of injecting SVG markup into the DOM
- download the already-generated SVG text directly without reparsing DOM text as markup
- preserve the existing SVG lab sizing for image-backed previews

## Security validation
- a raw SVG containing `<script>window.__thoughtXss=1</script>` rendered as one image, created no inline script node, and did not execute
- `pnpm run lint`
- `pnpm --filter @inshell/thought type-check`
- `pnpm --filter @inshell/thought build`
- `pnpm run test:thought-runtime` (34 panel/runtime tests)
- staged and source `gitleaks` scans