### PR TITLE
Promote brace-expansion security repair

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
       "@babel/core@^7.0.0": "7.29.6",
       "ajv@^6.0.0": "6.14.0",
       "axios@^1.0.0": "1.18.0",
-      "brace-expansion@^1.0.0": "1.1.16",
-      "brace-expansion@^2.0.0": "2.1.2",
+      "brace-expansion@^1.0.0": "5.0.8",
+      "brace-expansion@^2.0.0": "5.0.8",
       "brace-expansion@^5.0.0": "5.0.8",
       "defu@^6.0.0": "6.1.5",
       "diff@^4.0.0": "4.0.4",
@@ -101,6 +101,9 @@
       "viem>ws": "8.21.0",
       "yaml@^1.0.0": "1.10.3",
       "yaml@^2.0.0": "2.8.4"
+    },
+    "patchedDependencies": {
+      "brace-expansion@5.0.8": "patches/brace-expansion@5.0.8.patch"
     }
   }
 }

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index be9df86be09c7655787a65c55ae6da01858894c3..82171d18d3a0ef15daaba1e85ccb22cf04bc8a23 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -260,4 +260,11 @@ function expand_(str, max, maxLength, isTop) {
+     }
+     return acc;
+ }
++// Preserve the callable CommonJS API expected by minimatch 3/5 while keeping
++// the named exports used by current consumers.
++module.exports = Object.assign(expand, {
++    expand,
++    EXPANSION_MAX: exports.EXPANSION_MAX,
++    EXPANSION_MAX_LENGTH: exports.EXPANSION_MAX_LENGTH,
++});
+ //# sourceMappingURL=index.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ overrides:
   '@babel/core@^7.0.0': 7.29.6
   ajv@^6.0.0: 6.14.0
   axios@^1.0.0: 1.18.0
-  brace-expansion@^1.0.0: 1.1.16
-  brace-expansion@^2.0.0: 2.1.2
+  brace-expansion@^1.0.0: 5.0.8
+  brace-expansion@^2.0.0: 5.0.8
   brace-expansion@^5.0.0: 5.0.8
   defu@^6.0.0: 6.1.5
   diff@^4.0.0: 4.0.4
@@ -41,6 +41,11 @@ overrides:
   viem>ws: 8.21.0
   yaml@^1.0.0: 1.10.3
   yaml@^2.0.0: 2.8.4
+
+patchedDependencies:
+  brace-expansion@5.0.8:
+    hash: sw5gi76qr6m2rolksbtcd5klgq
+    path: patches/brace-expansion@5.0.8.patch
 
 importers:
 
@@ -2860,12 +2865,6 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 20 || >=22}
@@ -3039,9 +3038,6 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -9503,16 +9499,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.8(patch_hash=sw5gi76qr6m2rolksbtcd5klgq):
     dependencies:
       balanced-match: 4.0.4
 
@@ -9665,8 +9652,6 @@ snapshots:
   commander@7.2.0: {}
 
   common-tags@1.8.2: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
 
@@ -11357,15 +11342,15 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8(patch_hash=sw5gi76qr6m2rolksbtcd5klgq)
 
   minimatch@5.1.8:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8(patch_hash=sw5gi76qr6m2rolksbtcd5klgq)
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.8(patch_hash=sw5gi76qr6m2rolksbtcd5klgq)
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Promotes the verified staging repair from PR #122. All brace-expansion dependency paths now resolve to patched 5.0.8, with compatibility preserved for legacy minimatch consumers.