### PR TITLE
test(thought): align staging checks with current release

### DIFF
--- a/apps/home/tests/thoughtAgentFunction.test.ts
+++ b/apps/home/tests/thoughtAgentFunction.test.ts
@@ -370,6 +370,7 @@ async function submitResult(
 ) {
   const raw = JSON.stringify({
     schema: THOUGHT_AGENT_RESULT_VERSION,
+    release: THOUGHT_V2_PROTOCOL_RELEASE.release,
     agentLine,
   });
   const response = await onSubmitResult({
@@ -591,20 +592,20 @@ describe("THOUGHT Agent Pages API", () => {
     });
   });
 
-  test("serves the maintained Codex protocol client", async () => {
+  test("retires the compatibility Codex protocol client", async () => {
     const response = onGetCodexClient() as unknown as TestResponse;
-    const script = await response.text();
+    const payload = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
-    expect(script).toContain("THOUGHT_LAUNCH_TOKEN");
-    expect(script).toContain("THOUGHT_INPUT_READY");
-    expect(script).toContain("THOUGHT_RESULT_OK");
-    expect(script).toContain("Idempotency-Key");
-    expect(script).not.toContain("test-claim-token");
-    expect(script).not.toContain("test-bridge-token");
+    expect(payload).toEqual({
+      error: {
+        code: "PROTOCOL_UNSUPPORTED",
+        message: "This compatibility client is retired. Open the Agent task from THOUGHT.",
+      },
+    });
   });
 
   test("keeps result submission idempotent and rejects conflicting bytes", async () => {

--- a/apps/home/tests/thoughtAgentProtocol.test.ts
+++ b/apps/home/tests/thoughtAgentProtocol.test.ts
@@ -16,6 +16,16 @@ import {
 } from "../../../packages/thought-agent-protocol/src/index";
 import { hasThoughtPollDeadlineExpired } from "../../thought/src/thought-poll-wake";
 
+const releasedAgentResult = (
+  agentLine: string,
+  declaration?: Record<string, unknown>,
+) => ({
+  schema: THOUGHT_AGENT_RESULT_VERSION,
+  release: THOUGHT_V2_PROTOCOL_RELEASE.release,
+  agentLine,
+  ...(declaration ? { declaration } : {}),
+});
+
 describe("THOUGHT Agent V2 protocol helpers", () => {
   const originalCrypto = globalThis.crypto;
 
@@ -36,7 +46,9 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
   test("keeps the run-state transition matrix narrow", () => {
     expect(canTransitionThoughtAgentState("created", "claimed")).toBe(true);
     expect(canTransitionThoughtAgentState("created", "running")).toBe(false);
-    expect(canTransitionThoughtAgentState("claimed", "running")).toBe(true);
+    expect(canTransitionThoughtAgentState("claimed", "ready")).toBe(true);
+    expect(canTransitionThoughtAgentState("claimed", "running")).toBe(false);
+    expect(canTransitionThoughtAgentState("ready", "running")).toBe(true);
     expect(canTransitionThoughtAgentState("running", "returned")).toBe(true);
     expect(canTransitionThoughtAgentState("returned", "running")).toBe(false);
   });
@@ -49,7 +61,7 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
   });
 
   test("sends the exact prompt line to the Agent without framing or repair", async () => {
-    const promptLine = "quiet signal 你好";
+    const promptLine = "quiet signal";
     const input = await buildThoughtAgentInput({ promptLine });
     const again = await buildThoughtAgentInput({ promptLine });
 
@@ -74,11 +86,8 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
   });
 
   test("strictly parses the V2 result without trimming or extraction", async () => {
-    const agentLine = "quiet signal 你好";
-    const raw = JSON.stringify({
-      schema: THOUGHT_AGENT_RESULT_VERSION,
-      agentLine,
-    });
+    const agentLine = "quiet signal";
+    const raw = JSON.stringify(releasedAgentResult(agentLine));
     const parsed = await parseAgentOutput(raw);
 
     expect(parsed.raw).toBe(raw);
@@ -89,45 +98,38 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
 
     await expect(
       parseAgentOutput(
-        JSON.stringify({
-          schema: THOUGHT_AGENT_RESULT_VERSION,
-          agentLine,
-          extra: true,
-        }),
+        JSON.stringify({ ...releasedAgentResult(agentLine), extra: true }),
       ),
     ).rejects.toThrow(/required schema/);
     await expect(
-      parseAgentOutput(JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: " quiet" })),
-    ).rejects.toThrow(/invalid spacing/);
+      parseAgentOutput(JSON.stringify(releasedAgentResult(" quiet"))),
+    ).rejects.toThrow(/outer space/);
     await expect(
-      parseAgentOutput(JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: "quiet  signal" })),
-    ).resolves.toBeDefined();
+      parseAgentOutput(JSON.stringify(releasedAgentResult("quiet  signal"))),
+    ).rejects.toThrow(/repeated internal spaces/);
     await expect(
-      parseAgentOutput(JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: "quiet\nsignal" })),
-    ).rejects.toThrow(/control character/);
+      parseAgentOutput(JSON.stringify(releasedAgentResult("quiet\nsignal"))),
+    ).rejects.toThrow(/unsupported U\+000A/);
   });
 
   test("accepts the optional declaration only in its exact schema", async () => {
     const declaration = {
       schema: THOUGHT_AGENT_DECLARATION_VERSION,
-      agentLabel: "Codex",
-      specId: THOUGHT_V2_PROTOCOL_RELEASE.spec.evmSpecId,
-      specHash: THOUGHT_V2_PROTOCOL_RELEASE.spec.evmSpecHash,
+      status: "declared-unverified",
+      label: "Codex",
       declaredOneCreativeResult: true,
     } as const;
-    const raw = JSON.stringify({
-      schema: THOUGHT_AGENT_RESULT_VERSION,
-      agentLine: "quiet signal",
-      declaration,
-    });
+    const raw = JSON.stringify(releasedAgentResult("quiet signal", declaration));
 
     await expect(parseAgentOutput(raw)).resolves.toMatchObject({ declaration });
     await expect(
       parseAgentOutput(
         JSON.stringify({
-          schema: THOUGHT_AGENT_RESULT_VERSION,
-          agentLine: "quiet signal",
-          declaration: { ...declaration, declaredOneCreativeResult: false },
+          ...releasedAgentResult("quiet signal"),
+          declaration: {
+            ...declaration,
+            declaredOneCreativeResult: false,
+          },
         }),
       ),
     ).rejects.toThrow(/declaration/);
@@ -143,17 +145,17 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
     ).rejects.toThrow(/bytes/);
     await expect(
       parseAgentOutput(
-        JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: agentAtLimit }),
+        JSON.stringify(releasedAgentResult(agentAtLimit)),
       ),
     ).resolves.toBeDefined();
     await expect(
       parseAgentOutput(
-        JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: `${agentAtLimit}A` }),
+        JSON.stringify(releasedAgentResult(`${agentAtLimit}A`)),
       ),
     ).rejects.toThrow(/bytes/);
     await expect(
       parseAgentOutput(
-        JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: "A".repeat(27) }),
+        JSON.stringify(releasedAgentResult("A".repeat(27))),
       ),
     ).resolves.toBeDefined();
   });
