### PR TITLE
Restore June 10 production home frontend

### DIFF
--- a/apps/home/tests/middlewareFunction.test.ts
+++ b/apps/home/tests/middlewareFunction.test.ts
@@ -46,10 +46,17 @@ class TestHeaders {
 class TestRequest {
   readonly url: string;
   readonly method: string;
+  readonly headers: TestHeaders;
 
-  constructor(input: string | { url: string; method?: string }, init?: { method?: string }) {
+  constructor(
+    input: string | { url: string; method?: string; headers?: unknown },
+    init?: { method?: string; headers?: unknown },
+  ) {
     this.url = typeof input === "string" ? input : input.url;
     this.method = init?.method ?? (typeof input === "string" ? "GET" : (input.method ?? "GET"));
+    this.headers = new TestHeaders(
+      init?.headers ?? (typeof input === "string" ? undefined : input.headers),
+    );
   }
 }
 
@@ -70,6 +77,10 @@ class TestResponse {
     return this.status >= 200 && this.status < 300;
   }
 
+  async text() {
+    return typeof this.body === "string" ? this.body : String(this.body ?? "");
+  }
+
   static redirect(url: string, status = 302) {
     return new TestResponse(null, {
       status,
@@ -80,11 +91,17 @@ class TestResponse {
   }
 }
 
-function middlewareContext(url: string, init?: { method?: string; env?: Record<string, unknown> }) {
+function middlewareContext(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; env?: Record<string, unknown> },
+) {
   const next = jest.fn(async () => new Response("next", { status: 200 }));
   const assetsFetch = jest.fn(async () => new Response("asset", { status: 200 }));
   return {
-    request: new Request(url, { method: init?.method ?? "GET" }),
+    request: new Request(url, {
+      method: init?.method ?? "GET",
+      headers: init?.headers,
+    }),
     env: {
       ASSETS: {
         fetch: assetsFetch,
@@ -94,6 +111,28 @@ function middlewareContext(url: string, init?: { method?: string; env?: Record<s
     next,
     assetsFetch,
   };
+}
+
+function installLegacyHtmlFetchMock() {
+  const fetchMock = jest.fn(
+    async () =>
+      new Response("<!doctype html><title>legacy</title>", {
+        status: 200,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "no-store, max-age=0",
+          "clear-site-data": '"cache"',
+          etag: '"legacy-etag"',
+          "last-modified": "Wed, 10 Jun 2026 00:00:00 GMT",
+          nel: '{"report_to":"legacy"}',
+          "report-to": '{"group":"legacy"}',
+          "set-cookie": "legacy-session=must-not-reach-client",
+          "x-robots-tag": "noindex",
+        },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
 }
 
 describe("Pages middleware canonical routes", () => {
@@ -190,13 +229,17 @@ describe("Pages middleware canonical routes", () => {
     expect(ctx.next).not.toHaveBeenCalled();
   });
 
-  test("serves canonical root gallery route through the root app shell", async () => {
+  test("keeps canonical gallery on the current root app shell", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
     const ctx = middlewareContext("https://inshell.art/gallery");
     const response = await onRequest(ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
     expect(response.headers.get("clear-site-data")).toBeNull();
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
     expect(ctx.next).not.toHaveBeenCalled();
   });
@@ -225,13 +268,123 @@ describe("Pages middleware canonical routes", () => {
     expect(ctx.next).not.toHaveBeenCalled();
   });
 
-  test("serves the canonical PATH app route through the root app shell", async () => {
-    const ctx = middlewareContext("https://inshell.art/path");
+  test("serves canonical PATH from the June 10 home artifact without forwarding credentials", async () => {
+    const fetchMock = installLegacyHtmlFetchMock();
+    const ctx = middlewareContext("https://inshell.art/path?returnTo=%2Fthought%2F9", {
+      headers: {
+        authorization: "Bearer must-not-leave-current-origin",
+        cookie: "session=must-not-leave-current-origin",
+        "cf-access-jwt-assertion": "must-not-leave-current-origin",
+      },
+    });
     const response = await onRequest(ctx);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBe("20260610-02b53bb");
+    expect(response.headers.get("x-inshell-frontend-recovery-source")).toBe("home");
+    expect(String(response.body)).not.toContain("inshell-preview-watermark");
+    for (const strippedHeader of [
+      "clear-site-data",
+      "etag",
+      "last-modified",
+      "nel",
+      "report-to",
+      "set-cookie",
+      "x-robots-tag",
+    ]) {
+      expect(response.headers.get(strippedHeader)).toBeNull();
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://c02c54b0.inshell-art.pages.dev/",
+      expect.objectContaining({
+        method: "GET",
+        redirect: "manual",
+        headers: {
+          accept: "text/html, application/xhtml+xml;q=0.9, */*;q=0.1",
+        },
+      }),
+    );
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+    expect(ctx.next).not.toHaveBeenCalled();
+  });
+
+  test("limits document recovery to the six June 10 home route classes", async () => {
+    for (const pathname of ["/", "/path", "/path/9", "/pulse", "/color-font", "/verify"]) {
+      const fetchMock = installLegacyHtmlFetchMock();
+      const ctx = middlewareContext(`https://inshell.art${pathname}`);
+      const response = await onRequest(ctx);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-inshell-frontend-recovery")).toBe("20260610-02b53bb");
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://c02c54b0.inshell-art.pages.dev/",
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(ctx.next).not.toHaveBeenCalled();
+      expect(ctx.assetsFetch).not.toHaveBeenCalled();
+    }
+  });
+
+  test("keeps non-GET home route requests on the current app-shell behavior", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://inshell.art/path", { method: "POST" });
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
+    expect(ctx.next).not.toHaveBeenCalled();
+  });
+
+  test("keeps current API routes ahead of the frontend recovery proxy", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://inshell.art/api/ops/status", {
+      headers: { authorization: "Bearer current-api-only" },
+    });
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(ctx.next).toHaveBeenCalledTimes(1);
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+  });
+
+  test("leaves the normal preview host on the current frontend", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://preview.inshell.art/path", {
+      env: { CF_PAGES_BRANCH: "staging" },
+    });
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+  });
+
+  test("enables recovery on only the dedicated hotfix Pages branch preview", async () => {
+    const fetchMock = installLegacyHtmlFetchMock();
+    const ctx = middlewareContext(
+      "https://codex-prod-restore-20260610-fe.inshell-art.pages.dev/path",
+      { env: { CF_PAGES_BRANCH: "codex/prod-restore-20260610-fe" } },
+    );
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-inshell-frontend-recovery-source")).toBe("home");
+    expect(String(response.body)).toContain(
+      '<div class="inshell-preview-watermark" aria-hidden="true">preview</div>',
+    );
+    expect(response.headers.get("etag")).toBeNull();
+    expect(response.headers.get("last-modified")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
     expect(ctx.next).not.toHaveBeenCalled();
   });
 
@@ -254,6 +407,7 @@ describe("Pages middleware canonical routes", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("x-inshell-dev-path-boundary")).toBe("pub-proxy");
+      expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
       expect(response.headers.get("etag")).toBe("\"pub-etag\"");
       expect(ctx.next).not.toHaveBeenCalled();
       expect(ctx.assetsFetch).not.toHaveBeenCalled();
@@ -467,28 +621,105 @@ describe("Pages middleware canonical routes", () => {
     expect(ctx.assetsFetch).not.toHaveBeenCalled();
   });
 
-  test("serves canonical root THOUGHT routes through the mounted THOUGHT app shell", async () => {
+  test("keeps canonical root THOUGHT routes on the mounted THOUGHT app shell", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
     const ctx = middlewareContext("https://inshell.art/thought/9");
     const response = await onRequest(ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate=300");
     expect(response.headers.get("clear-site-data")).toBeNull();
+    expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
     expect(ctx.assetsFetch.mock.calls[0]?.[0].url).toBe("https://inshell.art/thought/");
     expect(ctx.next).not.toHaveBeenCalled();
   });
 
-  test("serves both canonical THOUGHT root forms without fetching the redirecting index URL", async () => {
+  test("keeps both canonical THOUGHT root forms on the mounted THOUGHT app shell", async () => {
     for (const pathname of ["/thought", "/thought/"]) {
+      const fetchMock = jest.fn();
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
       const ctx = middlewareContext(`https://inshell.art${pathname}`);
       const response = await onRequest(ctx);
 
       expect(response.status).toBe(200);
+      expect(response.headers.get("x-inshell-frontend-recovery")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
       expect(ctx.assetsFetch).toHaveBeenCalledTimes(1);
       expect(ctx.assetsFetch.mock.calls[0]?.[0].url).toBe("https://inshell.art/thought/");
       expect(ctx.next).not.toHaveBeenCalled();
     }
+  });
+
+  test("does not proxy a current cached entry hash into a historical SPA fallback", async () => {
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://inshell.art/assets/index-D8Dm5cPs.js");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ctx.next).toHaveBeenCalledTimes(1);
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("proxies only the exact June 10 home entry bundle", async () => {
+    const fetchMock = jest.fn(
+      async () =>
+        new Response("legacy bundle", {
+          status: 200,
+          headers: {
+            "content-type": "application/javascript",
+            "cache-control": "public, max-age=0, must-revalidate",
+            "x-robots-tag": "noindex",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext("https://inshell.art/assets/index-6XkpjGyk.js?cache=ignored");
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/javascript");
+    expect(response.headers.get("x-robots-tag")).toBeNull();
+    expect(response.headers.get("x-inshell-frontend-recovery-source")).toBe("home");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://c02c54b0.inshell-art.pages.dev/assets/index-6XkpjGyk.js",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          accept: "application/javascript, text/javascript;q=0.9, */*;q=0.1",
+        },
+      }),
+    );
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 instead of historical SPA HTML for a legacy font asset", async () => {
+    const fetchMock = jest.fn(
+      async () =>
+        new Response("<!doctype html><title>fallback</title>", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const ctx = middlewareContext(
+      "https://inshell.art/assets/source-code-pro-latin-600-normal-D9kwMNJ_.woff2",
+    );
+    const response = await onRequest(ctx);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("x-inshell-frontend-recovery-status")).toBe(
+      "mime-rejected",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ctx.next).not.toHaveBeenCalled();
+    expect(ctx.assetsFetch).not.toHaveBeenCalled();
   });
 
   test("redirects works alias to the gallery route", async () => {

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -4,6 +4,9 @@ const PUBLIC_FEED_SEPOLIA_RSS_URL = "https://inshell-public-feed.pages.dev/rss.s
 const PUBLIC_FEED_BASE_URL = "https://d807d286.inshell-public-feed.pages.dev";
 const PUB_UPSTREAM_DEFAULT = "https://inshell-pub.pages.dev";
 const APP_SHELL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
+const LEGACY_PROD_HOME_ORIGIN = "https://c02c54b0.inshell-art.pages.dev";
+const LEGACY_PROD_FRONTEND_MARKER = "20260610-02b53bb";
+const LEGACY_PROD_HOTFIX_BRANCH = "codex/prod-restore-20260610-fe";
 
 type PagesAssets = {
   fetch: (request: Request) => Promise<Response>;
@@ -13,12 +16,33 @@ type MiddlewareContext = {
   request: Request;
   env: {
     ASSETS?: PagesAssets;
+    CF_PAGES_BRANCH?: string;
     PUB_UPSTREAM?: string;
     PUB_BOUNDARY_CONTRACT_URL?: string;
   };
   next: (request?: Request) => Promise<Response>;
 };
 type UrlInstance = InstanceType<typeof globalThis.URL>;
+type LegacyProdResourceKind =
+  | "document"
+  | "javascript"
+  | "stylesheet"
+  | "font";
+type LegacyProdResource = {
+  kind: LegacyProdResourceKind;
+  injectPreviewWatermark?: boolean;
+};
+
+const LEGACY_PROD_ENTRY_ASSETS = new Map<string, LegacyProdResource>([
+  ["/assets/index-6XkpjGyk.js", { kind: "javascript" }],
+  ["/assets/index-CwenU7ox.css", { kind: "stylesheet" }],
+  ["/assets/source-code-pro-vietnamese-600-normal-NO4inUC1.woff2", { kind: "font" }],
+  ["/assets/source-code-pro-vietnamese-600-normal-RwzYAKw5.woff", { kind: "font" }],
+  ["/assets/source-code-pro-latin-ext-600-normal-ChD8h2GM.woff2", { kind: "font" }],
+  ["/assets/source-code-pro-latin-ext-600-normal-s-QVw45K.woff", { kind: "font" }],
+  ["/assets/source-code-pro-latin-600-normal-D9kwMNJ_.woff2", { kind: "font" }],
+  ["/assets/source-code-pro-latin-600-normal-DdCNScYx.woff", { kind: "font" }],
+]);
 
 export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   const url = new globalThis.URL(ctx.request.url);
@@ -53,6 +77,11 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
     return worksRedirect;
   }
 
+  // Keep every current Function route ahead of the temporary frontend recovery proxy.
+  if (isApiPathname(pathname)) {
+    return ctx.next();
+  }
+
   if (pathname === "/rss.xml") {
     return proxyFeed(PUBLIC_FEED_RSS_URL, ctx.request);
   }
@@ -66,6 +95,10 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   if (publicFeedArtifactUrl) {
     return proxyPublicFeedArtifact(publicFeedArtifactUrl, ctx.request);
   }
+  const legacyProdResource = getLegacyProdResource(ctx.request, url, pathname, ctx.env);
+  if (legacyProdResource) {
+    return proxyLegacyProdFrontend(ctx.request, url, legacyProdResource);
+  }
   if (isThoughtAppShellRoute(pathname)) {
     return serveThoughtAppShell(ctx);
   }
@@ -74,6 +107,163 @@ export async function onRequest(ctx: MiddlewareContext): Promise<Response> {
   }
 
   return ctx.next();
+}
+
+function getLegacyProdResource(
+  request: Request,
+  url: UrlInstance,
+  pathname: string,
+  env: MiddlewareContext["env"],
+): LegacyProdResource | null {
+  if (!isLegacyProdRecoveryHost(url.hostname, env)) return null;
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  if (isLegacyProdHomeDocumentPathname(pathname)) {
+    return {
+      kind: "document",
+      injectPreviewWatermark: isLegacyProdHotfixBranchHost(url.hostname, env),
+    };
+  }
+
+  return LEGACY_PROD_ENTRY_ASSETS.get(url.pathname) ?? null;
+}
+
+function isLegacyProdRecoveryHost(hostname: string, env: MiddlewareContext["env"]) {
+  const host = hostname.toLowerCase();
+  if (host === "inshell.art") return true;
+  return isLegacyProdHotfixBranchHost(host, env);
+}
+
+function isLegacyProdHotfixBranchHost(hostname: string, env: MiddlewareContext["env"]) {
+  const host = hostname.toLowerCase();
+  return (
+    env.CF_PAGES_BRANCH === LEGACY_PROD_HOTFIX_BRANCH &&
+    (host === "inshell-art.pages.dev" || host.endsWith(".inshell-art.pages.dev"))
+  );
+}
+
+function isLegacyProdHomeDocumentPathname(pathname: string) {
+  return (
+    pathname === "/" ||
+    pathname === "/pulse" ||
+    pathname === "/color-font" ||
+    pathname === "/verify" ||
+    pathname === "/path" ||
+    isTokenRoute(pathname, "path")
+  );
+}
+
+async function proxyLegacyProdFrontend(
+  request: Request,
+  requestUrl: UrlInstance,
+  resource: LegacyProdResource,
+): Promise<Response> {
+  const upstreamUrl = new globalThis.URL(
+    resource.kind === "document" ? "/" : encodedPathnameForProxy(requestUrl.pathname),
+    LEGACY_PROD_HOME_ORIGIN,
+  );
+  const abortController = new globalThis.AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 8000);
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl.toString(), {
+      method: request.method,
+      redirect: "manual",
+      signal: abortController.signal,
+      // Do not forward cookies, authorization, Access assertions, or request query data.
+      headers: {
+        accept: legacyProdAcceptHeader(resource.kind),
+      },
+    });
+  } catch {
+    return legacyProdFrontendUnavailable(502, "upstream-unavailable");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!upstream.ok) {
+    return legacyProdFrontendUnavailable(resource.kind === "document" ? 502 : 404, "upstream-error");
+  }
+
+  const contentType = new Headers(upstream.headers).get("content-type") ?? "";
+  if (!isExpectedLegacyProdContentType(resource.kind, contentType)) {
+    return legacyProdFrontendUnavailable(resource.kind === "document" ? 502 : 404, "mime-rejected");
+  }
+
+  let body: ConstructorParameters<typeof Response>[0] =
+    request.method === "HEAD" ? null : upstream.body;
+  if (request.method === "GET" && resource.injectPreviewWatermark) {
+    try {
+      body = injectLegacyProdPreviewWatermark(await upstream.text());
+    } catch {
+      return legacyProdFrontendUnavailable(502, "body-unavailable");
+    }
+  }
+
+  return new Response(body, {
+    status: 200,
+    headers: legacyProdFrontendResponseHeaders(upstream, contentType, resource.kind),
+  });
+}
+
+function injectLegacyProdPreviewWatermark(html: string) {
+  const watermark = '<div class="inshell-preview-watermark" aria-hidden="true">preview</div>';
+  if (html.includes(watermark)) return html;
+  if (/<\/body>/i.test(html)) return html.replace(/<\/body>/i, `${watermark}</body>`);
+  return `${html}${watermark}`;
+}
+
+function legacyProdAcceptHeader(kind: LegacyProdResourceKind) {
+  if (kind === "document") return "text/html, application/xhtml+xml;q=0.9, */*;q=0.1";
+  if (kind === "javascript") return "application/javascript, text/javascript;q=0.9, */*;q=0.1";
+  if (kind === "stylesheet") return "text/css, */*;q=0.1";
+  return "font/woff2, font/woff, */*;q=0.1";
+}
+
+function isExpectedLegacyProdContentType(kind: LegacyProdResourceKind, contentType: string) {
+  const normalized = contentType.toLowerCase();
+  if (kind === "document") return normalized.startsWith("text/html");
+  if (kind === "javascript") return normalized.includes("javascript");
+  if (kind === "stylesheet") return normalized.startsWith("text/css");
+  return normalized.startsWith("font/woff");
+}
+
+function legacyProdFrontendResponseHeaders(
+  upstream: Response,
+  contentType: string,
+  kind: LegacyProdResourceKind,
+) {
+  const upstreamHeaders = new Headers(upstream.headers);
+  const headers = new Headers();
+  headers.set("content-type", contentType);
+  headers.set("cache-control", upstreamHeaders.get("cache-control") ?? "no-store");
+  headers.set("referrer-policy", "no-referrer");
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("x-frame-options", "DENY");
+  headers.set("x-xss-protection", "1; mode=block");
+  headers.set("permissions-policy", "camera=(), microphone=(), geolocation=()");
+  headers.set("strict-transport-security", "max-age=31536000; includeSubDomains; preload");
+  headers.set("x-inshell-frontend-recovery", LEGACY_PROD_FRONTEND_MARKER);
+  headers.set("x-inshell-frontend-recovery-source", "home");
+  if (kind !== "document") {
+    const etag = upstreamHeaders.get("etag");
+    if (etag) headers.set("etag", etag);
+    const lastModified = upstreamHeaders.get("last-modified");
+    if (lastModified) headers.set("last-modified", lastModified);
+  }
+  return headers;
+}
+
+function legacyProdFrontendUnavailable(status: number, reason: string) {
+  return new Response(status === 404 ? "Frontend asset not found." : "Frontend unavailable.", {
+    status,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+      "x-inshell-frontend-recovery": LEGACY_PROD_FRONTEND_MARKER,
+      "x-inshell-frontend-recovery-status": reason,
+    },
+  });
 }
 
 function isPubReservedPathname(pathname: string) {


### PR DESCRIPTION
## Summary

Emergency production recovery for the unintended Cloudflare Pages Git deployment of `main` commit `53911ba`.

- Restores the operator-approved June 10 home/PATH frontend behavior from commit `02b53bb`.
- Applies only to `/`, `/path`, `/path/:id`, `/pulse`, `/color-font`, `/verify`, and an exact legacy asset/font allowlist.
- Preserves the current THOUGHT, gallery, API, feed/source, ops-status, and PUB route implementations.
- Shows the required `preview` watermark on this hotfix branch preview only; production remains unwatermarked.

## Safety boundary

This is deliberately not a whole-artifact rollback. The June 10 artifact predates the current PUB boundary and API surface, so the current Pages Functions/middleware stay in place.

The recovery proxy strips operator credentials and unsafe upstream response headers, validates paths and MIME types, and fails closed. Cloudflare Pages automatic production deployments are now disabled account-side for both Pages projects; preview deployments remain enabled.

## Validation

- pre-commit lint, type-check, and fast tests: pass
- middleware tests: 33/33
- pre-Sepolia tests: 188/188
- preview home build: pass
- deployment check: 63 pass, 8 warn, 0 fail
- PUB boundary: 419 paths pass
- gitleaks: pass
- diff check: pass

## Promotion gate

This PR intentionally bypasses `staging` only as an emergency production hotfix. Do not merge until the operator validates the branch preview and explicitly approves production promotion. Reconcile the exact fix back to `staging` immediately after any approved merge.