### PR TITLE
ops: add exact Pages artifact rollback

### DIFF
--- a/.github/workflows/rollback-pages.yml
+++ b/.github/workflows/rollback-pages.yml
@@ -1,0 +1,120 @@
+name: rollback-pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Pages project to roll back
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - home
+          - thought
+      home_deployment_url:
+        description: Successful production deployment URL for the home project
+        required: false
+        type: string
+      thought_deployment_url:
+        description: Successful production deployment URL for the THOUGHT project
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rollback-pages-${{ github.event.inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  rollback-home:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'home' }}
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT_HOME || 'inshell-art' }}
+      TARGET_DEPLOYMENT_URL: ${{ github.event.inputs.home_deployment_url }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Roll back home production deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_API_TOKEN"
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$TARGET_DEPLOYMENT_URL"
+          [[ "$TARGET_DEPLOYMENT_URL" =~ ^https://[0-9a-f]{8}\.inshell-art\.pages\.dev/?$ ]]
+
+          target_host="${TARGET_DEPLOYMENT_URL#https://}"
+          target_host="${target_host%/}"
+          deployments="$(
+            curl --fail-with-body --silent --show-error \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production&per_page=100"
+          )"
+          deployment_id="$(
+            jq --raw-output \
+              --arg url "https://$target_host" \
+              --arg host "$target_host" \
+              '.result[] | select(.url == $url or ((.aliases // []) | index($host))) | .id' \
+              <<<"$deployments" |
+              head -n 1
+          )"
+          test -n "$deployment_id"
+
+          rollback="$(
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --header "Content-Type: application/json" \
+              --data '{}' \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments/$deployment_id/rollback"
+          )"
+          jq --exit-status '.success == true' <<<"$rollback" >/dev/null
+
+  rollback-thought:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'thought' }}
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT_THOUGHT || 'thought-inshell-art' }}
+      TARGET_DEPLOYMENT_URL: ${{ github.event.inputs.thought_deployment_url }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Roll back THOUGHT production deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_API_TOKEN"
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$TARGET_DEPLOYMENT_URL"
+          [[ "$TARGET_DEPLOYMENT_URL" =~ ^https://[0-9a-f]{8}\.thought-inshell-art\.pages\.dev/?$ ]]
+
+          target_host="${TARGET_DEPLOYMENT_URL#https://}"
+          target_host="${target_host%/}"
+          deployments="$(
+            curl --fail-with-body --silent --show-error \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production&per_page=100"
+          )"
+          deployment_id="$(
+            jq --raw-output \
+              --arg url "https://$target_host" \
+              --arg host "$target_host" \
+              '.result[] | select(.url == $url or ((.aliases // []) | index($host))) | .id' \
+              <<<"$deployments" |
+              head -n 1
+          )"
+          test -n "$deployment_id"
+
+          rollback="$(
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --header "Content-Type: application/json" \
+              --data '{}' \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments/$deployment_id/rollback"
+          )"
+          jq --exit-status '.success == true' <<<"$rollback" >/dev/null


### PR DESCRIPTION
Emergency production recovery only. Adds a manually dispatched workflow that resolves a known successful Cloudflare Pages production deployment by its immutable deployment URL and calls the Pages rollback API. No application source or build artifact changes.\n\nTarget after merge:\n- home: https://6f45a57c.inshell-art.pages.dev\n- THOUGHT: https://84588c6c.thought-inshell-art.pages.dev\n- original successful production run: 28662682842 (2026-07-03)\n\nChecks run locally:\n- YAML parse\n- git diff --check\n- PUB boundary\n- gitleaks