@@ -162,14 +164,14 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
     const task = buildThoughtCodexTask({
       product: "Codex",
       runId: "tar_protocol_test",
-      promptLine: "hello world",
       runUrl: "http://127.0.0.1:5173/api/thought-agent/v2/runs/tar_protocol_test",
-      clientUrl: "http://127.0.0.1:5173/api/thought-agent/v2/client",
       launchToken: "launch-token",
     });
 
-    expect(task).toContain("1-64 UTF-8 bytes");
-    expect(task).toContain("Display units are renderer measurements only, not an acceptance limit.");
+    expect(task).toContain("1-64-byte Terminal English agentLine");
+    expect(task).toContain(
+      `<work_profile> = ${THOUGHT_V2_PROTOCOL_RELEASE.identifiers.workProfile}`,
+    );
     expect(task).not.toContain("162 display units");
     expect(task).not.toContain("approval code");
   });
@@ -207,7 +209,7 @@ describe("THOUGHT Agent V2 protocol helpers", () => {
       },
       output: {
         rawSha256: await sha256Hex(
-          JSON.stringify({ schema: THOUGHT_AGENT_RESULT_VERSION, agentLine: "A" }),
+          JSON.stringify(releasedAgentResult("A")),
         ),
         agentLineSha256: await sha256Hex("A"),
       },

--- a/apps/home/tests/thoughtV2ProtocolRelease.test.ts
+++ b/apps/home/tests/thoughtV2ProtocolRelease.test.ts
@@ -1,101 +1,248 @@
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
-import { keccak256, toUtf8Bytes } from "ethers";
-import {
-  binaryFieldPackedHex,
-  thoughtWorkHashes,
-} from "../../../packages/shared/src/thought-v2-protocol";
-import { buildThoughtV2Svg } from "../../../packages/shared/src/thought-v2-renderer";
 import { THOUGHT_V2_PROTOCOL_RELEASE } from "../../../packages/thought-agent-protocol/src";
 import { THOUGHT_AGENT_STATUS } from "../../../functions/api/thought-agent/v1/shared";
+import {
+  THOUGHT_V2_CONVERSATION_IDENTITY_DOMAIN,
+  THOUGHT_V2_RENDERER_ID,
+  THOUGHT_V2_RENDERER_ID_HASH,
+  THOUGHT_V2_WORK_DOMAIN,
+  THOUGHT_V2_WORK_PROFILE_ID,
+  THOUGHT_V2_WORK_PROFILE_ID_HASH,
+  deriveThoughtV2WorkHashes,
+} from "../../thought/contract-integration/current/reference/thought-v2-terminal-work-profile";
 
 const LOCK_PATH = resolve(
   cwd(),
   "../../packages/thought-agent-protocol/thought-v2.consumer-lock.json",
 );
-const RELEASE_ID = (JSON.parse(readFileSync(LOCK_PATH, "utf8")) as { releaseId: string }).releaseId;
-const RELEASE_DIR = resolve(
-  cwd(),
-  "public/artifacts/thought-protocol-v2",
-  RELEASE_ID,
-);
 
 type ConsumerLock = {
-  releaseId: string;
-  source: { tag: string; commit: string };
-  manifest: {
+  schema: string;
+  artifactId: string;
+  source: {
+    repository: string;
+    tag: string;
+    commit: string;
+    dirty: boolean;
+    eligibleForProduction: boolean;
+  };
+  contractManifestSha256: string;
+  runtimeRelease: {
+    protocolReleaseId: string;
+    manifestKeccak256: string;
+  };
+  selectedSpec: {
+    name: string;
     byteLength: number;
     sha256: string;
-    keccak256: string;
-    artifactCount: number;
+    evmSpecId: string;
+    evmSpecHash: string;
   };
-  deployment: { status: string; v2MintEnabled: boolean; address?: string };
-  artifacts: Array<{
+  identifiers: {
+    workProfile: string;
+  };
+  deployment: {
+    status: string;
+    v2MintEnabled: boolean;
+    address?: string;
+  };
+};
+
+type ReleaseManifest = {
+  artifactId: string;
+  source: { tag: string; dirty: boolean };
+  compatibility: {
+    selectedSpec: {
+      name: string;
+      byteLength: number;
+      sha256: string;
+      thoughtSpecId: string;
+      thoughtSpecHash: string;
+    };
+    workProfile: { id: string };
+  };
+  deploymentPolicy: {
+    authorizedNow: boolean;
+    targetChains: Array<{ deploymentAuthorized: boolean }>;
+  };
+  flags: {
+    deploymentAuthorized: boolean;
+    productionConsumable: boolean;
+  };
+  files: Array<{
     path: string;
     byteLength: number;
     sha256: string;
-    keccak256: string;
   }>;
 };
 
-type RendererFixture = {
-  id: string;
-  promptLine: string;
-  agentLine: string;
-  rendererId: string;
-  binaryFieldPacked: string;
-  binaryFieldKeccak256: string;
-  agentIdentityHash: string;
-  workHash: string;
-  expectedSvg: string;
-  expectedSvgKeccak256: string;
+type ReleaseReadme = {
+  artifactId: string;
+  sourceTag: string;
+  deploymentAuthorized: boolean;
+  productionConsumable: boolean;
 };
 
+type WorkHashVectors = {
+  profileId: string;
+  profileIdHash: string;
+  rendererId: string;
+  rendererIdHash: string;
+  conversationIdentityDomain: string;
+  workDomain: string;
+  vectors: Array<{
+    promptLine: string;
+    agentLine: string;
+    promptLineKeccak256: string;
+    agentLineKeccak256: string;
+    conversationIdentityHash: string;
+    workHash: string;
+  }>;
+};
+
+const lock = JSON.parse(readFileSync(LOCK_PATH, "utf8")) as ConsumerLock;
+const RELEASE_ID = lock.artifactId;
+const RELEASE_DIR = resolve(
+  cwd(),
+  "../thought/contract-release/releases",
+  RELEASE_ID,
+);
 const readBytes = (path: string) => readFileSync(path);
 const sha256 = (bytes: Uint8Array) =>
   createHash("sha256").update(bytes).digest("hex");
 
 describe("pinned THOUGHT V2 protocol release", () => {
-  test("pins the immutable release and verifies every normative artifact", () => {
-    const lock = JSON.parse(readFileSync(LOCK_PATH, "utf8")) as ConsumerLock;
+  test("pins the immutable release and verifies every packaged artifact", () => {
+    const manifestBytes = readBytes(resolve(RELEASE_DIR, "manifest.json"));
+    const manifest = JSON.parse(manifestBytes.toString("utf8")) as ReleaseManifest;
 
-    expect(lock.releaseId).toBe(RELEASE_ID);
+    expect(lock.schema).toBe("inshell.thought.current-v2-consumer-lock.v2");
+    expect(lock.artifactId).toBe(THOUGHT_V2_PROTOCOL_RELEASE.releaseId);
     expect(lock.source).toMatchObject({
       repository: THOUGHT_V2_PROTOCOL_RELEASE.source.repository,
+      tag: THOUGHT_V2_PROTOCOL_RELEASE.source.tag,
       commit: THOUGHT_V2_PROTOCOL_RELEASE.commit,
+      dirty: false,
+      eligibleForProduction: true,
     });
-    const manifestBytes = readBytes(resolve(RELEASE_DIR, "release-manifest.json"));
-    const manifest = JSON.parse(manifestBytes.toString("utf8")) as {
-      artifacts?: unknown[];
-    };
-    expect(manifestBytes.byteLength).toBe(lock.manifest.byteLength);
-    expect(sha256(manifestBytes)).toBe(lock.manifest.sha256);
-    expect(keccak256(new Uint8Array(manifestBytes))).toBe(lock.manifest.keccak256);
-    expect(manifest.artifacts).toHaveLength(lock.manifest.artifactCount);
-    expect(lock.artifacts).toHaveLength(lock.manifest.artifactCount);
+    expect(manifest.artifactId).toBe(RELEASE_ID);
+    expect(manifest.source).toMatchObject({ tag: lock.source.tag, dirty: false });
+    expect(sha256(manifestBytes)).toBe(lock.contractManifestSha256);
+    expect(manifest.files.length).toBeGreaterThan(0);
 
-    for (const artifact of lock.artifacts) {
-      const bytes = readBytes(resolve(RELEASE_DIR, "files", artifact.path));
+    for (const artifact of manifest.files) {
+      const bytes = readBytes(resolve(RELEASE_DIR, artifact.path));
       expect(bytes.byteLength).toBe(artifact.byteLength);
       expect(sha256(bytes)).toBe(artifact.sha256);
-      expect(keccak256(new Uint8Array(bytes))).toBe(artifact.keccak256);
+    }
+
+    expect(manifest.files.map(({ path }) => path)).toEqual(
+      expect.arrayContaining([
+        "contract/compiled/ThoughtNFTV2.json",
+        "dependencies/mono-76/manifest.json",
+        "reference/thought-v2-terminal-work-profile.ts",
+        "validation/producer-tests.json",
+      ]),
+    );
+  });
+
+  test("keeps the runtime binding aligned with the current consumer lock", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve(RELEASE_DIR, "manifest.json"), "utf8"),
+    ) as ReleaseManifest;
+
+    expect(lock.runtimeRelease).toEqual(THOUGHT_V2_PROTOCOL_RELEASE.release);
+    expect(lock.selectedSpec).toMatchObject({
+      name: THOUGHT_V2_PROTOCOL_RELEASE.spec.name,
+      byteLength: THOUGHT_V2_PROTOCOL_RELEASE.spec.byteLength,
+      sha256: THOUGHT_V2_PROTOCOL_RELEASE.spec.sha256,
+      evmSpecId: THOUGHT_V2_PROTOCOL_RELEASE.spec.evmSpecId,
+      evmSpecHash: THOUGHT_V2_PROTOCOL_RELEASE.spec.evmSpecHash,
+    });
+    expect(manifest.compatibility.selectedSpec).toEqual({
+      name: lock.selectedSpec.name,
+      byteLength: lock.selectedSpec.byteLength,
+      sha256: lock.selectedSpec.sha256,
+      thoughtSpecId: lock.selectedSpec.evmSpecId,
+      thoughtSpecHash: lock.selectedSpec.evmSpecHash,
+    });
+    expect(manifest.compatibility.workProfile.id).toBe(
+      THOUGHT_V2_PROTOCOL_RELEASE.identifiers.workProfile,
+    );
+    expect(lock.identifiers.workProfile).toBe(
+      THOUGHT_V2_PROTOCOL_RELEASE.identifiers.workProfile,
+    );
+  });
+
+  test("matches the released work-hash conformance vectors", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        resolve(
+          RELEASE_DIR,
+          "protocol/current/v2/conformance/work-hash-vectors.json",
+        ),
+        "utf8",
+      ),
+    ) as WorkHashVectors;
+
+    expect(fixture).toMatchObject({
+      profileId: THOUGHT_V2_WORK_PROFILE_ID,
+      profileIdHash: THOUGHT_V2_WORK_PROFILE_ID_HASH,
+      rendererId: THOUGHT_V2_RENDERER_ID,
+      rendererIdHash: THOUGHT_V2_RENDERER_ID_HASH,
+      conversationIdentityDomain: THOUGHT_V2_CONVERSATION_IDENTITY_DOMAIN,
+      workDomain: THOUGHT_V2_WORK_DOMAIN,
+    });
+    expect(fixture.vectors.length).toBeGreaterThan(0);
+
+    for (const vector of fixture.vectors) {
+      expect(
+        deriveThoughtV2WorkHashes(vector.promptLine, vector.agentLine),
+      ).toEqual({
+        promptLineKeccak256: vector.promptLineKeccak256,
+        agentLineKeccak256: vector.agentLineKeccak256,
+        conversationIdentityHash: vector.conversationIdentityHash,
+        workHash: vector.workHash,
+      });
     }
   });
 
-  test("keeps V2 mint disabled because the release is source-only", () => {
-    const lock = JSON.parse(readFileSync(LOCK_PATH, "utf8")) as ConsumerLock;
+  test("keeps V2 mint disabled until a persistent deployment is authorized", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve(RELEASE_DIR, "manifest.json"), "utf8"),
+    ) as ReleaseManifest;
+    const readme = JSON.parse(
+      readFileSync(resolve(RELEASE_DIR, "README.json"), "utf8"),
+    ) as ReleaseReadme;
 
-    expect(lock.deployment.status).toBe("source-only");
+    expect(lock.deployment.status).toBe("canonical-portable-not-deployed");
     expect(lock.deployment.v2MintEnabled).toBe(false);
     expect(lock.deployment.address).toBeUndefined();
+    expect(manifest.deploymentPolicy.authorizedNow).toBe(false);
+    expect(
+      manifest.deploymentPolicy.targetChains.every(
+        ({ deploymentAuthorized }) => deploymentAuthorized === false,
+      ),
+    ).toBe(true);
+    expect(manifest.flags).toMatchObject({
+      deploymentAuthorized: false,
+      productionConsumable: true,
+    });
+    expect(readme).toMatchObject({
+      artifactId: RELEASE_ID,
+      sourceTag: lock.source.tag,
+      deploymentAuthorized: false,
+      productionConsumable: true,
+    });
     expect(THOUGHT_V2_PROTOCOL_RELEASE.deployment.v2MintEnabled).toBe(false);
     expect(THOUGHT_AGENT_STATUS).toMatchObject({
       protocolVersion: "inshell.thought.agent-run.v2",
       resultSchema: "inshell.thought.agent-result.v2",
       protocolReleaseId: RELEASE_ID,
-      deploymentStatus: "source-only",
+      deploymentStatus: "canonical-portable-not-deployed",
       v2MintEnabled: false,
     });
   });
@@ -110,69 +257,26 @@ describe("pinned THOUGHT V2 protocol release", () => {
     expect(thoughtSource).not.toMatch(/thought:\/\/agent\/run\?[^`\n]*token=/);
   });
 
-  test("consumes the released four-argument ThoughtNFT constructor ABI", () => {
+  test("consumes the released six-argument ThoughtNFTV2 constructor ABI", () => {
     const artifact = JSON.parse(
       readFileSync(
-        resolve(RELEASE_DIR, "files/contract/abi/ThoughtNFT.json"),
+        resolve(RELEASE_DIR, "contract/compiled/ThoughtNFTV2.json"),
         "utf8",
       ),
-    ) as { abi: Array<{ type: string; inputs?: Array<{ name: string; type: string }> }> };
+    ) as { abi: Array<{ type: string; inputs?: Array<Record<string, string>> }> };
     const constructor = artifact.abi.find((entry) => entry.type === "constructor");
 
     expect(constructor?.inputs).toEqual([
       { internalType: "address", name: "pathNft_", type: "address" },
+      { internalType: "address", name: "thoughtSpecRegistry_", type: "address" },
+      { internalType: "address", name: "thoughtRenderer_", type: "address" },
+      { internalType: "address", name: "protocolRegistry_", type: "address" },
+      { internalType: "bytes32", name: "protocolReleaseId_", type: "bytes32" },
       {
         internalType: "address",
-        name: "thoughtSpecRegistry_",
+        name: "creationAttestationVerifier_",
         type: "address",
-      },
-      {
-        internalType: "address",
-        name: "thoughtRenderer_",
-        type: "address",
-      },
-      {
-        internalType: "bytes32",
-        name: "protocolReleaseKeccak256_",
-        type: "bytes32",
       },
     ]);
-  });
-
-  test("matches every packaged valid renderer fixture byte-for-byte", () => {
-    const fixturesDir = resolve(RELEASE_DIR, "files/renderer/fixtures");
-    const fixtureFiles = readdirSync(fixturesDir)
-      .filter(
-        (name) =>
-          name.endsWith(".json") &&
-          name !== "invalid-lines.json" &&
-          name !== "invalid-raw-utf8.json" &&
-          name !== "cycling-collisions.json",
-      )
-      .sort();
-
-    expect(fixtureFiles.length).toBeGreaterThan(0);
-    for (const fixtureFile of fixtureFiles) {
-      const fixture = JSON.parse(
-        readFileSync(resolve(fixturesDir, fixtureFile), "utf8"),
-      ) as RendererFixture;
-      const hashes = thoughtWorkHashes(fixture.promptLine, fixture.agentLine);
-      const svg = buildThoughtV2Svg({
-        promptLine: fixture.promptLine,
-        agentLine: fixture.agentLine,
-      });
-
-      expect(fixture.rendererId).toBe(
-        THOUGHT_V2_PROTOCOL_RELEASE.identifiers.renderer,
-      );
-      expect(binaryFieldPackedHex(fixture.promptLine, fixture.agentLine)).toBe(
-        fixture.binaryFieldPacked,
-      );
-      expect(hashes.binaryFieldKeccak256).toBe(fixture.binaryFieldKeccak256);
-      expect(hashes.agentIdentityHash).toBe(fixture.agentIdentityHash);
-      expect(hashes.workHash).toBe(fixture.workHash);
-      expect(svg).toBe(fixture.expectedSvg);
-      expect(keccak256(toUtf8Bytes(svg))).toBe(fixture.expectedSvgKeccak256);
-    }
   });
 });


### PR DESCRIPTION
## Summary

- align THOUGHT agent protocol and function integration assertions with the lifecycle already implemented on `staging`
- update release-lock assertions to the current artifact-bound canonical release
- change tests only; no runtime, route, deployment, or contract code

## Why

`staging` already contains the current protocol implementation, but these three suites still asserted the retired July behavior. That stale drift blocks the repository pre-push gate and therefore blocks the required production-hotfix reconciliation back into `staging`.

This is a test-only prerequisite extracted from the already-reviewed alignment commit on draft PR #133. It does not merge or activate the THOUGHT integration work.

## Validation

- full unit suite: 24/24 suites, 330/330 tests
- root lint: pass
- root type-check: pass
- gitleaks: no leaks
- `git diff --check`: pass

## Scope

Only these files change:

- `apps/home/tests/thoughtAgentFunction.test.ts`
- `apps/home/tests/thoughtAgentProtocol.test.ts`
- `apps/home/tests/thoughtV2ProtocolRelease.test.ts`