### PR TITLE
fix: use supported Pages rollback query

### DIFF
--- a/.github/workflows/rollback-pages.yml
+++ b/.github/workflows/rollback-pages.yml
@@ -55,7 +55,7 @@ jobs:
               "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production"
           )"
           jq --exit-status '.success == true' <<<"$deployments" >/dev/null
-+          deployment_id="$(
+          deployment_id="$(
             jq --raw-output \
               --arg url "https://$target_host" \
               '.result[] | select(.url == $url or ((.aliases // []) | index($url))) | .id' \

--- a/.github/workflows/rollback-pages.yml
+++ b/.github/workflows/rollback-pages.yml
@@ -52,13 +52,13 @@ jobs:
           deployments="$(
             curl --fail-with-body --silent --show-error \
               --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production&per_page=100"
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production"
           )"
-          deployment_id="$(
+          jq --exit-status '.success == true' <<<"$deployments" >/dev/null
++          deployment_id="$(
             jq --raw-output \
               --arg url "https://$target_host" \
-              --arg host "$target_host" \
-              '.result[] | select(.url == $url or ((.aliases // []) | index($host))) | .id' \
+              '.result[] | select(.url == $url or ((.aliases // []) | index($url))) | .id' \
               <<<"$deployments" |
               head -n 1
           )"
@@ -97,13 +97,13 @@ jobs:
           deployments="$(
             curl --fail-with-body --silent --show-error \
               --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production&per_page=100"
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PAGES_PROJECT/deployments?env=production"
           )"
+          jq --exit-status '.success == true' <<<"$deployments" >/dev/null
           deployment_id="$(
             jq --raw-output \
               --arg url "https://$target_host" \
-              --arg host "$target_host" \
-              '.result[] | select(.url == $url or ((.aliases // []) | index($host))) | .id' \
+              '.result[] | select(.url == $url or ((.aliases // []) | index($url))) | .id' \
               <<<"$deployments" |
               head -n 1
           )"


### PR DESCRIPTION
Fixes the emergency rollback workflow after Cloudflare rejected an unsupported oversized deployment-list page. Uses the supported default production deployment query, validates the API response, and matches the immutable deployment URL exactly.